### PR TITLE
Removed padding reset on #returnhome and #twittershare buttons

### DIFF
--- a/webcompat/static/css/development/main.css
+++ b/webcompat/static/css/development/main.css
@@ -516,14 +516,6 @@ form .button {
 .thanks p {
   margin-bottom: 1.5em;
 }
-/*------Page Errors------*/
-#returnhome {
-  padding: 0;
-}
-/*------Social Share------*/
-#twittershare {
-  padding: 0;
-}
 
 @media (--viewport-450px) {
   .maincontent.container,


### PR DESCRIPTION
# returnhome ID is not used in any templates and #twittershare padding:0 overrides .Button padding (shown on Thanks page).
