### PR TITLE
Added border radius to label editor caret

### DIFF
--- a/webcompat/static/css/development/components/labels.css
+++ b/webcompat/static/css/development/components/labels.css
@@ -55,11 +55,9 @@
   top: -0.625em;
   left: 1.06em;
   background-color: #ffffff;
-  border-color: var(--wc-variant-background-light);
-  border-radius: 0 0 100% 0;
-  border-style: solid;
-  border-width: 1px 0px 0px 1px;
+  box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.25);
   transform: rotate(45deg);
+  z-index: -1;
 }
 @media (--viewport-375px) {
   .label_editor:after {


### PR DESCRIPTION
This is stop the bottom corner of the white square from covering the input field, especially when in focus.
