### PR TITLE
Added try-catch for JSON parsing errors

### DIFF
--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -116,8 +116,7 @@ issues.LabelEditorView = Backbone.View.extend({
       try {
           return JSON.parse(removeQuotes(style));
       } catch(e) {
-          // Default to behavior for desktop devices
-          return {device: "wide", resizeEditorHeight: false};
+          return false;
       }
     };
 


### PR DESCRIPTION
`JSON.parse` fails in some browsers (e.g. old WebKit) so this should provide a fallback.
