### PR TITLE
Remove Twitter Bootstrap

### DIFF
--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -26,7 +26,6 @@
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-196x196.png') }}" sizes="196x196">
   <meta name="msapplication-TileColor" content="#e4bc05">
   <meta name="msapplication-TileImage" content="{{ url_for('static', filename='favicon/mstile-144x144.png') }}">
-  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
 {%- if config.PRODUCTION -%}
   <link href="{{ url_for('static', filename='css/webcompat.min.css') }}?{{ bust_cache() }}" type="text/css" rel="stylesheet">
 {%- else %}


### PR DESCRIPTION
It's time to remove Twitter Bootstrap. For optimization, delete one HTTP request. 

But we still have to test if I did not forget bug.

![booom](https://cloud.githubusercontent.com/assets/1997108/4156137/0e2eb7f8-3471-11e4-9dfc-8af8df2e97db.gif)
