### PR TITLE
Janitor for straightening code style using flake8

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -6,9 +6,9 @@
 
 '''Tests for our URL endpoints.'''
 
-import unittest
 import os.path
 import sys
+import unittest
 
 # Add webcompat module to import path
 sys.path.append(os.path.realpath(os.pardir))
@@ -29,35 +29,37 @@ class TestURLs(unittest.TestCase):
         pass
 
     def test_home(self):
-        '''Test that the home page exists'''
+        '''Test that the home page exists.'''
         rv = self.app.get('/', environ_base=headers)
         self.assertEqual(rv.status_code, 200)
 
     def test_about(self):
-        '''Test that /about exists'''
+        '''Test that /about exists.'''
         rv = self.app.get('/about')
         self.assertEqual(rv.status_code, 200)
 
     def test_privacy(self):
-        '''Test that /privacy exists'''
+        '''Test that /privacy exists.'''
         rv = self.app.get('/privacy')
         self.assertEqual(rv.status_code, 200)
 
-
     def test_thanks(self):
-        '''Test that /thanks/1 exists'''
+        '''Test that /thanks/1 exists.'''
         rv = self.app.get('/thanks/1')
         self.assertEqual(rv.status_code, 200)
 
     def test_login(self):
-        '''Test that the /login route 302s to GitHub'''
+        '''Test that the /login route 302s to GitHub.'''
         rv = self.app.get('/login')
         self.assertEqual(rv.status_code, 302)
         self.assertIn('github.com/login/oauth/', rv.headers['Location'])
 
     def test_issue_int(self):
-        '''Test that an issue only displays if <number> is an integer.'''
-        '''Test that the /issues/<number> exists, and does not redirect.'''
+        '''Test issues and integer for:
+
+        * an issue only displays if <number> is an integer
+        * /issues/<number> exists, and does not redirect.
+        '''
         rv = self.app.get('/issues/3')
         self.assertEqual(rv.status_code, 200)
         self.assertNotEqual(rv.status_code, 404)
@@ -72,7 +74,7 @@ class TestURLs(unittest.TestCase):
         self.assertNotEqual(rv.status_code, 307)
 
     def test_issues_redirect(self):
-        '''Test that the /issues route 307s to /index (for now)'''
+        '''Test that the /issues route 307s to /index (for now).'''
         rv = self.app.get('/issues')
         self.assertEqual(rv.status_code, 307)
         self.assertIn('localhost', rv.headers['Location'])

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -6,12 +6,12 @@
 
 '''This module powers the webcompat.com Flask application.'''
 
-from flask import Flask
+import os
+
 from flask.ext.cache import Cache
 from flask.ext.github import GitHub
-
+from flask import Flask
 from sqlalchemy import create_engine
-import os
 
 app = Flask(__name__, static_url_path='')
 app.config.from_object('config')
@@ -26,5 +26,5 @@ cache = Cache(app)
 import webcompat.views
 
 # register API blueprint
-from .api.endpoints import api
+from api.endpoints import api
 app.register_blueprint(api)

--- a/webcompat/api/__init__.py
+++ b/webcompat/api/__init__.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/webcompat/api/endpoints.py
+++ b/webcompat/api/endpoints.py
@@ -8,11 +8,23 @@
 back to GitHub'''
 
 import json
-from flask import abort, Blueprint, g, request, session, make_response
+
+from flask import abort
+from flask import Blueprint
 from flask.ext.github import GitHubError
-from webcompat import github, app, cache
-from ..issues import REPO_URI, proxy_request, filter_untriaged
-from ..helpers import get_user_info
+from flask import g
+from flask import make_response
+from flask import request
+from flask import session
+
+from webcompat import app
+from webcompat import cache
+from webcompat import github
+from webcompat.helpers import get_user_info
+from webcompat.issues import filter_untriaged
+from webcompat.issues import proxy_request
+from webcompat.issues import REPO_URI
+
 
 api = Blueprint('api', __name__, url_prefix='/api')
 JSON_MIME = 'application/json'
@@ -21,7 +33,10 @@ JSON_MIME = 'application/json'
 @api.route('/issues')
 @cache.cached(timeout=300)
 def proxy_issues():
-    '''API endpoint to list all issues from GitHub. Cached for 5 minutes.'''
+    '''API endpoint to list all issues from GitHub.
+
+    Cached for 5 minutes.
+    '''
     if g.user:
         issues = github.get('repos/{0}'.format(REPO_URI))
     else:
@@ -31,8 +46,10 @@ def proxy_issues():
 
 @api.route('/issues/<int:number>')
 def proxy_issue(number):
-    '''XHR endpoint to get issue data from GitHub, either as an authed
-    user, or as one of our proxy bots.'''
+    '''XHR endpoint to get issue data from GitHub.
+
+    either as an authed user, or as one of our proxy bots.
+    '''
     if g.user:
         issue = github.raw_request('GET', 'repos/{0}/{1}'.format(
             app.config['ISSUES_REPO_URI'], number))
@@ -49,8 +66,10 @@ def proxy_issue(number):
 @api.route('/issues/<int:number>/edit', methods=['PATCH'])
 def edit_issue(number):
     '''XHR endpoint to push back edits to GitHub for a single issue.
+
     Note: this is always proxied to allow any logged in user to be able to
-    edit issues.'''
+    edit issues.
+    '''
     edit = proxy_request('patch', '/{0}'.format(number), data=request.data,
                          token='closerbot')
     return (json.dumps(edit.json()), edit.status_code,
@@ -60,8 +79,10 @@ def edit_issue(number):
 @api.route('/issues/mine')
 @cache.cached(timeout=300)
 def user_issues():
-    '''API endpoint to return issues filed by the logged in user. Cached
-    for five minutes.'''
+    '''API endpoint to return issues filed by the logged in user.
+
+    Cached for 5 minutes.
+    '''
     get_user_info()
     issues = github.get('repos/{0}?creator={1}&state=all'.format(
         REPO_URI, session['username']))
@@ -71,8 +92,11 @@ def user_issues():
 @api.route('/issues/untriaged')
 @cache.cached(timeout=300)
 def get_untriaged():
-    '''Return all issues that are "untriaged". Essentially all unclosed issues
-    with no activity. Cached for five minutes.'''
+    '''Return all issues that are "untriaged".
+
+    Essentially all unclosed issues with no activity.
+    Cached for 5 minutes.
+    '''
     if g.user:
         issues = github.raw_request('GET', 'repos/{0}'.format(REPO_URI))
     else:
@@ -91,8 +115,10 @@ def get_untriaged():
 @api.route('/issues/contactready')
 @cache.cached(timeout=300)
 def get_contactready():
-    '''Return all issues with a "contactready" label. Cached for five
-    minutes.'''
+    '''Return all issues with a "contactready" label.
+
+    Cached for 5 minutes.
+    '''
     if g.user:
         uri = 'repos/{0}?labels=contactready'.format(REPO_URI)
         issues = github.raw_request('GET', uri)
@@ -108,8 +134,10 @@ def get_contactready():
 @api.route('/issues/needsdiagnosis')
 @cache.cached(timeout=300)
 def get_needsdiagnosis():
-    '''Return all issues with a "needsdiagnosis" label. Cached for five
-    minutes.'''
+    '''Return all issues with a "needsdiagnosis" label.
+
+    Cached for 5 minutes.
+    '''
     if g.user:
         uri = 'repos/{0}?labels=needsdiagnosis'.format(REPO_URI)
         issues = github.raw_request('GET', uri)
@@ -125,8 +153,10 @@ def get_needsdiagnosis():
 @api.route('/issues/sitewait')
 @cache.cached(timeout=300)
 def get_sitewait():
-    '''Return all issues with a "sitewait" label. Cached for five
-    minutes.'''
+    '''Return all issues with a "sitewait" label.
+
+    Cached for 5 minutes.
+    '''
     if g.user:
         uri = 'repos/{0}?labels=sitewait'.format(REPO_URI)
         issues = github.raw_request('GET', uri)
@@ -141,8 +171,10 @@ def get_sitewait():
 
 @api.route('/issues/<int:number>/comments', methods=['GET', 'POST'])
 def proxy_comments(number):
-    '''XHR endpoint to get issues comments from GitHub, either as an authed
-    user, or as one of our proxy bots.'''
+    '''XHR endpoint to get issues comments from GitHub.
+
+    Either as an authed user, or as one of our proxy bots.
+    '''
     if request.method == 'POST':
         try:
             comment_data = json.loads(request.data)
@@ -173,9 +205,12 @@ def proxy_comments(number):
 
 @api.route('/issues/<int:number>/labels', methods=['POST'])
 def modify_labels(number):
-    '''XHR endpoint to modify issue labels. Sending in an empty array removes
-    them all as well. This method is always proxied because non-repo collabs
-    can't normally edit labels for an issue.'''
+    '''XHR endpoint to modify issue labels.
+
+    Sending in an empty array removes them all as well.
+    This method is always proxied because non-repo collabs
+    can't normally edit labels for an issue.
+    '''
     try:
         labels = proxy_request('put', '/{0}/labels'.format(number),
                                data=request.data, token='labelbot')
@@ -189,8 +224,10 @@ def modify_labels(number):
 @api.route('/issues/labels')
 @cache.cached(timeout=600)
 def get_repo_labels():
-    '''XHR endpoint to get all possible labels in a repo. Cached for ten
-    minutes.'''
+    '''XHR endpoint to get all possible labels in a repo.
+
+    Cached for 10 minutes.
+    '''
     # Chop off /issues. Someone feel free to refactor the ISSUES_REPO_URI.
     labels_uri = app.config['ISSUES_REPO_URI'][:-7]
     if g.user:

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -7,10 +7,16 @@
 '''This module contains the base IssueForm class and helper methods that
 power the issue reporting form on webcompat.com.'''
 
-from random import randrange
-from urlparse import urlparse
-from wtforms import Form, RadioField, StringField, TextAreaField
-from wtforms.validators import Optional, Required, Length
+import random
+import urlparse
+
+from wtforms import Form
+from wtforms import RadioField
+from wtforms import StringField
+from wtforms import TextAreaField
+from wtforms.validators import Length
+from wtforms.validators import Optional
+from wtforms.validators import Required
 
 AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
@@ -23,7 +29,7 @@ problem_choices = [(u'browser_bug', u'Looks like the browser has a bug'),
 url_message = u'A URL is required.'
 summary_message = u'Please give a summary.'
 username_message = u'A valid username must be {0} characters long'.format(
-    randrange(0, 99))
+    random.randrange(0, 99))
 
 desc_default = u'''1) Navigate to: Site URL
 2) …
@@ -70,10 +76,12 @@ def get_owner(is_site_owner):
 
 
 def wrap_label(label):
-    '''Helper method to wrap a label and its type in an HTML comment (which
-    we use to hide from users in GitHub issues. We can parse these later and
-    add labels programmatically (as you have to have push access to the report
-    to add labels.'''
+    '''Helper method to wrap a label and its type in an HTML comment.
+
+    We use it to hide from users in GitHub issues.
+    We can parse these later and add labels programmatically (as you
+    have to have push access to the report to add labels.
+    '''
     return u'<!-- @{0}: {1} -->\n'.format(*label)
 
 
@@ -90,7 +98,7 @@ def get_labels(browser_name):
 
 
 def normalize_url(url):
-    '''normalize URL for consistency'''
+    '''normalize URL for consistency.'''
     url = url.strip()
     if not url.startswith(SCHEMES):
         # We assume that http is missing not https
@@ -99,20 +107,19 @@ def normalize_url(url):
 
 
 def domain_name(url):
-    '''Extract the domain name of a sanitized version of the submitted URL'''
+    '''Extract the domain name of a sanitized version of the submitted URL.'''
     # Removing leading spaces
     url = url.lstrip()
     # testing if it's an http URL
     if url.startswith(SCHEMES):
-        domain = urlparse(url).netloc
+        domain = urlparse.urlparse(url).netloc
     else:
         domain = None
     return domain
 
 
 def build_formdata(form_object):
-    '''Translate the form data that comes from our form into something that
-    the GitHub API is expecting.
+    '''Convert HTML form data to GitHub API data.
 
     Summary -> title
     Browser -> part of body, labels
@@ -140,7 +147,8 @@ def build_formdata(form_object):
 
     For now, we'll put them in the body so they're visible. But as soon as we
     have a bot set up to parse the label comments (see wrap_label), we'll stop
-    doing that.'''
+    doing that.
+    '''
     # URL normalization
     url = form_object.get('url')
     normalized_url = normalize_url(url)

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -5,13 +5,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flask import session
-from webcompat import github
 from ua_parser import user_agent_parser
+
+from webcompat import github
 
 
 def get_user_info():
-    '''Grab the username and avatar URL from GitHub and stash it
-    in the session.'''
+    '''Grab the username and avatar URL from GitHub.'''
     if session.get('username') and session.get('avatar_url'):
         return
     else:
@@ -21,8 +21,10 @@ def get_user_info():
 
 
 def get_browser_name(user_agent_string):
-    '''Return just the browser name, unknown user agents will be reported as
-    "other".'''
+    '''Return just the browser name.
+
+    unknown user agents will be reported as "other".
+    '''
     ua_dict = user_agent_parser.Parse(user_agent_string)
     name = ua_dict.get('user_agent').get('family').lower()
     if (name == 'firefox mobile' and
@@ -32,8 +34,10 @@ def get_browser_name(user_agent_string):
 
 
 def get_browser(user_agent_string):
-    '''Return browser name (i.e., "user agent family") and version for
-    pre-populating the bug reporting form.'''
+    '''Return browser name family and version.
+
+    It will pre-populate the bug reporting form.
+    '''
     ua_dict = user_agent_parser.Parse(user_agent_string)
     ua = ua_dict.get('user_agent')
     name = ua.get('family')
@@ -49,8 +53,10 @@ def get_browser(user_agent_string):
 
 
 def get_os(user_agent_string):
-    '''Return operating system name for pre-populating the bug reporting
-    form.'''
+    '''Return operating system name.
+
+    It pre-populates the bug reporting form.
+    '''
     ua_dict = user_agent_parser.Parse(user_agent_string)
     os = ua_dict.get('os')
     version = os.get('major', u'Unknown')

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -8,9 +8,12 @@
 authed user and the proxy case.'''
 
 import json
+
 import requests
+
+from webcompat import app
 from webcompat.form import build_formdata
-from webcompat import github, app
+from webcompat import github
 
 REPO_URI = app.config['ISSUES_REPO_URI']
 DEFAULT_TOKEN = app.config['BOT_OAUTH_TOKEN']
@@ -18,9 +21,12 @@ TOKEN_MAP = app.config['TOKEN_MAP']
 
 
 def proxy_request(method, path_mod='', data=None, uri=None, token=None):
-    '''Make a GitHub API request with a bot's OAuth token, for non-logged in
-    users. `path`, if included, will be appended to the end of the URI.
-    Optionally pass in POST data via the `data` arg.'''
+    '''Make a GitHub API request with a bot's OAuth token.
+
+    Necessary for non-logged in users.
+    * `path`, if included, will be appended to the end of the URI.
+    * Optionally pass in POST data via the `data` arg.
+    '''
     # Create a User Agent string depending on the bot name
     if not token:
         user_agent = 'Basic'
@@ -62,8 +68,11 @@ def get_issue(number):
 
 
 def filter_untriaged(issues):
-    '''For our purposes, "untriaged" means anything that isn't an issue
-    with a "contactready", "sitewait", or "needsdiagnosis" label.'''
+    '''Return the list of untriaged issues.
+
+    "untriaged" means anything that isn't an issue with a "contactready",
+    "sitewait", or "needsdiagnosis" label.
+    '''
     def is_untriaged(issue):
         '''Filter function.'''
         match = True

--- a/webcompat/models.py
+++ b/webcompat/models.py
@@ -4,9 +4,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy import Column
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Integer
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import String
+
 from webcompat import engine
 
 db_session = scoped_session(sessionmaker(autocommit=False,

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -4,22 +4,36 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import hashlib
 import urllib
-from flask import (flash, g, redirect, request, render_template, session,
-                   url_for)
+
 from flask.ext.github import GitHubError
-from hashlib import md5
-from .form import IssueForm, AUTH_REPORT, PROXY_REPORT
-from .helpers import get_user_info, get_browser, get_browser_name, get_os
-from .issues import report_issue
-from .models import db_session, User
-from webcompat import github, app
+from flask import flash
+from flask import g
+from flask import redirect
+from flask import render_template
+from flask import request
+from flask import session
+from flask import url_for
+from form import AUTH_REPORT
+from form import IssueForm
+from form import PROXY_REPORT
+from helpers import get_browser
+from helpers import get_browser_name
+from helpers import get_os
+from helpers import get_user_info
+from issues import report_issue
+from models import db_session
+from models import User
+
+from webcompat import app
+from webcompat import github
 
 
 @app.context_processor
 def cache_buster():
     def bust_cache():
-        return md5(app.config['STARTUP']).hexdigest()[:14]
+        return hashlib.md5(app.config['STARTUP']).hexdigest()[:14]
     return dict(bust_cache=bust_cache)
 
 
@@ -51,7 +65,7 @@ def token_getter():
 @app.template_filter('format_date')
 def format_date(datestring):
     '''For now, just chops off crap.'''
-    #2014-05-01T02:26:28Z
+    # 2014-05-01T02:26:28Z
     return datestring[0:10]
 
 


### PR DESCRIPTION
@miketaylr Not mandatory to import. 
Your choice. I was trying to see if we could be consistent in the coding style of the project. There were different ways of doing things here and there. A lot is about docstrings and modules import. You can try first on your master branch with flake8.  

→ flake8 .
./webcompat/**init**.py:26:1: F401 'webcompat' imported but unused
./webcompat/api/endpoints.py:201:80: E501 line too long (81 > 79 characters)
./webcompat/api/endpoints.py:234:80: E501 line too long (81 > 79 characters)

There are 3 remaining defaults, but which are not necessary easy or necessary to fix.

The one I have struggles with is webcompat in **init**.py
