### PR TITLE
Fix flash error when clicking label from /issues and not logged in.

### DIFF
--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -285,7 +285,9 @@ issueList.IssueView = Backbone.View.extend({
     // "search:update" event to populate the view with search results
     // for the given label.
     var labelFilter = 'label:' + $(e.target).text();
-    issueList.events.trigger('search:update', labelFilter);
+    if (this._isLoggedIn) {
+      issueList.events.trigger('search:update', labelFilter);
+    }
     issueList.events.trigger('issues:update', {query: labelFilter});
     e.preventDefault();
   },


### PR DESCRIPTION
This way we don't call any methods on the SearchView which doesn't get init'ed if you're not logged in. But it will still update the issues list.

r? @magsout 
