### PR TITLE
Issue #357 - Display "no results found" when no results are found.

### DIFF
--- a/webcompat/static/css/development/page/issue-list.css
+++ b/webcompat/static/css/development/page/issue-list.css
@@ -66,7 +66,7 @@
   padding-bottom:1.5em;
 }
   .IssueList-search-content {
-    display:flex; 
+    display:flex;
   }
   .IssueList-search-form {
     background-color:#F7F7F7;
@@ -123,3 +123,12 @@
 .IssueList-displayed {
   background-color:#F0F0F0;
 }
+/* no resultats */
+.IssueList-noResultat {
+  font-size:2.5em;
+  text-align:center;
+  padding:1em 0;
+}
+  .IssueList-noResultat .icon {
+    margin-bottom:.6em;
+  }

--- a/webcompat/templates/issue-list.html
+++ b/webcompat/templates/issue-list.html
@@ -77,7 +77,10 @@
           </div>
           <% }); %>
         <% } else { %>
-          <p>No results found.</p>
+          <p class="IssueList-noResultat">
+              <span class="icon icon-search"></span>
+              <span class="u-block">No results found.</span>
+          </p>
         <% } %>
         </script>
       </div>


### PR DESCRIPTION
Added generic "no results found" text. @magsout could you add a touch of style to this? It looks a bit squashed at the bottom, if that makes sense.

To reproduce you can either log-in and search for nonsense, or click the "Site Contacted" filter button (http://localhost:5000/issues?sitewait=1) if you have `ISSUES_REPO_URI = "miketaylr/nobody-look-at-this/issues"` in config.py.

![blah](https://cldup.com/kSfQo4RdgR-2000x2000.png)
