### PR TITLE
Fixes #391 - trim wysiwyg:// from URL field if it's there.

### DIFF
--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -36,9 +36,20 @@ function BugForm() {
         }
         var urlParam = location.search.match(/url=(.+)/);
         if (urlParam != null) {
-          urlField.val(decodeURIComponent(urlParam[1]));
+          // weird Gecko bug. See https://bugzilla.mozilla.org/show_bug.cgi?id=1098037
+          urlParam = self.trimWysiwyg(urlParam[1]);
+          urlField.val(decodeURIComponent(urlParam));
           self.copyURL();
           self.makeValid('url');
+      }
+    },
+    trimWysiwyg: function(url) {
+      //trim wysiwyg://N/ from URL.
+      var wysiwygRe = /(wysiwyg:\/\/\d+\/)/i;
+      if (url.search(wysiwygRe) !== 0) {
+        return url;
+      } else {
+        return url.replace(wysiwygRe, '');
       }
     },
     disableSubmits: function() {


### PR DESCRIPTION
Simple if matches regex, remove what was matched fix.

r? @magsout 
