### PR TITLE
Add repository key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "name": "The fine folks who contribute to webcompat.com",
     "url": "http://webcompat.com"
   },
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/webcompat/webcompat.com.git"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Tired of looking at `npm WARN package.json webcompat@ No repository field.`

r? @magsout 
