### PR TITLE
Fixes #485 - Only serialize params once.

### DIFF
--- a/tests/functional/lib/issue-list.js
+++ b/tests/functional/lib/issue-list.js
@@ -162,6 +162,22 @@ define([
           assert.equal(isDisplayed, true, 'We\'re at GitHub now.');
         })
         .end();
+    },
+
+    'clicking on a label performs a label search': function() {
+      return this.remote
+        .setFindTimeout(intern.config.wc.pageLoadTimeout)
+        .get(require.toUrl(url))
+        .findByCssSelector('div.Dropdown:nth-child(2) > button:nth-child(1)').click()
+        .end()
+        .findByCssSelector('div.Dropdown:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > a:nth-child(1)').click()
+        .end()
+        .findByCssSelector('[title="Labels : there-can-only-be-one"]').click()
+        .end()
+        .findByCssSelector('.js-issue-list .IssueItem:first-of-type .js-issue-label').getVisibleText()
+        .then(function (text) {
+          assert.include(text, 'there-can-only-be-one', 'The shown issue has the right label.');
+        });
     }
   });
 });

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -389,7 +389,7 @@ issueList.IssueView = Backbone.View.extend({
     // note: if query is the empty string, it will load all issues from the
     // '/api/issues' endpoint (which I think we want).
     if (category && category.query) {
-      params = $.param($.extend(params, {q: category.query}));
+      params = $.extend(params, {q: category.query});
       this.issues.setURLState('/api/issues/search', params);
     } else if (_.contains(searchCategories, category)) {
       this.issues.setURLState('/api/issues/search/' + category, params);


### PR DESCRIPTION
This bug was only exposed by clicking on an issue label. This patch
includes tests for that specific use case as well. Thanks for reporting @magsout.

Given that we've got such a nasty bug on production, when Travis passes I'm going to go ahead and merge and deploy.
