### PR TITLE
Fix #507 - Scope toggleFilter to more specific class

### DIFF
--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -57,7 +57,7 @@ issueList.DropdownView = Backbone.View.extend({
 issueList.FilterView = Backbone.View.extend({
   el: $('.js-issuelist-filter'),
   events: {
-    'click button': 'toggleFilter'
+    'click .js-filter-button': 'toggleFilter'
   },
   _isLoggedIn: $('body').data('username'),
   _userName: $('body').data('username'),

--- a/webcompat/templates/issue-list.html
+++ b/webcompat/templates/issue-list.html
@@ -8,19 +8,19 @@
       <script type="text/template" id="issuelist-filter-tmpl">
       <div class="Dropdown Dropdown--large js-dropdown-wrapper"></div>
       <div>
-        <button type="button" class="wc-Filter wc-Filter--untriaged" data-filter="untriaged">
+        <button type="button" class="wc-Filter wc-Filter--untriaged js-filter-button" data-filter="untriaged">
           <span class="wc-Filter-count"></span> Untriaged</span>
         </button>
-        <button type="button" class="wc-Filter wc-Filter--need" data-filter="needsdiagnosis">
+        <button type="button" class="wc-Filter wc-Filter--need js-filter-button" data-filter="needsdiagnosis">
           <span class="wc-Filter-count"></span> Needs Diagnosis</span>
         </button>
-        <button type="button" class="wc-Filter wc-Filter--ready" data-filter="contactready">
+        <button type="button" class="wc-Filter wc-Filter--ready js-filter-button" data-filter="contactready">
           <span class="wc-Filter-count"></span> Ready for outreach</span>
         </button>
-        <button type="button" class="wc-Filter wc-Filter--sitewait" data-filter="sitewait">
+        <button type="button" class="wc-Filter wc-Filter--sitewait js-filter-button" data-filter="sitewait">
           <span class="wc-Filter-count"></span> Site contacted</span>
         </button>
-        <button type="button" class="wc-Filter wc-Filter--close" data-filter="closed">
+        <button type="button" class="wc-Filter wc-Filter--close js-filter-button" data-filter="closed">
           <span class="wc-Filter-count"></span> Closed</span>
         </button>
       </div>


### PR DESCRIPTION
The bug was that the selector was too liberal--clicking the `<button>` of the dropdown component was triggering the filter request.