### PR TITLE
Fix #529 - Use closest() to ensure we add is-active to correct wrapper

### DIFF
--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -25,8 +25,8 @@ issueList.DropdownView = Backbone.View.extend({
     return this;
   },
   openDropdown: function(e) {
-    var btn = $(e.target);
-    btn.parent().toggleClass('is-active');
+    var target = $(e.target);
+    target.closest('.js-dropdown-wrapper').toggleClass('is-active');
   },
   closeDropdown: function() {
     this.$el.removeClass('is-active');


### PR DESCRIPTION
r? @magsout 

I guess Chrome and Firefox have different handling of html elements inside of `<button>` :fried_shrimp: 