### PR TITLE
Fixes #546 - go back in history from an issue page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/.selenium/
 
 addons:
-  firefox: "33.1"
+  firefox: "34.0"
 
 env:
   global:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==1.3
 Flask==0.10.1
 Flask-Cache==0.13.1
-Flask-Limiter==0.6.6
+Flask-Limiter==0.7.4
 Flask-SQLAlchemy==1.0
 GitHub-Flask==0.3.4
 WTForms==1.0.5

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -15,6 +15,9 @@ marked.setOptions({
 
 issues.TitleView = Backbone.View.extend({
   el: $('.Issue-title'),
+  events: {
+    'click .js-linkBack': 'goBack'
+  },
   template: _.template($('#title-tmpl').html()),
   render: function() {
     document.title = "Issue " + this.model.get('number') +
@@ -22,6 +25,17 @@ issues.TitleView = Backbone.View.extend({
                      " - webcompat.com";
     this.$el.html(this.template(this.model.toJSON()));
     return this;
+  },
+  goBack: function(e) {
+    if (!('origin' in location)) {
+      location.origin = location.protocol + '//' + location.host;
+    }
+
+    // Only go back in history if we came from the /issues page.
+    if (document.referrer.indexOf(location.origin + '/issues') === 0) {
+      history.back();
+      e.preventDefault();
+    }
   }
 });
 

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -5,7 +5,7 @@
     <main class="wc-content wc-content--body Issue" role="main">
       <h1 class="Issue-title wc-Title--l">
       <script type="text/template" id="title-tmpl">
-        <a class="Issue-linkBack" href="{{ url_for("show_issues") }}" title="All issues">
+        <a class="Issue-linkBack js-linkBack" href="{{ url_for("show_issues") }}" title="All issues">
           <span class="wc-sronly">All Issues</span>
           <span class="Issue-linkBack-icon wc-Icon wc-Icon--arrow-left" aria-hidden="true"></span>
         </a>

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -6,7 +6,7 @@
       <h1 class="Issue-title wc-Title--l">
       <script type="text/template" id="title-tmpl">
         <a class="Issue-linkBack" href="{{ url_for("show_issues") }}" title="All issues">
-		  <span class="wc-sronly">All Issues</span>
+          <span class="wc-sronly">All Issues</span>
           <span class="Issue-linkBack-icon wc-Icon wc-Icon--arrow-left" aria-hidden="true"></span>
         </a>
         Issue <%= number %>: <%- title %>
@@ -75,7 +75,7 @@
             <!--<div class="Comment-drag">-->
               <!-- TODO(miket) <div class="comment__dd">Attach images by dragging &amp; dropping, <span class="comment__dd__label">selecting them</span> or pasting form the clipboad </div> -->
               <label for="Comment-text" class="wc-sronly">Comment Text</label>
-			  <textarea id="Comment-text" class="Comment-wrapper Comment-text" placeholder="Leave a comment"></textarea>
+              <textarea id="Comment-text" class="Comment-wrapper Comment-text" placeholder="Leave a comment"></textarea>
             <!--</div>-->
             <div class="Comment-button">
               <button class="Button Button--action js-issue-state-button">


### PR DESCRIPTION
If someone clicks the back arrow, and they just came from /issues, call `history.back()`. Otherwise, the link is just a regular link to /issues.

r? @karlcow 