### PR TITLE
Fixes #480 - Remove "divider" element from form section of homepage.

### DIFF
--- a/webcompat/static/css/development/page/home.css
+++ b/webcompat/static/css/development/page/home.css
@@ -1,15 +1,5 @@
 /*------Home view------*/
 
-
-.divider {
-  display: block;
-  font-weight: 700;
-  border-top: 5px solid var(--wc-background-dark);
-  width: 30px;
-  color: #fff;
-  margin: 1em 0 0;
-}
-
 /*-------Browse Issues------*/
 #browse-issues-wrapper {
   background-color: #f0f0f0;

--- a/webcompat/templates/form.html
+++ b/webcompat/templates/form.html
@@ -82,7 +82,6 @@
           <button name="submit-type" value="github-proxy-report" class="Button Button--action" id="submitanon">Report Anonymously</button>
       </div>
     </div>
-    <p class="divider" id="submitdiv">___</p>
   </form>
   </div>
 </div>


### PR DESCRIPTION
Taking another look at this, I think we can live without the divider. We used to have a few to break up the page--but this was the only one left.

r? @magsout 