### PR TITLE
Issue #587 - Add a task to check npm dependencies and run by default

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,5 +19,7 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt)
 
   // Default task.
-  grunt.registerTask('default', ['jshint', 'concat', 'uglify','cssnext', 'cssmin', 'imagemin']);
+  grunt.registerTask('default', [
+    'checkDependencies', 'jshint', 'concat', 'uglify','cssnext', 'cssmin', 'imagemin'
+  ]);
 };

--- a/grunt-tasks/check-deps.js
+++ b/grunt-tasks/check-deps.js
@@ -1,0 +1,7 @@
+module.exports = function(grunt) {
+  grunt.config('checkDependencies', {
+    default: {
+      this: {}
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "name": "The fine folks who contribute to webcompat.com",
     "url": "http://webcompat.com"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/webcompat/webcompat.com.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webcompat/webcompat.com.git"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -19,15 +19,16 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-cssmin": "~0.9.0",
+    "grunt-check-dependencies": "~0.9.0",
     "load-grunt-tasks": "~0.6.0",
     "intern": "2.2.0",
     "grunt-contrib-imagemin": "~0.7.1",
-    "grunt-cssnext" : "^1.0.0",
-    "suitcss-utils-display" : "^0.4.0",
-    "suitcss-utils-align" : "^0.2.0",
-    "cssrecipes-reset" : "^0.5.0",
-    "cssrecipes-utils" : "^0.5.0",
-    "cssrecipes-grid" : "^0.4.0",
-    "cssrecipes-custom-media-queries" : "0.3.0"
+    "grunt-cssnext": "^1.0.0",
+    "suitcss-utils-display": "^0.4.0",
+    "suitcss-utils-align": "^0.2.0",
+    "cssrecipes-reset": "^0.5.0",
+    "cssrecipes-utils": "^0.5.0",
+    "cssrecipes-grid": "^0.4.0",
+    "cssrecipes-custom-media-queries": "0.3.0"
   }
 }


### PR DESCRIPTION
This will check npm dependencies if you run any of the following commands.

`grunt`
`grunt checkDependencies`
`make install`
`make build`

r? @magsout 