### PR TITLE
Fixes #368 - ca$he bust all compiled assets

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -41,8 +41,6 @@ DEBUG = False
 if not PRODUCTION:
     DEBUG = True
 
-STARTUP = str(datetime.now())
-
 # Get the secrets from [1] if you're part of the webcompat organization.
 # Otherwise, create your own test and production applications.
 #

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+import hashlib
 import math
 import urlparse
 
@@ -25,6 +26,11 @@ def format_delta_filter(timestamp):
     '''Jinja2 fiter to format a unix timestamp to a time delta string.'''
     delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(timestamp)
     return format_timedelta(delta, locale='en_US')
+
+
+@app.template_filter('bust_cache')
+def bust_cache(filename):
+    return filename + '?' + hashlib.md5(app.config['STARTUP']).hexdigest()[:14]
 
 
 def format_delta_seconds(timestamp):

--- a/webcompat/templates/index.html
+++ b/webcompat/templates/index.html
@@ -101,7 +101,7 @@
 {% endblock %}
 {%- block extrascripts -%}
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/diagnose.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/diagnose.min.js')}}?{{ bust_cache() }}"></script>
 {%- else -%}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/diagnose.js') }}"></script>

--- a/webcompat/templates/index.html
+++ b/webcompat/templates/index.html
@@ -101,7 +101,7 @@
 {% endblock %}
 {%- block extrascripts -%}
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/diagnose.min.js')}}?{{ bust_cache() }}"></script>
+<script src="{{ url_for('static', filename='js/diagnose.min.js')|bust_cache }}"></script>
 {%- else -%}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/diagnose.js') }}"></script>

--- a/webcompat/templates/issue-list.html
+++ b/webcompat/templates/issue-list.html
@@ -132,7 +132,7 @@
 {% block extrascripts %}
 <script>var repoPath="{{config['ISSUES_REPO_URI']}}"</script>
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/issue-list.min.js') }}?{{ bust_cache() }}"></script>
+<script src="{{ url_for('static', filename='js/issue-list.min.js')|bust_cache }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/issue-list.js') }}"></script>

--- a/webcompat/templates/issue-list.html
+++ b/webcompat/templates/issue-list.html
@@ -132,7 +132,7 @@
 {% block extrascripts %}
 <script>var repoPath="{{config['ISSUES_REPO_URI']}}"</script>
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/issue-list.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/issue-list.min.js') }}?{{ bust_cache() }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/issue-list.js') }}"></script>

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -123,7 +123,7 @@
 <script>var issueNumber={{ number }};
 var repoPath="{{config['ISSUES_REPO_URI']}}"</script>
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/issues.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/issues.min.js') }}?{{ bust_cache() }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/models/comment.js') }}"></script>

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -123,7 +123,7 @@
 <script>var issueNumber={{ number }};
 var repoPath="{{config['ISSUES_REPO_URI']}}"</script>
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-<script src="{{ url_for('static', filename='js/issues.min.js') }}?{{ bust_cache() }}"></script>
+<script src="{{ url_for('static', filename='js/issues.min.js')|bust_cache }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/lib/models/issue.js') }}"></script>
 <script src="{{ url_for('static', filename='js/lib/models/comment.js') }}"></script>

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -27,7 +27,7 @@
   <meta name="msapplication-TileColor" content="#e4bc05">
   <meta name="msapplication-TileImage" content="{{ url_for('static', filename='favicon/mstile-144x144.png') }}">
 {%- if config.PRODUCTION or config.DEVELOPMENT -%}
-  <link href="{{ url_for('static', filename='css/webcompat.min.css') }}?{{ bust_cache() }}" type="text/css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/webcompat.min.css')|bust_cache }}" type="text/css" rel="stylesheet">
 {%- else %}
   <link href="{{ url_for('static', filename='css/webcompat.dev.css') }}" type="text/css" rel="stylesheet">
 {%- endif %}
@@ -46,7 +46,7 @@
   ga('create', 'UA-49507820-1', 'webcompat.com');
   ga('send', 'pageview');
 </script>
-<script src="{{ url_for('static', filename='js/webcompat.min.js') }}?{{ bust_cache() }}"></script>
+<script src="{{ url_for('static', filename='js/webcompat.min.js')|bust_cache }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/vendor/jquery-1.11.2.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/vendor/lodash.underscore-min.js') }}"></script>

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import hashlib
 import json
 import urllib
 
@@ -32,13 +31,6 @@ from models import User
 from webcompat import app
 from webcompat import github
 from webcompat.api.endpoints import get_rate_limit
-
-
-@app.context_processor
-def cache_buster():
-    def bust_cache():
-        return hashlib.md5(app.config['STARTUP']).hexdigest()[:14]
-    return dict(bust_cache=bust_cache)
 
 
 @app.teardown_appcontext


### PR DESCRIPTION
Let's consistently cache bust all compiled JS + CSS assets. And let's only update the hash if a file actually changed. Before we were doing it based on a deploy timestamp which is not very efficient.