### PR TITLE
Fixes #564 - fix history navigation from issues

### DIFF
--- a/tests/functional.js
+++ b/tests/functional.js
@@ -8,7 +8,8 @@ define([
   './functional/issue-list',
   './functional/issues',
   './functional/reporting',
-  './functional/contributors'
+  './functional/contributors',
+  './functional/history-navigation'
 ], function () {
   'use strict';
 });

--- a/tests/functional/history-navigation.js
+++ b/tests/functional/history-navigation.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require'
+], function (intern, registerSuite, assert, require) {
+  'use strict';
+
+  var url = intern.config.siteRoot;
+
+  registerSuite({
+    name: 'history navigation',
+
+    'Back button works from issues page': function () {
+      return this.remote
+        .get(require.toUrl(url))
+        .findByCssSelector('.js-issues-link').click()
+        .end()
+        //find an issue so we know the page has loaded
+        .findByCssSelector('div.IssueItem:nth-child(1)')
+        .end()
+        .goBack()
+        // now check that we're back at the home page.
+        .findByCssSelector('.wc-Hero-title').getVisibleText()
+        .then(function (text) {
+          assert.equal(text, 'Bug reporting\nfor the internet.');
+        })
+        .end();
+    }
+  });
+});

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -317,7 +317,7 @@ issueList.IssueView = Backbone.View.extend({
       // There are some params in the URL
       if (category = window.location.search.match(this._filterRegex)) {
         // If there was a stage filter match, fire an event which loads results
-        this.updateModelParams(urlParams)
+        this.updateModelParams(urlParams);
         _.delay(function() {
           issueList.events.trigger('filter:activate', category[1]);
         }, 0);
@@ -424,7 +424,7 @@ issueList.IssueView = Backbone.View.extend({
     issueList.events.trigger('issues:update', {query: labelFilter});
     e.preventDefault();
   },
-  resetStageFilter: function(options) {
+  resetStageFilter: function() {
     // We also want to remove 'q' if present as well.
     delete this.issues.params['q'];
 

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -484,6 +484,8 @@ issueList.IssueView = Backbone.View.extend({
     // splitting on & in case of multiple params
     // params are merged into issues model
     // call _.uniq() on it to ignore duplicate values
+    var hasPerPageChange = params.indexOf('per_page') !== -1;
+    var hasSortChange = params.indexOf('sort') !== -1;
     var paramsArray = _.uniq(params.split('&'));
 
     // paramsArray is an array of param 'key=value' string pairs
@@ -496,7 +498,7 @@ issueList.IssueView = Backbone.View.extend({
 
     //broadcast to each of the dropdowns that they need to update
     var pageDropdown;
-    if ('per_page' in this.issues.params) {
+    if (hasPerPageChange) {
       pageDropdown = 'per_page=' + this.issues.params.per_page;
       _.delay(function(){
         issueList.events.trigger('dropdown:update', pageDropdown);
@@ -505,7 +507,7 @@ issueList.IssueView = Backbone.View.extend({
 
     var sortDropdown;
     // all the sort options begin with sort, and end with direction.
-    if ('sort' in this.issues.params) {
+    if (hasSortChange) {
       sortDropdown = 'sort=' + this.issues.params.sort + '&direction=' + this.issues.params.direction;
       _.delay(function(){
         issueList.events.trigger('dropdown:update', sortDropdown);

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -533,11 +533,9 @@ issueList.IssueView = Backbone.View.extend({
         delete this.issues.params[param];
       }, this));
 
-      var stateDropdown;
       if (currentStateParamName in this.issues.params) {
-        stateDropdown = stateParam;
         _.delay(function(){
-          issueList.events.trigger('dropdown:update', stateDropdown);
+          issueList.events.trigger('dropdown:update', stateParam);
         }, 0);
       }
     }

--- a/webcompat/static/js/lib/models/issue.js
+++ b/webcompat/static/js/lib/models/issue.js
@@ -108,8 +108,9 @@ issueList.IssueCollection = Backbone.Collection.extend({
   model: issueList.Issue,
   /* the url property is set in issueList.IssueView#fetchAndRenderIssues */
   initialize: function() {
-    // set conservative defaults (first page of all open issues, 50 per page)
-    this.params = {page: 1, per_page: 50, state: 'open'};
+    // set defaults
+    this.params = {page: 1, per_page: 50, state: 'open', stage: 'all',
+                   sort: 'created', direction: 'desc'};
     this.path = '/api/issues';
   },
   parse: function(response, jqXHR) {

--- a/webcompat/templates/browse-issues.html
+++ b/webcompat/templates/browse-issues.html
@@ -3,19 +3,19 @@
     <h2 class="wc-Title--l">Browse Issues</h2>
     <ul class="r-ResetList u-inlineBlock">
       <li class="IssueItem IssueItem--list IssueItem--new">
-        <a href="{{ url_for('show_issues') }}?stage=new">New Issues</a>
+        <a href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=new&sort=created&direction=desc">New Issues</a>
       </li>
       <li class="IssueItem IssueItem--list IssueItem--need">
-        <a href="{{ url_for('show_issues') }}?stage=needsdiagnosis">Needs&nbsp;Diagnosis</a>
+        <a href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs&nbsp;Diagnosis</a>
       </li>
       <li class="IssueItem IssueItem--list IssueItem--ready">
-        <a href="{{ url_for('show_issues') }}?stage=contactready">Ready&nbsp;for&nbsp;Outreach</a>
+        <a href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=contactready&sort=created&direction=desc">Ready&nbsp;for&nbsp;Outreach</a>
       </li>
       <li class="IssueItem IssueItem--list IssueItem--sitewait">
-        <a href="{{ url_for('show_issues') }}?stage=sitewait">Site&nbsp;Contacted</a>
+        <a href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=sitewait&sort=created&direction=desc">Site&nbsp;Contacted</a>
       </li>
       <li class="IssueItem IssueItem--list IssueItem--close">
-        <a href="{{ url_for('show_issues') }}?stage=closed">Closed</a>
+        <a href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=closed&sort=created&direction=desc">Closed</a>
       </li>
     </ul>
     {% include "browse-issues/my-issues.html" %}

--- a/webcompat/templates/browse-issues/needs-diagnosis.html
+++ b/webcompat/templates/browse-issues/needs-diagnosis.html
@@ -1,7 +1,7 @@
 <div id="needs-diagnosis" class="r-Grid-cell r-all--1of2 r-maxM--2of2">
   <script type="text/template" id="needs-diagnosis-tmpl">
   <h3 class="wc-titleIssue">
-    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?stage=needsdiagnosis">Needs Diagnosis</a>
+    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a>
   </h3>
   <% if (needsDiagnosis.length) { %>
     <% _.each(needsDiagnosis, function(issue) { %>

--- a/webcompat/templates/browse-issues/new.html
+++ b/webcompat/templates/browse-issues/new.html
@@ -1,7 +1,7 @@
 <div id="new" class="r-Grid-cell r-all--1of2 r-maxM--2of2">
   <script type="text/template" id="new-tmpl">
   <h3 class="wc-titleIssue">
-    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?stage=new">New Issues</a>
+    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=new&sort=created&direction=desc">New Issues</a>
   </h3>
   <% if (newIssues.length) { %>
     <% _.each(newIssues, function(issue) { %>

--- a/webcompat/templates/browse-issues/ready-for-outreach.html
+++ b/webcompat/templates/browse-issues/ready-for-outreach.html
@@ -1,7 +1,7 @@
 <div id="ready-for-outreach" class="r-Grid-cell r-all--1of2 r-maxM--2of2">
   <script type="text/template" id="contactready-tmpl">
   <h3 class="wc-titleIssue">
-    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?stage=contactready">Ready for Outreach</a>
+    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=contactready&sort=created&direction=desc">Ready for Outreach</a>
   </h3>
   <% if (contactReady.length) { %>
     <% _.each(contactReady, function(issue) { %>

--- a/webcompat/templates/browse-issues/site-contacted.html
+++ b/webcompat/templates/browse-issues/site-contacted.html
@@ -1,7 +1,7 @@
 <div id="sitewait" class="r-Grid-cell r-all--1of2 r-maxM--2of2">
   <script type="text/template" id="sitewait-tmpl">
   <h3 class="wc-titleIssue">
-    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?stage=sitewait">Site Contacted</a>
+    <a class="wc-titleIssue-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=sitewait&sort=created&direction=desc">Site Contacted</a>
   </h3>
   <% if (sitewait.length) { %>
     <% _.each(sitewait, function(issue) { %>

--- a/webcompat/templates/shared/nav.html
+++ b/webcompat/templates/shared/nav.html
@@ -10,7 +10,7 @@
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--bug" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">Report a bug</span>
       </a>
-      <a class="wc-Navbar-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
+      <a class="wc-Navbar-link js-issues-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--list" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">All issues</span>
       </a>

--- a/webcompat/templates/shared/nav.html
+++ b/webcompat/templates/shared/nav.html
@@ -10,7 +10,7 @@
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--bug" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">Report a bug</span>
       </a>
-      <a class="wc-Navbar-link" href="{{ url_for("show_issues") }}">
+      <a class="wc-Navbar-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--list" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">All issues</span>
       </a>

--- a/webcompat/templates/topbar.html
+++ b/webcompat/templates/topbar.html
@@ -14,7 +14,7 @@
       <a class="wc-Navbar-link" href="https://github.com/webcompat/webcompat.com/issues?state=open">Give Feedback</a>{%- endif -%}
     </div>
     <div class="wc-Navbar-section wc-Navbar-section--right">
-      <a class="wc-Navbar-link" href="{{ url_for("show_issues") }}">
+      <a class="wc-Navbar-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--list" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">All issues</span>
       </a>

--- a/webcompat/templates/topbar.html
+++ b/webcompat/templates/topbar.html
@@ -14,7 +14,7 @@
       <a class="wc-Navbar-link" href="https://github.com/webcompat/webcompat.com/issues?state=open">Give Feedback</a>{%- endif -%}
     </div>
     <div class="wc-Navbar-section wc-Navbar-section--right">
-      <a class="wc-Navbar-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
+      <a class="wc-Navbar-link js-issues-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc">
         <span class="wc-Navbar-link-icon wc-Icon wc-Icon--list" aria-hidden="true"></span>
         <span class="wc-Navbar-link-label">All issues</span>
       </a>


### PR DESCRIPTION
The problem was that I was creating an infinite `pushState` loop, more or less. Go back and push two more states on the history stack.

This changes a bunch of things, but mostly it's a simplification. A lot less circular method calls.

I'm going to push this to staging so you can play around with it. I need to file one follow up issue that's unrelated to this bug, but is about `q=blah` in the URL should be able to load that search in a fresh tab.

r? @magsout 