### PR TITLE
Fixes #592 - Use the Issues API for label filtering of issues.

### DIFF
--- a/webcompat/api/endpoints.py
+++ b/webcompat/api/endpoints.py
@@ -181,13 +181,9 @@ def get_search_results(query_string=None, params=None):
 def get_category_from_search(issue_category):
     '''XHR endpoint to get issues categories from GitHub's Search API.
 
-    There is some overlap between /issues/category/<issue_category> as used on
-    the home page - but this endpoint returns paginated results.
-
-    Note: until GitHub fixes a bug where requesting issues filtered by labels
-    doesn't return pagination via Link, we get those results from this
-    endpoint. Once it's fixed, we can get "contactready", "needsdiagnosis"
-    and "sitewait" issues from /issues/category/<issue_category>.
+    It's also possible to use /issues/category/<issue_category> for a category
+    that maps to a label. This uses the Issues API, which is less costly than
+    the Search API.
     '''
     category_list = ['contactready', 'needscontact',
                      'needsdiagnosis', 'sitewait']

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -455,9 +455,11 @@ issueList.IssueView = Backbone.View.extend({
     // depending on what category was clicked (or if a search came in),
     // update the collection instance url property and fetch the issues.
 
-    // note: until GitHub fixes a bug where requesting issues filtered by labels
-    // doesn't return pagination via Link, we get those results via the Search API.
-    var searchCategories = ['new', 'contactready', 'needsdiagnosis', 'sitewait'];
+    // new is a special category that must be retrieved via the Search API,
+    // rather than the Issues API (which can return results for labels)
+    var searchAPICategories = ['new'];
+    var issuesAPICategories = ['closed', 'contactready', 'needsdiagnosis',
+                               'needscontact', 'sitewait'];
     var params = this.issues.params;
 
     // note: if query is the empty string, it will load all issues from the
@@ -465,9 +467,9 @@ issueList.IssueView = Backbone.View.extend({
     if (category && category.query) {
       params = $.extend(params, {q: category.query});
       this.issues.setURLState('/api/issues/search', params);
-    } else if (_.contains(searchCategories, category)) {
+    } else if (_.contains(searchAPICategories, category)) {
       this.issues.setURLState('/api/issues/search/' + category, params);
-    } else if (category === "closed") {
+    } else if (_.contains(issuesAPICategories, category)) {
       this.issues.setURLState('/api/issues/category/' + category, params);
     } else {
       this.issues.setURLState('/api/issues', params);


### PR DESCRIPTION
GitHub now returns pagination via Link header, yay!

r? @karlcow 