### PR TITLE
Fixes #612 - Remove duplicate issue update after a search.

### DIFF
--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -131,8 +131,8 @@ issueList.FilterView = Backbone.View.extend({
     var btns = $('[data-filter]');
     btns.removeClass('is-active');
 
+    // Remove existing filters from model and URL
     issueList.events.trigger('filter:reset-stage', options);
-    issueList.events.trigger('issues:update');
   },
   toggleFilter: function(e) {
     var btn;


### PR DESCRIPTION
OK, I don't really remember why this extra `issues:update` event was in here--probably made sense at one point. :8ball: 

r? @magsout 