### PR TITLE
Fixes #634: load results from q param (for logged in users)

### DIFF
--- a/tests/functional/issue-list.js
+++ b/tests/functional/issue-list.js
@@ -226,6 +226,22 @@ define([
           });
     },
 
+    'results are loaded from the query params': function() {
+        var params = '?q=vladvlad';
+        return this.remote
+          .setFindTimeout(intern.config.wc.pageLoadTimeout)
+          .get(require.toUrl(url + params))
+          .findByCssSelector('.wc-IssueItem:nth-of-type(1) a').getVisibleText()
+          .then(function(text){
+            assert.include(text, 'vladvlad', 'The search query results show up on the page.');
+          })
+          .end()
+          .getCurrentUrl()
+          .then(function(currUrl){
+            assert.include(currUrl, 'q=vladvlad', 'Our params didn\'t go anywhere.');
+          });
+    },
+
     'dropdowns reflect state from URL': function() {
       var params = '?per_page=25&sort=updated&direction=desc&state=all';
 

--- a/webcompat/api/endpoints.py
+++ b/webcompat/api/endpoints.py
@@ -71,6 +71,12 @@ def proxy_issues():
     '''API endpoint to list all issues from GitHub.'''
     params = request.args.copy()
 
+    # If there's a q param, then we need to use the Search API
+    # and load those results. Unfortunately, we restrict search requests
+    # to logged in users.
+    if g.user and params.get('q'):
+        return get_search_results(params.get('q'), params)
+
     if g.user:
         issues = github.raw_request('GET', 'repos/{0}'.format(ISSUES_PATH),
                                     params=params)


### PR DESCRIPTION
This is part 1, which allows us to load results from the URL param. Right now it will only work for logged in users. I'll open a bug to handle the unauthed people.

r? @karlcow 