### PR TITLE
Change how we compute the user_id in the session.db.

### DIFF
--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -60,7 +60,7 @@ def after_request(response):
 def token_getter():
     user = g.user
     if user is not None:
-        return user.github_access_token
+        return user.access_token
 
 
 @app.template_filter('format_date')
@@ -96,12 +96,12 @@ def authorized(access_token):
     if access_token is None:
         flash(u'Something went wrong trying to sign into GitHub. :(', 'error')
         return redirect(g.referer)
-    user = User.query.filter_by(github_access_token=access_token).first()
+    user = User.query.filter_by(access_token=access_token).first()
     if user is None:
         user = User(access_token)
         db_session.add(user)
     db_session.commit()
-    session['user_id'] = user.id
+    session['user_id'] = user.user_id
     if session.get('form_data', None) is not None:
         return redirect(url_for('file_issue'))
     else:


### PR DESCRIPTION
I have a theory that somehow our `user_id` computation would be off by 1 (or so) resulting in selecting the wrong user. Possibly by restarting the app if a user was logging in? Unsure, but we know this has happened 2 or 3 times in a year. So it's rare, but very very bad.

The plan here is to do away with integer ids and use a salted + hashed github access token as the user id, so it's guaranteed to be unique. And if we do have a hidden bug somewhere we'll find out because `441262a70a96g6c84339af1fb96365df485e32aa75b03e7ce7a79dcb76f48f8a590caf9066c342ce5efbbd5f75ae962f61aca0206x23b4aa5b4f0becfb6571b9` + 1 (or something, if my hunch is true) will just explode rather than select the wrong user. And maybe that will allow us to find the bug.

r? @karlcow 