### PR TITLE
Adding very simple logging capabilities to webcompat.com

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -55,6 +55,14 @@ DEBUG = False
 if not PRODUCTION:
     DEBUG = True
 
+# Logging Capabilities
+# To benefit from the logging, you may want to add:
+#   app.logger.info(Thing_To_Log)
+# it will create a line with the following format
+# 2015-09-14 20:50:19,185 INFO: Thing_To_Log [in /codepath/views.py:127]
+LOG_FILE = '/tmp/webcompat.log'
+LOG_FMT = '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
+
 # Get the secrets from [1] if you're part of the webcompat organization.
 # Otherwise, create your own test and production applications.
 #

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -6,6 +6,7 @@
 
 '''This module powers the webcompat.com Flask application.'''
 
+import logging
 import os
 
 from flask.ext.cache import Cache
@@ -32,3 +33,10 @@ from api.uploads import uploads
 
 app.register_blueprint(api)
 app.register_blueprint(uploads)
+
+# Start Logging Handlers
+# See config.py for parameters
+file_handler = logging.FileHandler(app.config['LOG_FILE'])
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(logging.Formatter(app.config['LOG_FMT']))
+app.logger.addHandler(file_handler)

--- a/webcompat/api/endpoints.py
+++ b/webcompat/api/endpoints.py
@@ -23,7 +23,6 @@ from webcompat import github
 from webcompat import limiter
 from webcompat.helpers import get_headers
 from webcompat.helpers import get_request_headers
-from webcompat.helpers import get_user_info
 from webcompat.helpers import normalize_api_params
 from webcompat.issues import filter_new
 from webcompat.issues import proxy_request

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -142,8 +142,8 @@ def index():
         # see https://github.com/webcompat/webcompat.com/issues/688
         if 'facebook' in form.get('url'):
             msg = (u'Anonymous reporting for Facebook.com is temporarily '
-                    'disabled. Please see https://github.com/webcompat/we'
-                    'bcompat.com/issues/688 for more details.')
+                   'disabled. Please see https://github.com/webcompat/we'
+                   'bcompat.com/issues/688 for more details.')
             flash(msg, 'notimeout')
             return redirect(url_for('index'))
         form['ua_header'] = ua_header


### PR DESCRIPTION
It's now possible to do something such as 

```python
app.logger.info("IP address: {0}".format(request.remote_addr))
```

or really anything we think is useful for debugging, monitoring for performances, etc.