### PR TITLE
Fixed height of SearchBar

### DIFF
--- a/webcompat/static/css/development/components/search-bar.css
+++ b/webcompat/static/css/development/components/search-bar.css
@@ -2,6 +2,7 @@
 
 .wc-SearchBar {
   position: relative;
+  min-height: 1.4375em;
   transform-style: preserve-3d;
 }
   .wc-SearchBar-face {


### PR DESCRIPTION
Regression due to height of `SearchBar`. All elements inside are `position absolute`, so light bug is mixed in the header

r? @miketaylr 