### PR TITLE
Fixes #751. Import issue labeler into webcompat app.

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -105,6 +105,13 @@ class TestURLs(unittest.TestCase):
         result = '[{"labels": [{"name": "bug"}, {"name": "help wanted"}], "id": 0, "title": "fake bug 0"}, {"labels": [], "id": 1, "title": "fake bug 1"}]'
         self.assertEqual(filter_new(issues), result)
 
+    def test_labeler_webhook(self):
+        '''Test that the labeler webhook can respond to ping event.'''
+        headers = {'X-GitHub-Event': 'ping'}
+        rv = self.app.get('/webhooks/labeler', headers=headers)
+        self.assertEqual(rv.status_code, 403)
+        rv = self.app.post('/webhooks/labeler', headers=headers)
+        self.assertEqual(rv.data, 'pong')
 
 if __name__ == '__main__':
     unittest.main()

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -30,9 +30,9 @@ import webcompat.views
 # register blueprints
 from api.endpoints import api
 from api.uploads import uploads
-from webhooks import webhook
+from webhooks import webhooks
 
-for blueprint in [api, uploads, webhook]:
+for blueprint in [api, uploads, webhooks]:
     app.register_blueprint(blueprint)
 
 

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -30,9 +30,11 @@ import webcompat.views
 # register blueprints
 from api.endpoints import api
 from api.uploads import uploads
+from webhooks import webhook
 
-app.register_blueprint(api)
-app.register_blueprint(uploads)
+for blueprint in [api, uploads, webhook]:
+    app.register_blueprint(blueprint)
+
 
 # Start Logging Handlers
 # See config.py for parameters

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -25,7 +25,7 @@ def hooklistener():
     '''Listen for the "issues" webhook event, parse the body,
        post back labels. But only do that for the 'opened' action.'''
     if request.method == 'GET':
-        return abort(403)
+        abort(403)
     elif (request.method == 'POST' and
             request.headers.get('X-GitHub-Event') == 'issues'):
         payload = json.loads(request.data)
@@ -33,9 +33,11 @@ def hooklistener():
             issue_body = payload.get('issue')['body']
             issue_number = payload.get('issue')['number']
             parse_and_set_label(issue_body, issue_number)
-            return 'gracias, amigo.'
+            return ('gracias, amigo.', 200)
         else:
-            return 'cool story, bro.'
+            return ('cool story, bro.', 200)
     elif (request.method == 'POST' and
             request.headers.get('X-GitHub-Event') == 'ping'):
-        return 'pong'
+        return ('pong', 200)
+    else:
+        abort(403)

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -17,10 +17,10 @@ from flask import request
 
 from helpers import parse_and_set_label
 
-webhook = Blueprint('webhook', __name__, url_prefix='/webhook')
+webhooks = Blueprint('webhooks', __name__, url_prefix='/webhooks')
 
 
-@webhook.route('/labeler', methods=['GET', 'POST'])
+@webhooks.route('/labeler', methods=['GET', 'POST'])
 def hooklistener():
     '''Listen for the "issues" webhook event, parse the body,
        post back labels. But only do that for the 'opened' action.'''

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''Flask Blueprint for our "webhooks" module, which we use to do cool things
+with GitHub events and actions.
+
+See https://developer.github.com/webhooks/ for what is possible.'''
+
+import json
+
+from flask import Blueprint
+from flask import abort
+from flask import request
+
+from helpers import parse_and_set_label
+
+webhook = Blueprint('webhook', __name__, url_prefix='/webhook')
+
+
+@webhook.route('/labeler', methods=['GET', 'POST'])
+def hooklistener():
+    '''Listen for the "issues" webhook event, parse the body,
+       post back labels. But only do that for the 'opened' action.'''
+    if request.method == 'GET':
+        return abort(403)
+    elif (request.method == 'POST' and
+            request.headers.get('X-GitHub-Event') == 'issues'):
+        payload = json.loads(request.data)
+        if payload.get('action') == 'opened':
+            issue_body = payload.get('issue')['body']
+            issue_number = payload.get('issue')['number']
+            parse_and_set_label(issue_body, issue_number)
+            return 'gracias, amigo.'
+        else:
+            return 'cool story, bro.'
+    elif (request.method == 'POST' and
+            request.headers.get('X-GitHub-Event') == 'ping'):
+        return 'pong'

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+import re
+import requests
+
+from webcompat import app
+
+
+def api_post(endpoint, payload, issue):
+    '''Helper method to post junk to GitHub.'''
+    headers = {
+        'Authorization': 'token {0}'.format(app.config['BOT_OAUTH_TOKEN'])
+    }
+    uri = 'https://api.github.com/repos/{0}/{1}/{2}'.format(
+        app.config['ISSUES_REPO_URI'], issue, endpoint)
+    requests.post(uri, data=json.dumps(payload), headers=headers)
+
+
+def parse_and_set_label(body, issue_number):
+    '''Parse the labels from the body in comments like so:
+    <!-- @browser: value -->. Currently this only handles a single label,
+    becuase that's all that we set in webcompat.com.
+    '''
+    match_list = re.search(r'<!--\s@(\w+):\s([^\d]+?)\s[\d\.]+\s-->', body)
+    if match_list:
+        # perhaps we do something more interesting depending on
+        # what groups(n)[0] is in the future.
+        # right now, match_list.groups(0) should look like:
+        # ('browser', 'firefox')
+        browser = match_list.groups(0)[1].lower()
+        dash_browser = '-'.join(browser.split())
+        set_label('browser-' + dash_browser, issue_number)
+
+
+def set_label(label, issue_number):
+    '''Do a GitHub POST request using one of our bots, which has push access
+    and set a label for the issue.'''
+    # POST /repos/:owner/:repo/issues/:number/labels
+    # ['Label1', 'Label2']
+    payload = [label]
+    api_post('labels', payload, issue_number)

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -25,7 +25,7 @@ def api_post(endpoint, payload, issue):
 def parse_and_set_label(body, issue_number):
     '''Parse the labels from the body in comments like so:
     <!-- @browser: value -->. Currently this only handles a single label,
-    becuase that's all that we set in webcompat.com.
+    because that's all that we set in webcompat.com.
     '''
     match_list = re.search(r'<!--\s@(\w+):\s([^\d]+?)\s[\d\.]+\s-->', body)
     if match_list:


### PR DESCRIPTION
This also makes adding other webhooks fairly simple, by adding `@webhooks.route('/foo')` routes to `webhooks/__init.__.py`

r? @hallvors 