### PR TITLE
Fixes #819. Update ua-parser to 0.5.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ Flask-Uploads==0.1.3
 Flask-WTF==0.12
 GitHub-Flask==0.3.4
 WTForms==2.0.2
-ua-parser==0.3.5
+ua-parser==0.5.0
 nose==1.3.1
 blinker==1.3


### PR DESCRIPTION
This will fix the broken detection of Firefox tablets as Android browser. However, they will be identified as Firefox Mobile.

r? @karlcow 