### PR TITLE
Fix #856 - Send the right content to rate_limit route

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -123,6 +123,12 @@ class TestURLs(unittest.TestCase):
         rv = self.app.get('/tools/cssfixme')
         self.assertEqual(rv.status_code, 200)
 
+    def test_rate_limit(self):
+        '''Test that we are receiving the appropriate text file.'''
+        rv = self.app.get('/rate_limit')
+        response_start = 'Current user:'
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue = rv.data.startswith(response_start)
 
 if __name__ == '__main__':
     unittest.main()

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -222,7 +222,8 @@ def show_user_page(username):
 
 @app.route('/rate_limit')
 def show_rate_limit():
-    rl = json.loads(get_rate_limit())
+    body, status_code, response_headers = get_rate_limit()
+    rl = json.loads(body)
     if g.user:
         rl.update({"user": session.get('username')})
     else:


### PR DESCRIPTION
This is working. 

Nosetests done.

```
→ nosetests
...............................
----------------------------------------------------------------------
Ran 31 tests in 4.101s

OK
```

