### PR TITLE
Fixes #878. Return 401 Unauthorized for non-logged in users at /me

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -56,10 +56,13 @@ class TestURLs(unittest.TestCase):
         self.assertEqual(rv.status_code, 302)
         self.assertIn('github.com/login/oauth/', rv.headers['Location'])
 
-    def test_activity_page_login_redirect(self):
+    def test_activity_page_route(self):
+        rv = self.app.get('/activity/username')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_activity_page_401_if_not_logged_in(self):
         rv = self.app.get('/me')
-        self.assertEqual(rv.status_code, 302)
-        self.assertIn('/login', rv.headers['Location'])
+        self.assertEqual(rv.status_code, 401)
 
     def test_issue_int(self):
         '''Test issues and integer for:

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -8,6 +8,7 @@ import json
 import urllib
 
 from flask.ext.github import GitHubError
+from flask import abort
 from flask import flash
 from flask import g
 from flask import jsonify
@@ -210,7 +211,7 @@ def thanks(number):
 def me_redirect():
     '''This route redirects to /activity/<username>, for logged in users.'''
     if not g.user:
-        return redirect(url_for('login'))
+        abort(401)
     get_user_info()
     return redirect(url_for('show_user_page', username=session['username']))
 

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -289,24 +289,38 @@ def jumpship(e):
 
 @app.errorhandler(401)
 def unauthorized(err):
+    message = 'Unauthorized. Please log in.'
     if (request.path.startswith('/api/') and
        request.accept_mimetypes.accept_json and
        not request.accept_mimetypes.accept_html):
         message = {
             'status': 401,
-            'message': 'API call. Unauthorized. Please log in.',
+            'message': 'API call' + message,
         }
         resp = jsonify(message)
         resp.status_code = 401
         return resp
-    else:
+    return render_template('error.html',
+                           error_code=401,
+                           error_message=message), 401
+
+
+@app.errorhandler(400)
+def unauthorized(err):
+    message = 'Bad Request.'
+    if (request.path.startswith('/api/') and
+       request.accept_mimetypes.accept_json and
+       not request.accept_mimetypes.accept_html):
         message = {
             'status': 400,
-            'message': 'API call. Bad Request.',
+            'message': 'API call' + message,
         }
         resp = jsonify(message)
         resp.status_code = 400
         return resp
+    return render_template('error.html',
+                           error_code=400,
+                           error_message=message), 400
 
 
 @app.errorhandler(404)


### PR DESCRIPTION
Rather than redirecting for a login, send a 401.

r? @karlcow 