### PR TITLE
Fixes #926. Use dark yellow for CSS fix me highlight.

### DIFF
--- a/webcompat/static/css/development/components/cssfixme.css
+++ b/webcompat/static/css/development/components/cssfixme.css
@@ -3,7 +3,7 @@
 :root {
   --CSSFixme-fontSize: var(--base-fontSize);
   --CSSFixme-backgroundColor : rgba(249, 249, 249, 0.6);
-  --CSSFixme-backgroundColorStrong: var(--base-variantColorDark);
+  --CSSFixme-backgroundColorStrong: var(--base-colorDark);
   --CSSFixme-preBorderColor: var(--base-colorDark);
 }
 


### PR DESCRIPTION
r? @magsout 

![](https://cldup.com/MrhLNLTTCR-2000x2000.png)