### PR TITLE
Fix #767: display proper URL hostname when scheme is missing slashes

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+'''Tests for form validation.'''
+
+import unittest
+from webcompat import form
+
+
+class TestForm(unittest.TestCase):
+
+    def test_normalize_url(self):
+
+        r = form.normalize_url('example.com')
+        self.assertEqual(r, 'http://example.com/')
+
+        r = form.normalize_url('http:/example.com')
+        self.assertEqual(r, 'http://example.com/')
+
+        r = form.normalize_url('https:/example.com')
+        self.assertEqual(r, 'https://example.com/')
+
+        r = form.normalize_url('http:example.com')
+        self.assertEqual(r, 'http://example.com/')
+
+        r = form.normalize_url('https:example.com')
+        self.assertEqual(r, 'https://example.com/')
+
+
+    def test_domain_name(self):
+        
+        r = form.domain_name("http://example.com")
+        self.assertEqual(r, "example.com")
+
+        r = form.domain_name("https://example.com")
+        self.assertEqual(r, "example.com")

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -30,7 +30,7 @@ class TestForm(unittest.TestCase):
         self.assertEqual(r, 'http://example.com')
 
     def test_domain_name(self):
-        
+
         r = form.domain_name("http://example.com")
         self.assertEqual(r, "example.com")
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -11,6 +11,12 @@ class TestForm(unittest.TestCase):
 
     def test_normalize_url(self):
 
+        r = form.normalize_url('http://example.com')
+        self.assertEqual(r, 'http://example.com')
+
+        r = form.normalize_url('https://example.com')
+        self.assertEqual(r, 'https://example.com')
+
         r = form.normalize_url('example.com')
         self.assertEqual(r, 'http://example.com')
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -12,20 +12,22 @@ class TestForm(unittest.TestCase):
     def test_normalize_url(self):
 
         r = form.normalize_url('example.com')
-        self.assertEqual(r, 'http://example.com/')
+        self.assertEqual(r, 'http://example.com')
 
         r = form.normalize_url('http:/example.com')
-        self.assertEqual(r, 'http://example.com/')
+        self.assertEqual(r, 'http://example.com')
 
         r = form.normalize_url('https:/example.com')
-        self.assertEqual(r, 'https://example.com/')
+        self.assertEqual(r, 'https://example.com')
 
         r = form.normalize_url('http:example.com')
-        self.assertEqual(r, 'http://example.com/')
+        self.assertEqual(r, 'http://example.com')
 
         r = form.normalize_url('https:example.com')
-        self.assertEqual(r, 'https://example.com/')
+        self.assertEqual(r, 'https://example.com')
 
+        r = form.normalize_url('//example.com')
+        self.assertEqual(r, 'http://example.com')
 
     def test_domain_name(self):
         

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -132,11 +132,10 @@ def normalize_url(url):
             url += '#' + parsed.fragment
     elif not parsed.scheme:
         # We assume that http is missing not https
-        url = 'http://%s' % (url)
-
-    # if url does not contain a path, ensure it has a trailing slash
-    if not urlparse.urlparse(url).path:
-        url += "/"
+        if url.startswith("//"):
+            url = "http://%s" % (url[2:])
+        else:
+            url = 'http://%s' % (url)
 
     return url
 

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -121,11 +121,11 @@ def normalize_url(url):
     url = url.strip()
     parsed = urlparse.urlparse(url)
 
-    if url.startswith(BAD_SCHEMES):
+    if url.startswith(BAD_SCHEMES) and not url.startswith(SCHEMES):
         # if url starts with a bad scheme, parsed.netloc will be empty,
         # so we use parsed.path instead
         path = parsed.path.lstrip('/')
-        url = '%s://%s' % (parsed.scheme, path)
+        url = '{}://{}'.format(parsed.scheme, path)
         if parsed.query:
             url += '?' + parsed.query
         if parsed.fragment:
@@ -133,10 +133,9 @@ def normalize_url(url):
     elif not parsed.scheme:
         # We assume that http is missing not https
         if url.startswith("//"):
-            url = "http://%s" % (url[2:])
+            url = "http://{}".format(url[2:])
         else:
-            url = 'http://%s' % (url)
-
+            url = 'http://{}'.format(url)
     return url
 
 

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -25,6 +25,7 @@ from webcompat.api.uploads import Upload
 AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
 SCHEMES = ('http://', 'https://')
+BAD_SCHEMES = ('http:/', 'https:/', 'http:', 'https:')
 
 problem_choices = [
     (u'detection_bug', u'Desktop site instead of mobile site'),
@@ -118,9 +119,25 @@ def get_labels(browser_name):
 def normalize_url(url):
     '''normalize URL for consistency.'''
     url = url.strip()
-    if not url.startswith(SCHEMES):
+    parsed = urlparse.urlparse(url)
+
+    if url.startswith(BAD_SCHEMES):
+        # if url starts with a bad scheme, parsed.netloc will be empty,
+        # so we use parsed.path instead
+        path = parsed.path.lstrip('/')
+        url = '%s://%s' % (parsed.scheme, path)
+        if parsed.query:
+            url += '?' + parsed.query
+        if parsed.fragment:
+            url += '#' + parsed.fragment
+    elif not parsed.scheme:
         # We assume that http is missing not https
         url = 'http://%s' % (url)
+
+    # if url does not contain a path, ensure it has a trailing slash
+    if not urlparse.urlparse(url).path:
+        url += "/"
+
     return url
 
 


### PR DESCRIPTION
this updates webcompat.form.normalize_url to account for missing slashes (e.g., "http:/example.com"), and adds basic unit tests for normalize_url and domain_name.

r? @miketaylr 