### PR TITLE
Fixes #741: Add a origin help comment to issue (for GitHub users)

### DIFF
--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -26,6 +26,7 @@ AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
 SCHEMES = ('http://', 'https://')
 BAD_SCHEMES = ('http:/', 'https:/', 'http:', 'https:')
+GITHUB_HELP = '<p class="wc-is-hidden">This issue was filed via webcompat.com</p>'  # nopep8
 
 problem_choices = [
     (u'detection_bug', u'Desktop site instead of mobile site'),
@@ -196,11 +197,13 @@ def build_formdata(form_object):
         'browser': form_object.get('browser'),
         'os': form_object.get('os'),
         'problem_type': get_problem(form_object.get('problem_category')),
-        'description': form_object.get('description')
+        'description': form_object.get('description'),
+        'help_message': GITHUB_HELP
     }
 
     # Preparing the body
     body = u'''{browser_label}{ua_label}
+{help_message}
 **URL**: {url}
 **Browser / Version**: {browser}
 **Operating System**: {os}

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -26,7 +26,7 @@ AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
 SCHEMES = ('http://', 'https://')
 BAD_SCHEMES = ('http:/', 'https:/', 'http:', 'https:')
-GITHUB_HELP = '<p class="wc-is-hidden">This issue was filed via webcompat.com</p>'  # nopep8
+GITHUB_HELP = u'_From [webcompat.com](https://webcompat.com/) with ❤️_'
 
 problem_choices = [
     (u'detection_bug', u'Desktop site instead of mobile site'),
@@ -197,8 +197,7 @@ def build_formdata(form_object):
         'browser': form_object.get('browser'),
         'os': form_object.get('os'),
         'problem_type': get_problem(form_object.get('problem_category')),
-        'description': form_object.get('description'),
-        'help_message': GITHUB_HELP
+        'description': form_object.get('description')
     }
 
     # Preparing the body
@@ -211,12 +210,13 @@ def build_formdata(form_object):
 **Steps to Reproduce**
 {description}
 
-{help_message}
 '''.format(**formdata)
     # Add the image, if there was one.
     if form_object.get('image_upload') is not None:
         body += '\n\n![Screenshot of the site issue]({image_url})'.format(
             image_url=form_object.get('image_upload').get('url'))
+    # Append "from webcompat.com" message to bottom (for GitHub issue viewers)
+    body += u'\n\n{0}'.format(GITHUB_HELP)
     result = {}
     result['title'] = summary
     result['body'] = body

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -203,7 +203,6 @@ def build_formdata(form_object):
 
     # Preparing the body
     body = u'''{browser_label}{ua_label}
-{help_message}
 **URL**: {url}
 **Browser / Version**: {browser}
 **Operating System**: {os}
@@ -211,6 +210,8 @@ def build_formdata(form_object):
 
 **Steps to Reproduce**
 {description}
+
+{help_message}
 '''.format(**formdata)
     # Add the image, if there was one.
     if form_object.get('image_upload') is not None:

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -140,13 +140,21 @@ issues.BodyView = Backbone.View.extend({
   render: function() {
     this.$el.html(this.template(this.model.toJSON()));
     // hide metadata
-    $('.js-Issue-markdown')
+    var issueDesc = $('.js-Issue-markdown');
+    issueDesc
       .contents()
       .filter(function() {
         //find the bare html comment-ish text nodes
         return this.nodeType === 3 && this.nodeValue.match(/<!--/);
         //and hide them
       }).wrap('<p class="is-hidden"></p>');
+
+    // this is probably really slow, but it's the safest way to not hide user data
+    issueDesc
+      .find('p:last-of-type em:contains(From webcompat.com)')
+      .parent()
+      .addClass('is-hidden');
+
     this.QrView.setElement('.wc-QrCode').render();
     return this;
   }


### PR DESCRIPTION
Work started by @deckycoss in https://github.com/webcompat/webcompat.com/pull/973.

I cleaned up some conflicts, moved the message to the bottom of the report, and decided to hide it in the webcompat UI via JS (since we already do similar things for the comment metadata).

r? @karlcow because this has changed quite a bit since the last review.