### PR TITLE
Fixes #1011. Bump z-index of loader so it will always be on top.

### DIFF
--- a/webcompat/static/css/development/components/loader.css
+++ b/webcompat/static/css/development/components/loader.css
@@ -4,7 +4,7 @@
   display:none;
   position:fixed;
   background-image:url(/img/loader.gif);
-  z-index:2;
+  z-index:10;
   background-color:rgba(255,255,255,0);
   top:0px;left:0px;right:0px;bottom:0px;
   background-position:center center;


### PR DESCRIPTION
The z-index of the image upload was also 2, so I just bumped it to 10 (in case something else gets a 3 in the future? -- probably unlikely)

r? @magsout