### PR TITLE
Fixes #994. Better handle 413 errors when uploading an image.

### DIFF
--- a/webcompat/static/css/development/components/flash-message.css
+++ b/webcompat/static/css/development/components/flash-message.css
@@ -21,7 +21,7 @@
   /* states */
   .wc-FlashMessage.is-active {
     display:block;
-    z-index: 2;
+    z-index: 10;
   }
 
   /* modifier */

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -102,10 +102,14 @@ function BugForm() {
         this.loaderImage.hide();
         window.location.href = '/thanks/' + response.number;
       }, this),
-      error: function() {
+      error: _.bind(function(response) {
         var msg = 'There was an error trying to file the bug, try again?.';
-        wcEvents.trigger('flash:error', {message: msg, timeout: 4000});
-      }
+        if (response && response.status === 413) {
+          msg = 'The image is too big! Please choose something smaller than 4MB.';
+        }
+        wcEvents.trigger('flash:error', {message: msg, timeout: 5000});
+        this.loaderImage.hide();
+      }, this)
     });
   };
 

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -233,6 +233,12 @@ function BugForm() {
                 .insertAfter('.js-image-upload-label');
 
       $('.wc-UploadForm-label').hide();
+      // "reset" the form field, because the file would get rejected
+      // from the server anyways.
+      this.uploadField.val(this.uploadField.get(0).defaultValue);
+      // return early because we just cleared out the input.
+      // someone might decide to just not select an image.
+      return;
     }
 
     this.disableSubmits();
@@ -248,7 +254,8 @@ function BugForm() {
 
     if (this.inputMap['url'].valid &&
         this.inputMap['problem_type'].valid &&
-        this.inputMap['image'].valid) {
+        this.inputMap['image'].valid &&
+        this.inputMap['img_too_big'].valid) {
       this.enableSubmits();
     }
   };
@@ -257,6 +264,8 @@ function BugForm() {
     of the image they're about to load.
   */
   this.showUploadPreview = function(event) {
+    var UPLOAD_LIMIT = 1024 * 1024 * 4;
+
     if (!(window.FileReader && window.File)) {
       return;
     }
@@ -265,9 +274,11 @@ function BugForm() {
     var img = event.target.files[0];
     // The limit is 4MB (which is crazy big!), so let the user know if their
     // file is unreasonably large.
-    if (img.size > 1024 * 1024 * 4) {
+    if (img.size > UPLOAD_LIMIT) {
       this.makeInvalid('img_too_big');
       return;
+    } else if (img.size < UPLOAD_LIMIT) {
+      this.makeValid('img_too_big');
     }
 
     // One last image type validation check.

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -284,7 +284,7 @@ function BugForm() {
   };
 
   this.addPreviewBackground = function(dataURI) {
-    if (!_.startsWith(dataURI, 'data:image/png;base64')) {
+    if (!_.startsWith(dataURI, 'data:image/')) {
       return;
     }
 


### PR DESCRIPTION
This PR has 3 related changes:

1) Show a better flash message when the server returns a 413 (image too large)
2) Fix the z-index issue where the flash message was behind the image preview
3) Fix bugs in "image too large" validation that meant submit buttons were never re-enabled if you removed or changed the image.

r? @magsout