### PR TITLE
Fixes #890. Remove intermittent failing search tests.

### DIFF
--- a/tests/fixtures/api/issues/search.658ca355332f37516ee5154982b283c5.json
+++ b/tests/fixtures/api/issues/search.658ca355332f37516ee5154982b283c5.json
@@ -1,0 +1,54 @@
+{
+  "_fixture": "true",
+  "total_count": 1,
+  "incomplete_results": false,
+  "items": [
+    {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/114",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/114/labels{/name}",
+      "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/114/comments",
+      "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/114/events",
+      "html_url": "https://github.com/webcompat/webcompat-tests/issues/114",
+      "id": 37931436,
+      "number": 114,
+      "title": "vladvlad",
+      "user": {
+        "login": "testerbuddy2",
+        "id": 8173975,
+        "avatar_url": "https://avatars.githubusercontent.com/u/8173975?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/testerbuddy2",
+        "html_url": "https://github.com/testerbuddy2",
+        "followers_url": "https://api.github.com/users/testerbuddy2/followers",
+        "following_url": "https://api.github.com/users/testerbuddy2/following{/other_user}",
+        "gists_url": "https://api.github.com/users/testerbuddy2/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/testerbuddy2/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/testerbuddy2/subscriptions",
+        "organizations_url": "https://api.github.com/users/testerbuddy2/orgs",
+        "repos_url": "https://api.github.com/users/testerbuddy2/repos",
+        "events_url": "https://api.github.com/users/testerbuddy2/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/testerbuddy2/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/closed-duplicate",
+          "name": "closed-duplicate",
+          "color": "cccccc"
+        }
+      ],
+      "state": "open",
+      "locked": true,
+      "assignee": null,
+      "milestone": null,
+      "comments": 9,
+      "created_at": "2014-07-15T22:14:21Z",
+      "updated_at": "2014-07-21T14:56:05Z",
+      "closed_at": null,
+      "body": "<!-- @browser: Chrome 35.0.1916 -->\r\n\r\n**URL**: test.com\r\n**Browser / Version**: Chrome 35.0.1916\r\n**Operating System**: Mac OS X 10.9.2\r\n**Problem type**: Unknown\r\n**Site owner**: Unknown\r\n\r\n**Steps to Reproduce**\r\n1) Navigate to: test.com\r\n2) …\r\n\r\nExpected Behavior:\r\nActual Behavior:\r\n\r\n```css\r\nfloat: left\r\n```\r\n",
+      "score": 32.393833
+    }
+  ]
+}

--- a/tests/functional/search-auth.js
+++ b/tests/functional/search-auth.js
@@ -71,6 +71,24 @@ define([
         .end();
     },
 
+    'Search works': function() {
+      return this.remote
+        .setFindTimeout(intern.config.wc.pageLoadTimeout)
+        .get(require.toUrl(url('/issues')))
+        .findByCssSelector('.js-SearchForm input')
+        .type('vladvlad')
+        .end()
+        .findByCssSelector('.js-SearchForm button').click()
+        .end()
+        // this is lame, but we gotta wait on search results.
+        .sleep(3000)
+        .findByCssSelector('.wc-IssueList:nth-of-type(1) a').getVisibleText()
+        .then(function(text) {
+          assert.include(text, 'vladvlad', 'The search results show up on the page.');
+        })
+        .end();
+    },
+
     'Search from the homepage': function() {
       return this.remote
         .setFindTimeout(intern.config.wc.pageLoadTimeout)

--- a/tests/functional/search-non-auth.js
+++ b/tests/functional/search-non-auth.js
@@ -8,7 +8,7 @@ define([
   'intern/chai!assert',
   'require',
   'intern/dojo/node!leadfoot/keys'
-], function(intern, registerSuite, assert, require, keys) {
+], function(intern, registerSuite, assert, require) {
   'use strict';
 
   var url = function(path) {
@@ -72,47 +72,6 @@ define([
         .findByCssSelector('.js-SearchForm').isDisplayed()
         .then(function(isDisplayed) {
           assert.equal(isDisplayed, true, 'Search input is visible for non-authed users.');
-        })
-        .end();
-    },
-
-    'Search works': function() {
-      return this.remote
-        .setFindTimeout(intern.config.wc.pageLoadTimeout)
-        .get(require.toUrl(url('/issues')))
-        .findByCssSelector('.js-SearchForm input')
-        .type('vladvlad')
-        .end()
-        .findByCssSelector('.js-SearchForm button').click()
-        .end()
-        // this is lame, but we gotta wait on search results.
-        .sleep(3000)
-        .findByCssSelector('.wc-IssueList:nth-of-type(1) a').getVisibleText()
-        .then(function(text) {
-          assert.include(text, 'vladvlad', 'The search results show up on the page.');
-        })
-        .end();
-    },
-
-    'Search from the homepage': function() {
-      return this.remote
-        .setFindTimeout(intern.config.wc.pageLoadTimeout)
-        .get(require.toUrl(url('/')))
-        .findByCssSelector('.js-SearchBarOpen').click()
-        .end()
-        .findByCssSelector('.js-SearchBar input').click()
-        .type('vladvlad')
-        .type(keys.ENTER)
-        .end()
-        .sleep(3000)
-        .findByCssSelector('.wc-IssueList:nth-of-type(1) a').getVisibleText()
-        .then(function(text) {
-          assert.include(text, 'vladvlad', 'The search query results show up on the page.');
-        })
-        .end()
-        .getCurrentUrl()
-        .then(function(currUrl) {
-          assert.include(currUrl, 'page=1', 'Default params got merged.');
         })
         .end();
     }


### PR DESCRIPTION
It dawned on me that the reason these sometimes fail is because of Search API rate limits (non-authed tests are sending requests from the Travis IP, not the authed webcompat proxy).

If that theory is true, then moving the "search works" to the auth tests should never fail (which is good, because we don't lose test coverage -- sort of).

r? @karlcow 