### PR TITLE
fix #1051 Converting PNGs to JPEG

### DIFF
--- a/webcompat/api/uploads.py
+++ b/webcompat/api/uploads.py
@@ -86,6 +86,8 @@ class Upload(object):
         # Optimize further the image compression for these formats
         if self.image_object.format in ['JPEG', 'JPG', 'JPE', 'PNG']:
             save_parameters['optimize'] = True
+            # Convert PNG to JPEG. See issue #1051
+            file_dest = 'jpg'.join(file_dest.rsplit('png', 1))
         # If animated GIF, aka duration > 0, add save_all parameter
         if (self.image_object.format == 'GIF' and
            self.image_object.info['duration'] > 0):


### PR DESCRIPTION
r? @miketaylr 

This convert the PNG to JPEG for optimizing the size and the time, and bypass the issue with PNG poor encoding performances.
This is not necessary to integrate. but it would be worth testing at least. This is a simple fix following up my tests in #1051