### PR TITLE
Fixes #1055. Include bmp and gif in the "remove image upload" regex.

### DIFF
--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -334,7 +334,7 @@ function BugForm() {
       // Note: this could fail in weird ways depending on how
       // the user has edited the descField.
       this.descField.val(function(idx, value) {
-        return value.replace(/!\[.+\.jpe*g\)$/, '');
+        return value.replace(/!\[.+\.(?:bmp|gif|jpe*g*)\)$/, '');
       });
     }, this));
   };


### PR DESCRIPTION
To test the regex, you can mess with this in the console:

`"![Screenshot Description](http://localhost:5000/uploads/2016/5/7a6a1a82-fe93-4138-8734-ec92df462b85.jpeg)".replace(/!\[.+\.(?:bmp|gif|jpe*g*)\)$/, "lol")`

r? @adamopenweb 