### PR TITLE
Fixes #1088. Add pointer-events:none to font icons.

### DIFF
--- a/webcompat/static/css/development/components/icon-font.css
+++ b/webcompat/static/css/development/components/icon-font.css
@@ -21,6 +21,10 @@
   vertical-align:middle;
 }
 
+.wc-Icon:not(button) {
+  pointer-events: none;
+}
+
 .wc-Icon--cloud-download:before {
   content: "\f0ed";
 }


### PR DESCRIPTION
This is to prevent them from consuming the click event in Chrome,
which apparently doesn't bubble up to the parent `<button>`?

r? @magsout 

cc @cch5ng 