### PR TITLE
Fixes #1121. Fix bogus CSS variable name.

### DIFF
--- a/webcompat/static/css/development/components/tag.css
+++ b/webcompat/static/css/development/components/tag.css
@@ -42,7 +42,7 @@
     .wc-Tag--needstriage.wc-Tag--filter:focus,
     .wc-Tag--needstriage.is-active,
     .wc-Tag--needstriage.wc-Tag--label {
-      background-color:var(--base-needstriage);
+      background-color:var(--base-stateNeedsTriage);
     }
 
   /* Tag needsDiagnosis */


### PR DESCRIPTION
Seems like postcss was possibly bailing after not finding a value for `--base-needstriage`.

r? @deepthivenkat 