### PR TITLE
Fixes #1169. Add class to hide the add-on download link.

### DIFF
--- a/webcompat/static/css/development/components/navbar.css
+++ b/webcompat/static/css/development/components/navbar.css
@@ -68,9 +68,9 @@
     vertical-align: middle;
   }
 
-  /* .is-hidden class added when add-on is installed */
-  .wc-Navbar .is-hidden {
-    display: none;
+  /* .is-hidden class added when add-on is already installed */
+  .wc-Navbar-link.is-hidden {
+    display: none
   }
 
   @media all and (max-width: 30em) {

--- a/webcompat/static/css/development/components/navbar.css
+++ b/webcompat/static/css/development/components/navbar.css
@@ -68,6 +68,11 @@
     vertical-align: middle;
   }
 
+  /* .is-hidden class added when add-on is installed */
+  .wc-Navbar .is-hidden {
+    display: none;
+  }
+
   @media all and (max-width: 30em) {
     .wc-Navbar-linkDownload-label-word {
       display: none;

--- a/webcompat/static/js/lib/homepage.js
+++ b/webcompat/static/js/lib/homepage.js
@@ -14,9 +14,10 @@ function HomePage() {
 
   this.init = function() {
     reportButton.add(reportLink).on('click', this.toggleForm);
-    document.documentElement.className =
-      ('ontouchstart' in window || 'createTouch' in document) ?
-      'touch' : 'no-touch';
+    var htmlClass = ('ontouchstart' in window || 'createTouch' in document) ?
+                     'touch' : 'no-touch';
+    document.documentElement.classList.add(htmlClass);
+
     // Open the form if we've got open=1 param in the URL
     if (formContainer.hasClass('is-closed') &&
         location.search.search(/open=1/) > -1) {


### PR DESCRIPTION
This class is added by the add-on content script here:

https://github.com/webcompat/webcompat-reporter-extensions/commit/5f5bda5049e656cf60c9bf3e1feb635442b9687e

