### PR TITLE
Issue #1002 - Upgrade eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,46 @@
+{
+  "env": {
+    "browser": true
+  },
+  "extends": "eslint:recommended",
+  "globals": {
+    "jQuery": true,
+    "$": true,
+    "_": true,
+    "Backbone": true,
+    "console": true,
+    "define": true,
+    "issueNumber": true,
+    "markdownitEmoji": true,
+    "markdownitSanitizer": true,
+    "md": true,
+    "module": true,
+    "moment": true,
+    "Mousetrap": true,
+    "PaginationMixin": true,
+    "Prism": true,
+    "qr": true,
+    "repoPath": true,
+    "require": true,
+    "wcEvents": true
+  },
+  "rules": {
+    "comma-dangle": 0,
+    "curly": [2, "all"],
+    "eqeqeq": [2, "smart"],
+    "indent": [2, 2],
+    "keyword-spacing": 2,
+    "linebreak-style": [2, "unix"],
+    "new-cap": 2,
+    "no-cond-assign": 0,
+    "no-spaced-func": 2,
+    "no-use-before-define": 2,
+    "one-var": [2, "never"],
+    "quotes": [2, "single"],
+    "semi": [2, "always"],
+    "space-before-blocks": 2,
+    "space-before-function-paren": [2, "never"],
+    "space-infix-ops": 2,
+    "space-unary-ops": 2
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cssrecipes-grid": "^0.4.0",
     "cssrecipes-reset": "^0.5.0",
     "cssrecipes-utils": "^0.5.0",
-    "eslint": "^1.8.0",
+    "eslint": "^3.4.0",
     "grunt": "~0.4.5",
     "grunt-check-dependencies": "~0.9.0",
     "grunt-contrib-concat": "~0.3.0",
@@ -26,7 +26,7 @@
     "grunt-contrib-imagemin": "~1.0.0",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-eslint": "^17.3.1",
+    "grunt-eslint": "^19.0.0",
     "grunt-postcss": "^0.8.0",
     "intern": "2.2.0",
     "load-grunt-tasks": "~0.6.0",
@@ -49,54 +49,6 @@
     "pip": "pip install -r config/requirements.txt",
     "config": "cp config/secrets.py.example config/secrets.py",
     "project-update": "pip install --upgrade pip && npm run backend-install && npm update"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true
-    },
-    "extends": "eslint:recommended",
-    "globals": {
-      "jQuery": true,
-      "$": true,
-      "_": true,
-      "Backbone": true,
-      "console": true,
-      "define": true,
-      "issueNumber": true,
-      "markdownitEmoji": true,
-      "markdownitSanitizer": true,
-      "md": true,
-      "module": true,
-      "moment": true,
-      "Mousetrap": true,
-      "PaginationMixin": true,
-      "Prism": true,
-      "qr": true,
-      "repoPath": true,
-      "require": true,
-      "wcEvents": true
-    },
-    "rules": {
-      "comma-dangle": 0,
-      "curly": [2, "all"],
-      "eqeqeq": [2, "smart"],
-      "indent": [2, 2],
-      "linebreak-style": [2, "unix"],
-      "new-cap": 2,
-      "no-cond-assign": 0,
-      "no-spaced-func": 2,
-      "no-use-before-define": 2,
-      "one-var": [2, "never"],
-      "quotes": [2, "single"],
-      "semi": [2, "always"],
-      "space-after-keywords": 2,
-      "space-before-blocks": 2,
-      "space-before-function-paren": [2, "never"],
-      "space-before-keywords": [2, "always"],
-      "space-infix-ops": 2,
-      "space-return-throw-case": 2,
-      "space-unary-ops": 2
-    }
   },
   "license": "MPL-2.0"
 }

--- a/webcompat/static/js/lib/comments.js
+++ b/webcompat/static/js/lib/comments.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 issues.CommentsCollection = Backbone.Collection.extend({
   model: issues.Comment,

--- a/webcompat/static/js/lib/diagnose.js
+++ b/webcompat/static/js/lib/diagnose.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var diagnose = diagnose || {};
-var issues = issues || {};
+var diagnose = diagnose || {}; // eslint-disable-line no-use-before-define
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 diagnose.NewCollection = Backbone.Collection.extend({
   model: issues.Issue,

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issueList = issueList || {};
+var issueList = issueList || {}; // eslint-disable-line no-use-before-define
 issueList.events = _.extend({},Backbone.Events);
 
 if (!window.md) {

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 issues.events = _.extend({},Backbone.Events);
 
 if (!window.md) {

--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 // We need a complete list of labels for certain operations,
 // especially namespace mapping. If the list we're handling

--- a/webcompat/static/js/lib/mixins/pagination.js
+++ b/webcompat/static/js/lib/mixins/pagination.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issueList = issueList || {};
+var issueList = issueList || {}; // eslint-disable-line no-use-before-define
 issueList.events = _.extend({},Backbone.Events);
 
 /*

--- a/webcompat/static/js/lib/models/comment.js
+++ b/webcompat/static/js/lib/models/comment.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 if (!window.md) {
   window.md = window.markdownit({

--- a/webcompat/static/js/lib/models/issue.js
+++ b/webcompat/static/js/lib/models/issue.js
@@ -5,8 +5,8 @@
  * Contains some code modified from https://github.com/jfromaniello/li
  * which is released under the MIT license. */
 
-var issues = issues || {};
-var issueList = issueList || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
+var issueList = issueList || {}; // eslint-disable-line no-use-before-define
 
 if (!window.md) {
   window.md = window.markdownit({

--- a/webcompat/static/js/lib/models/label-list.js
+++ b/webcompat/static/js/lib/models/label-list.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 /**
 * A LabelList is a list of labels.

--- a/webcompat/static/js/lib/models/query-params.js
+++ b/webcompat/static/js/lib/models/query-params.js
@@ -1,5 +1,5 @@
 /*globals issues*/
-var issueList = issueList || {};
+var issueList = issueList || {}; // eslint-disable-line no-use-before-define
 
 /*
 * QueryParams is a model for keeping track of all parameters

--- a/webcompat/static/js/lib/qrcode.js
+++ b/webcompat/static/js/lib/qrcode.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 issues.QrView = Backbone.View.extend({
   qrButton: null,

--- a/webcompat/static/js/lib/user-activity.js
+++ b/webcompat/static/js/lib/user-activity.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var issues = issues || {};
-var issueList = issueList || {};
+var issues = issues || {}; // eslint-disable-line no-use-before-define
+var issueList = issueList || {}; // eslint-disable-line no-use-before-define
 var loadingIndicator =  $('.js-Loader');
 issueList.user = $('body').data('username');
 


### PR DESCRIPTION
This updates eslint to the most recent 3.4.0:

* Moved the eslint config out of the `package.json` into `.eslintrc` for compatibility reasons.
* Replaced `space-after-keywords`,`space-before-blocks`, and `space-return-throw-case` with `keyword-spacing`
* Added `// eslint-disable-line no-use-before-define` to the default object assignments. eslint 3 is a bit smarter about variable hoisting and the default assignments are indeed a use before define. It's not an issue for us at the moment, but there is no way to tell eslint this is okay without the comments or completely disabling `no-use-before-define`.

r? @miketaylr