### PR TITLE
Issue #1004 - Do not cut off text on the contributors page

### DIFF
--- a/webcompat/static/css/development/components/contributors.css
+++ b/webcompat/static/css/development/components/contributors.css
@@ -124,7 +124,7 @@
   display:inline-block;
   font-size:20px;
   vertical-align:middle;
-  margin-left:2.2em;
+  padding-left:2.2em;
   line-height:normal;
 }
 .contributors__list__item--lvl_down {


### PR DESCRIPTION
The box has `box-sizing: border-box`, so better use a padding to not extend the element beyond its container...

Before:
![screen shot 2016-09-07 at 17 01 38](https://cloud.githubusercontent.com/assets/344777/18317131/6e2070c2-751d-11e6-8bd2-13473d00f086.png)

After:
![screen shot 2016-09-07 at 17 01 49](https://cloud.githubusercontent.com/assets/344777/18317121/5ef79314-751d-11e6-9086-13ef9aaed476.png)

r? @miketaylr