### PR TITLE
Small grammatical change + consistency/clarity fix

### DIFF
--- a/webcompat/templates/contributors/diagnose-bug.html
+++ b/webcompat/templates/contributors/diagnose-bug.html
@@ -1,11 +1,14 @@
 <ul class="contributors__list">
-  <li class="contributors__list__item"><span>Find a bug with a "needsdiagnosis" label or that is otherwise new</span></li>
-  <li class="contributors__list__item"><span>Check to see if bug has been reproduced already</span></li>
+  <li class="contributors__list__item"><span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis or is otherwise new</a>"</span>
+    <div class="contributors__list__screenshot">
+      <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
+    </div></li>
+  <li class="contributors__list__item"><span>Check to see if the bug has been reproduced already</span></li>
   <li class="contributors__list__item"><span>If not, try to reproduce the bug</span></li>
-  <li class="contributors__list__item"><span>If bug is NOT reproducible, write a comment on the issue</span></li>
-  <li class="contributors__list__item"><span>If bug is reproducible, try to reproduce on other browsers or OS</span></li>
+  <li class="contributors__list__item"><span>If the bug is NOT reproducible, write a comment on the issue</span></li>
+  <li class="contributors__list__item"><span>If the bug is reproducible, try to reproduce on other browsers or OS</span></li>
   <li class="contributors__list__item">
-    <span>Check the console to see if there are errors</span>
+    <span>Check the console to see if there are any errors</span>
     <div class="contributors__list__screenshot">
       <img src="../img/6consolesnapshot.png" alt="Developer Console Screenshot"/>
     </div>

--- a/webcompat/templates/contributors/diagnose-bug.html
+++ b/webcompat/templates/contributors/diagnose-bug.html
@@ -1,5 +1,5 @@
 <ul class="contributors__list">
-  <li class="contributors__list__item"><span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis or is otherwise new</a>"</span>
+  <li class="contributors__list__item"><span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a> or <a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needstriage&sort=created&direction=desc">Needs Triage"</a></span>
     <div class="contributors__list__screenshot">
       <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
     </div></li>


### PR DESCRIPTION
ln 2: changed the "Find a bug with a "needsdiagnosis" label or that is otherwise new" to be the same as the corresponding step in "How to Reproduce the Bug" to make that instruction easier to understand, and be consistent in terms of linking to the "Need Diagnosis" tag rather than sending users to a label. 

ln 6;8-9: added the between "if bug" to both be consistent with the other instructions that refer to the bug as "the bug" rather than just "bug" and for grammatical correctness. 

ln 11: It's more correct to say "if there are any errors" than "if there are errors"

[ci skip]