### PR TITLE
Fix #1196: Remove invalid "spaces" value in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
@miketaylr r?
