### PR TITLE
Fixes #1262. Display new bug report URI, rather than /issues/new.

### DIFF
--- a/webcompat/static/js/lib/flash-message.js
+++ b/webcompat/static/js/lib/flash-message.js
@@ -57,6 +57,9 @@ var FlashMessageView = Backbone.View.extend({
     this.$el.addClass('is-active wc-FlashMessage--thanks');
     this.$el.html(buildTemplate({number: opts.message}))
             .insertBefore('.wc-Issue-information').show();
+
+    // show the correct URL now, rather than /issues/new
+    history.replaceState({}, '', '/issues/' + opts.message);
   },
   hide: function() {
     this.$el.fadeOut();


### PR DESCRIPTION
Originally I wanted to solve this on the Python side... but there's an issue:

Flask's `url_for` can only pass in variables if they're defined in the route as "variables". So for the following route we have the variable `<int:number>`

```
@app.route('/issues/<int:number>')
def show_issue(number, show_thanks_flash=False):
```

if we do `return redirect(url_for('show_issue', number=123, show_thanks_flash=False)`,

we get redirected to `/issues/123?show_thanks_flash=False` (because stuff it doesn't recognize is treated as GET args).

We could work around this by defining a route like so:

`@app.route('/issues/<int:number>/<thanks>')`, but people might bookmark that.

I wonder if we could work around this with the session cookie, rather than doing it in JS? Or some other idea?

Not ready for review. Let me try the session thingy.