### PR TITLE
Fixes #1317 - install packages in virtualenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ cd webcompat.com
 # check out submodules
 npm run module
 # initializing project
-[sudo] npm run init
+[sudo] npm run setup
 ```
 
 **Note**: if you got an error message, you may need to [install pip](#installing-pip) before running `make install` again.

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "suitcss-utils-display": "^0.4.0"
   },
   "scripts": {
-    "init": "npm run module && npm run virtualenv && npm run pip && npm install && npm run config",
+    "setup": "npm run module && npm run virtualenv && npm install && npm run config",
     "watch" : "grunt watch",
     "build": "grunt",
     "module": "git submodule init && git submodule update",
     "start": "source env/bin/activate && python run.py",
-    "virtualenv" : "pip install virtualenv && virtualenv env &&  source env/bin/activate",
+    "virtualenv" : "pip install virtualenv && virtualenv env && source env/bin/activate && npm run pip",
     "pip": "pip install -r config/requirements.txt",
     "config": "cp config/secrets.py.example config/secrets.py",
     "project-update": "pip install --upgrade pip && npm run backend-install && npm update"


### PR DESCRIPTION
The issue #1317 was caused by non-installed packages in the virtualenv.
It seems it's not clearly described for a new contributor in the contribute.md and as we have the scripts anyway, it should be added to the `npm run virtualenv`. The install will be skipped when the packages are found.

@miketaylr @karlcow could you please confirm? Thanks :)