### PR TITLE
Fixes #705. Update privacy policy around report logging and deletion.

### DIFF
--- a/webcompat/templates/privacy.html
+++ b/webcompat/templates/privacy.html
@@ -4,7 +4,7 @@
   <main class="wc-UIContent" role="main">
     <section class="wc-UISection wc-UISection">
       <h1 class="wc-Title wc-Title--l">Webcompat.com Privacy Policy</h1>
-      <small>Last Updated: August 21, 2015</small>
+      <small>Last Updated: February 7, 2017</small>
       <h2 class="wc-Title wc-Title--s">About Us</h2>
       <p><a class="wc-Link" href="http://www.webcompat.com">Webcompat.com</a> allows you to report web compatibility issues though a simple webform. Volunteers view the reports, identify solutions, and share the reports and solutions with the website admins. For more details see our <a class="wc-Link" href="about">About page</a>.</p>
       <h2 class="wc-Title wc-Title--s">Public Reports</h2>
@@ -15,6 +15,8 @@
       <p>If you choose the anonymous option, the only information that we’ll receive is the content of your report.</p>
       <h2 class="wc-Title wc-Title--s">Reporting via GitHub</h2>
       <p>If you choose the GitHub option, webcompat.com will receive your GitHub username and avatar.  You can revoke our access to this information at any time from the <a class="wc-Link" href="https://github.com/settings/applications">"Applications" section of your profile page</a>.</p>
+      <h2>Website Logs</h2>
+      <p>When a bug report is filed on webcompat.com we log your IP address, the time at which the bug was filed, and the URI of the bug report. This data may be used to investigate potential security issues and spam efforts. These logs are only kept for 14 days, after which they are deleted automatically.</p>
       <h2 class="wc-Title wc-Title--s">Cookies &amp; Analytics</h2>
       <p>If you log into our site using your GitHub user account, webcompat.com will use cookies to record your session information.  The cookie will expire when the session ends, i.e., when you click "logout".</p>
       <p>Webcompat.com also uses Google Analytics to track usage statistics.</p>


### PR DESCRIPTION
Log rotation is set up on the server now (#717), so we're ready to update the privacy policy.

r? @zoepage 