### PR TITLE
Fix #609 - Implements HTTP Caching for HTML routes

### DIFF
--- a/tests/test_http_caching.py
+++ b/tests/test_http_caching.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+'''Tests for HTTP Caching on webcompat resources.'''
+
+import os.path
+import sys
+import unittest
+
+# Add webcompat module to import path
+sys.path.append(os.path.realpath(os.pardir))
+import webcompat  # nopep8
+
+# Any request that depends on parsing HTTP Headers (basically anything
+# on the index route, will need to include the following: environ_base=headers
+html_headers = {
+    'HTTP_USER_AGENT': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; '
+                        'rv:53.0) Gecko/20100101 Firefox/53.0'),
+    'HTTP_ACCEPT': 'text/html'}
+
+
+class TestHTTPCaching(unittest.TestCase):
+    def setUp(self):
+        webcompat.app.config['TESTING'] = True
+        self.app = webcompat.app.test_client()
+
+    def tearDown(self):
+        pass
+
+    def test_issue_has_etag(self):
+        '''Check ETAG for issues.'''
+        rv = self.app.get('/issues/100', environ_base=html_headers)
+        response_headers = rv.headers
+        self.assertIn('etag', response_headers)
+        self.assertIsNotNone(response_headers['etag'])
+
+    def test_cache_control(self):
+        '''Check Cache-Control for issues.'''
+        rv = self.app.get('/issues/100', environ_base=html_headers)
+        response_headers = rv.headers
+        self.assertIn('cache-control', response_headers)
+        self.assertEqual(response_headers['cache-control'],
+                         'private, max-age=86400')
+
+    def test_not_modified_status(self):
+        '''Checks if we receive a 304 Not Modified.'''
+        for uri in ['/about',
+                    '/contributors',
+                    '/issues',
+                    '/issues/100',
+                    '/privacy']:
+            rv = self.app.get(uri, environ_base=html_headers)
+            response_headers = rv.headers
+            etag = response_headers['etag']
+            rv2 = self.app.get(uri,
+                               environ_base=html_headers,
+                               headers={'If-None-Match': etag})
+            self.assertEqual(rv2.status_code, 304)
+            self.assertEqual(rv2.data, '')
+            self.assertIn('cache-control', response_headers)
+            self.assertEqual(response_headers['cache-control'],
+                             'private, max-age=86400')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webcompat/api/endpoints.py
+++ b/webcompat/api/endpoints.py
@@ -9,7 +9,6 @@
 This is used to make API calls to GitHub, either via a logged-in users
 credentials or as a proxy on behalf of anonymous or unauthenticated users.'''
 
-import json
 
 from flask import abort
 from flask import Blueprint

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -7,11 +7,11 @@
 import json
 import logging
 import os
-import urllib
 
 from flask import abort
 from flask import flash
 from flask import g
+from flask import make_response
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -21,6 +21,7 @@ from flask import url_for
 
 from form import AUTH_REPORT
 from form import PROXY_REPORT
+from helpers import cache_policy
 from helpers import get_browser_name
 from helpers import get_form
 from helpers import get_referer
@@ -143,6 +144,7 @@ def index():
 
 
 @app.route('/issues')
+@cache_policy(private=True, uri_max_age=86400)
 def show_issues():
     '''Route to display global issues view.'''
     if g.user:
@@ -152,6 +154,7 @@ def show_issues():
 
 
 @app.route('/issues/new', methods=['GET', 'POST'])
+@cache_policy(private=True, uri_max_age=86400)
 def create_issue():
     """Creates a new issue.
 
@@ -201,6 +204,7 @@ def create_issue():
 
 
 @app.route('/issues/<int:number>')
+@cache_policy(private=True, uri_max_age=86400)
 def show_issue(number):
     '''Route to display a single issue.'''
     if g.user:
@@ -208,7 +212,9 @@ def show_issue(number):
     if session.get('show_thanks'):
         flash(number, 'thanks')
         session.pop('show_thanks')
-    return render_template('issue.html', number=number)
+    content = render_template('issue.html', number=number)
+    response = make_response(content)
+    return response
 
 
 @app.route('/me')
@@ -279,6 +285,7 @@ if app.config['LOCALHOST']:
 
 
 @app.route('/about')
+@cache_policy(private=True, uri_max_age=86400)
 def about():
     '''Route to display about page.'''
     if g.user:
@@ -287,6 +294,7 @@ def about():
 
 
 @app.route('/privacy')
+@cache_policy(private=True, uri_max_age=86400)
 def privacy():
     '''Route to display privacy page.'''
     if g.user:
@@ -295,6 +303,7 @@ def privacy():
 
 
 @app.route('/contributors')
+@cache_policy(private=True, uri_max_age=86400)
 def contributors():
     '''Route to display contributors page.'''
     if g.user:


### PR DESCRIPTION
This currently doesn't fix all HTML resources served on our site, but just the issue view.
I would love to get it on staging, because of our nginx layer and see how it flies. Locally, things seem to go well.

```
→ nosetests -v

API access to comments greater than 30 returns pagination in Link ... ok
API issue for a non existent number returns JSON 404. ... ok
API issue search with bad keywords returns JSON 404. ... ok
API access to labels without auth returns JSON 200. ... ok
API with wrong parameter returns JSON 404. ... ok
API setting labels without auth returns JSON 403 error code. ... ok
API access to user activity without auth returns JSON 401. ... ok
API with wrong category returns JSON 404. ... ok
API with wrong route returns JSON 404. ... ok
test_domain_name (tests.test_form.TestForm) ... ok
Make sure wrap_metadata and get_metadata methods work. ... ok
test_normalize_url (tests.test_form.TestForm) ... ok
Test HTTP Links formating. ... ok
Test browser parsing via get_browser helper method. ... ok
Test browser name parsing via get_browser_name helper method. ... ok
Test OS parsing via get_os helper method. ... ok
Test that API params are correctly converted to Search API. ... ok
normalize_api_params shouldn't transform unknown params. ... ok
Test HTTP Links parsing for GitHub only. ... ok
test_rewrite_and_sanitize_link (tests.test_helpers.TestHelpers) ... ok
Test we're correctly rewriting the passed in link. ... ok
Test that we're removing access_token parameters. ... ok
Check Cache-Control for issues. ... ok
Check ETAG for issues. ... ok
Check if we receive a 304 Not Modified. ... ok
testBase64ScreenshotUploads (tests.test_uploads.TestUploads) ... ok
Test that /upload/ doesn't let you GET. ... ok
testRegularUploads (tests.test_uploads.TestUploads) ... ok
Test that /about exists. ... ok
Test that asks user to log in before displaying activity. ... ok
Test that the home page exists. ... ok
Test issues and integer for: ... ok
Test that the /issues/<number> exists, and does not redirect. ... ok
Test that the /issues route gets 200 and does not redirect. ... ok
Webhook related tests. ... ok
Test that the /login route 302s to GitHub. ... ok
Test that /issues/new exists. ... ok
Test that /privacy exists. ... ok
Rate Limit URI sends 200 OK and starts with Current user. ... ok
Test that the /tools/cssfixme route gets 200. ... ok
Test that the /tools/cssfixme route gets 200 with ?url query. ... ok
Test that the /tools/cssfixme route gets 200 with bad ?url query. ... ok

----------------------------------------------------------------------
Ran 42 tests in 9.196s

OK
```

And on the CLI.

First request:

```
→ http --print Hh GET http://localhost:5000/issues/100 
```

```http
GET /issues/100 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: localhost:5000
User-Agent: HTTPie/0.9.3
```

The 1st response

```http
HTTP/1.0 200 OK
Cache-Control: private, max-age=31536000
Content-Length: 9366
Content-Type: text/html; charset=utf-8
Date: Thu, 09 Feb 2017 04:46:16 GMT
ETag: "bce46f17692195b267de8026b3c5f66f"
Server: Werkzeug/0.10.4 Python/2.7.10
```

Then the second request with `If-None-Match`

```
→ http --print Hhb GET http://localhost:5000/issues/100 'If-None-Match:"bce46f17692195b267de8026b3c5f66f"'
```

```http
GET /issues/100 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: localhost:5000
If-None-Match: "bce46f17692195b267de8026b3c5f66f"
User-Agent: HTTPie/0.9.3
```

with the second response:

```http
HTTP/1.0 304 NOT MODIFIED
Cache-Control: private, max-age=31536000
Connection: close
Date: Thu, 09 Feb 2017 04:46:56 GMT
ETag: "bce46f17692195b267de8026b3c5f66f"
Server: Werkzeug/0.10.4 Python/2.7.10



```