### PR TITLE
Fixes #1329, #1328. Add a CSP reporting endpoint and move security headers into app.

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -30,6 +30,9 @@ if not PRODUCTION:
 if not LOCALHOST:
     SESSION_COOKIE_SECURE = True
 
+# By default, we want to log CSP violations. See /csp-report in views.py.
+CSP_LOG = True
+
 # Logging Capabilities
 # To benefit from the logging, you may want to add:
 #   app.logger.info(Thing_To_Log)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -38,6 +38,7 @@ if not LOCALHOST:
 
 LOG_FILE = '/tmp/webcompat.log'
 LOG_FMT = '%(asctime)s tracking %(message)s'
+CSP_REPORTS_LOG = '/tmp/webcompat-csp-reports.log'
 
 # Status categories used in the project
 # 'new', 'needsdiagnosis', 'needscontact', 'contactready' , 'sitewait', 'close'

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -93,6 +93,19 @@ class TestURLs(unittest.TestCase):
         # A random post should 401, only requests from GitHub will 200
         self.assertEqual(rv.status_code, 401)
 
+    def test_csp_report_uri(self):
+        '''Test POST to /csp-report w/ correct content-type returns 204.'''
+        headers = {'Content-Type': 'application/csp-report'}
+        rv = self.app.post('/csp-report', headers=headers)
+        self.assertEqual(rv.status_code, 204)
+
+    def test_csp_report_uri_bad_content_type(self):
+        '''Test POST w/ wrong content-type to /csp-report returns 400.'''
+        headers = {'Content-Type': 'application/json'}
+        rv = self.app.post('/csp-report', headers=headers)
+        self.assertNotEqual(rv.status_code, 204)
+        self.assertEqual(rv.status_code, 400)
+
     def test_tools_cssfixme(self):
         '''Test that the /tools/cssfixme route gets 200.'''
         rv = self.app.get('/tools/cssfixme')

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -487,3 +487,15 @@ def cache_policy(private=True, uri_max_age=86400):
             return response
         return update_wrapper(policy, view)
     return set_policy
+
+
+def add_sec_headers(response):
+    '''Add security-related headers to the response.
+
+    This should be used in @app.after_request to ensure the headers are
+    added to all responses.'''
+    if not app.config['LOCALHOST']:
+        response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'  # nopep8
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+    response.headers['X-Frame-Options'] = 'DENY'

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -499,3 +499,22 @@ def add_sec_headers(response):
     response.headers['X-Content-Type-Options'] = 'nosniff'
     response.headers['X-XSS-Protection'] = '1; mode=block'
     response.headers['X-Frame-Options'] = 'DENY'
+
+
+def add_csp(response):
+    '''Add a Content-Security-Policy header to response.
+
+    This should be used in @app.after_request to ensure the header is
+    added to all responses.'''
+    # short term, we send Content-Security-Policy-Report-Only
+    # see https://github.com/webcompat/webcompat.com/issues/763 for
+    # sending Content-Security-Policy
+    response.headers['Content-Security-Policy-Report-Only'] = (
+        "default-src 'none'; " +
+        "connect-src 'self'; " +
+        "font-src 'self'; " +
+        "img-src 'self'; " +
+        "script-src 'self' https://www.google-analytics.com; " +
+        "style-src 'self'; " +
+        "report-uri /csp-report"
+    )

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -315,3 +315,13 @@ def contributors():
 def cssfixme():
     '''Route for CSS Fix me tool'''
     return render_template('cssfixme.html')
+
+
+@app.route('/csp-report', methods=['POST'])
+def log_csp_report():
+    '''Route to record CSP header violations.'''
+    if 'application/csp-report' not in request.headers.get('content-type', ''):
+        return ('Wrong Content-Type.', 400)
+    with open(app.config['CSP_REPORTS_LOG'], 'a') as r:
+        r.write(request.data + '\n')
+    return ('', 204)

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -21,6 +21,7 @@ from flask import url_for
 
 from form import AUTH_REPORT
 from form import PROXY_REPORT
+from helpers import add_csp
 from helpers import add_sec_headers
 from helpers import cache_policy
 from helpers import get_browser_name
@@ -54,6 +55,7 @@ def before_request():
 def after_request(response):
     session_db.remove()
     add_sec_headers(response)
+    add_csp(response)
     return response
 
 

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -21,6 +21,7 @@ from flask import url_for
 
 from form import AUTH_REPORT
 from form import PROXY_REPORT
+from helpers import add_sec_headers
 from helpers import cache_policy
 from helpers import get_browser_name
 from helpers import get_form
@@ -52,6 +53,7 @@ def before_request():
 @app.after_request
 def after_request(response):
     session_db.remove()
+    add_sec_headers(response)
     return response
 
 

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -323,9 +323,18 @@ def cssfixme():
 
 @app.route('/csp-report', methods=['POST'])
 def log_csp_report():
-    '''Route to record CSP header violations.'''
-    if 'application/csp-report' not in request.headers.get('content-type', ''):
-        return ('Wrong Content-Type.', 400)
-    with open(app.config['CSP_REPORTS_LOG'], 'a') as r:
-        r.write(request.data + '\n')
-    return ('', 204)
+    '''Route to record CSP header violations.
+
+    This route can be enabled/disabled by setting CSP_LOG to True/False
+    in config/__init__.py. It's enabled by default.
+    '''
+    expected_mime = 'application/csp-report'
+
+    if app.config['CSP_LOG']:
+        if expected_mime not in request.headers.get('content-type', ''):
+            return ('Wrong Content-Type.', 400)
+        with open(app.config['CSP_REPORTS_LOG'], 'a') as r:
+            r.write(request.data + '\n')
+        return ('', 204)
+    else:
+        return ('Forbidden.', 403)


### PR DESCRIPTION
This will report CSP violations to `/tmp/webcompat-csp-reports.log` (and DevTools also will dump them for the page you're on). Let's let this run wild for a week or so then figure out what needs to change. 

(I already noticed the following, which points to lodash):
```
[Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' https://www.google-analytics.com".
```

r? @karlcow 