### PR TITLE
Fixes #1372 - change twitter link in footer

### DIFF
--- a/webcompat/templates/shared/footer.html
+++ b/webcompat/templates/shared/footer.html
@@ -25,7 +25,7 @@
       </ul>
       <ul class="wc-Footer-list r-ResetList">
         <li class="wc-Footer-item wc-Footer-item--follow">
-          <a class="wc-Footer-link" href="https://twitter.com/intent/user?screen_name=webcompat" target="_blank">
+          <a class="wc-Footer-link" href="https://twitter.com/webcompat" target="_blank">
             <span class="wc-Footer-link-label">Follow @WebCompat</span>
           </a>
         </li>


### PR DESCRIPTION
#1372 

> As @lockettm mentioned today, the twitter link on webcompat.com directs to https://twitter.com/intent/user?screen_name=webcompat, which is a good idea in general, but the tweets shown below are suggesting not much interaction on the site and a long response time. She suggested to change the link to https://twitter.com/webcompat/