### PR TITLE
Fixes #1240 #1259 - Put label editor on right side of issues page

### DIFF
--- a/webcompat/static/css/development/components/issue.css
+++ b/webcompat/static/css/development/components/issue.css
@@ -4,7 +4,7 @@
   --Issue-fontSize: var(--base-fontSize);
   --Issue-detailLink: var(--Link-color);
   --Issue-detailLinkHover: var(--Link-colorHover);
-  --Issue-widthComment: 45.125em;
+  --Issue-widthComment: 68%;
 }
 
 .wc-Issue {
@@ -101,7 +101,7 @@
     .wc-Issue-report,
     .wc-Issue-commentList,
     .wc-Issue-commentSubmit,
-    .wc-Issue-information {
+    .wc-Issue-information:not(.wc-Issue-information--fullWidth){
       width: var(--Issue-widthComment);
     }
   }
@@ -138,10 +138,6 @@
     margin-top: 2em;
   }
 
-.wc-Issue-labels {
-  margin-bottom: 2em;
-}
-
 /* FullScreen LabelEditor*/
 @media all and (max-width: 23.43em) {
   .wc-Issue-labels {
@@ -163,11 +159,28 @@
 /* labeleditor wrapper */
 .wc-Issue-labelEditor {
   position: relative;
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 .625em 0;
 }
 
 @media all and (max-width: 23.43em) {
   .wc-Issue-labelEditor {
     position: static; /* position of label_editor not depend of this class */
+  }
+}
+
+@media all and (min-width: 48.13em) {
+  .wc-Issue-aside {
+    float: right;
+    width: 30%;
+  }
+}
+
+@media all and (min-height: 40em), all and (min-width: 48.13em) {
+  .wc-Issue-aside {
+    position: sticky;
+    top: 1em;
   }
 }

--- a/webcompat/static/css/development/components/issue.css
+++ b/webcompat/static/css/development/components/issue.css
@@ -8,7 +8,7 @@
 }
 
 .wc-Issue {
-  font-size:var(--Issue-fontSize);
+  font-size: var(--Issue-fontSize);
 }
 
     /* header */
@@ -20,35 +20,35 @@
     }
 
     .wc-Issue-information-header--needstriage {
-      background-color:var(--base-stateNeedsTriage);
+      background-color: var(--base-stateNeedsTriage);
     }
 
     .wc-Issue-information-header--needsDiagnosis {
-      background-color:var(--base-stateNeedsDiagnosis);
+      background-color: var(--base-stateNeedsDiagnosis);
     }
 
     .wc-Issue-information-header--needsContact {
-      background-color:var(--base-stateNeedsContact);
+      background-color: var(--base-stateNeedsContact);
     }
 
     .wc-Issue-information-header--closed {
-      background-color:var(--base-stateClosed);
+      background-color: var(--base-stateClosed);
     }
 
     .wc-Issue-information-header--ready {
-      background-color:var(--base-stateReady);
+      background-color: var(--base-stateReady);
     }
 
     .wc-Issue-information-header--sitewait {
-      background-color:var(--base-stateSitewait);
+      background-color: var(--base-stateSitewait);
     }
 
     .wc-Issue-information-header--fixed {
-      background-color:var(--base-stateFixed);
+      background-color: var(--base-stateFixed);
     }
 
     .wc-Issue-information-header--worksforme {
-      background-color:var(--base-stateWorksForMe);
+      background-color: var(--base-stateWorksForMe);
     }
 
     /* content */
@@ -70,7 +70,6 @@
   }
 
   @media all and (max-width: 28.12em) {
-
     .wc-Issue-title {
       font-size: 1.2em;
     }
@@ -88,7 +87,6 @@
   }
 
   @media all and (max-width: 28.12em) {
-
     .wc-Issue-date {
       font-size: .9em;
     }
@@ -100,7 +98,6 @@
   }
 
   @media all and (min-width: 48.13em) {
-
     .wc-Issue-report,
     .wc-Issue-commentList,
     .wc-Issue-commentSubmit,
@@ -126,7 +123,6 @@
   }
 
     @media all and (max-width: 73.75em) {
-
       .wc-Issue-wrapper {
         margin: 0;
       }
@@ -139,16 +135,16 @@
   }
 
   .wc-Issue-comment {
-    margin-top:2em;
+    margin-top: 2em;
   }
 
 .wc-Issue-labels {
   margin-bottom: 2em;
 }
+
 /* FullScreen LabelEditor*/
 @media all and (max-width: 23.43em) {
-
-  .wc-Issue-lbels {
+  .wc-Issue-labels {
     position: relative;
   }
 }
@@ -164,14 +160,13 @@
   margin:4em 0 0;
 }
 
-/* labeleditor */
+/* labeleditor wrapper */
 .wc-Issue-labelEditor {
   position: relative;
   display: inline-block;
 }
 
 @media all and (max-width: 23.43em) {
-
   .wc-Issue-labelEditor {
     position: static; /* position of label_editor not depend of this class */
   }

--- a/webcompat/static/css/development/components/issue.css
+++ b/webcompat/static/css/development/components/issue.css
@@ -138,6 +138,11 @@
     margin-top: 2em;
   }
 
+.wc-Issue-labels {
+  background-color: #fff;
+  margin: 2px 0;
+  padding: 1em;
+}
 /* FullScreen LabelEditor*/
 @media all and (max-width: 23.43em) {
   .wc-Issue-labels {

--- a/webcompat/static/css/development/components/label.css
+++ b/webcompat/static/css/development/components/label.css
@@ -1,19 +1,31 @@
 /** @define Label */
 
 :root {
-  --Label-fontSize: .7rem;
+  --Label-fontSize: .75rem;
 }
 
 .wc-Label {
   font-size:var(--Label-fontSize);
-  display: inline-block;
   vertical-align:middle;
-  line-height:1;
   color: #fff;
   border-radius: 4px;
-  padding: 0.4em;
   font-weight: bold;
 }
+
+  @media all and (min-width: 48.13em) {
+    .wc-Label {
+      display: block;
+      padding: .375rem .625rem;
+    }
+  }
+
+  @media all and (max-width: 48.12em) {
+    .wc-Label {
+      display: inline-block;
+      line-height:1;
+      padding: 0.4em;
+    }
+  }
 
   /* Labels */
   .wc-Label--large {
@@ -24,10 +36,17 @@
     margin-right: 0.1em;
   }
 
-  .wc-Label--badge {
-    margin-left: 1em;
+  @media all and (max-width: 48.12em) {
+    .wc-Label--badge {
+      margin-left: 1em;
+    }
+    .wc-Label--badge + .wc-Label--badge {
+      margin-left: .7em;
+    }
   }
 
-  .wc-Label--badge + .wc-Label--badge {
-    margin-left: .7em;
+  @media all and (min-width: 48.13em) {
+    .wc-Label--badge + .wc-Label--badge {
+      margin-top: .625em;
+    }
   }

--- a/webcompat/static/css/development/components/label.css
+++ b/webcompat/static/css/development/components/label.css
@@ -5,8 +5,8 @@
 }
 
 .wc-Label {
-  font-size:var(--Label-fontSize);
-  vertical-align:middle;
+  font-size: var(--Label-fontSize);
+  vertical-align: middle;
   color: #fff;
   border-radius: 4px;
   font-weight: bold;
@@ -22,7 +22,7 @@
   @media all and (max-width: 48.12em) {
     .wc-Label {
       display: inline-block;
-      line-height:1;
+      line-height: 1;
       padding: 0.4em;
     }
   }
@@ -33,7 +33,7 @@
     color: #000;
     padding-right: 0;
     padding-left: 0;
-    margin-right: 0.1em;
+    margin-right: .1em;
   }
 
   @media all and (max-width: 48.12em) {

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -86,7 +86,7 @@ md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
 };
 
 issues.MetaDataView = Backbone.View.extend({
-  el: $(".wc-Issue-information"),
+  el: $("#js-Issue-information"),
   initialize: function() {
     this.model.on("change:issueState", _.bind(function() {
       this.render();

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -99,6 +99,20 @@ issues.MetaDataView = Backbone.View.extend({
   }
 });
 
+issues.AsideView = Backbone.View.extend({
+  el: $("#js-Issue-aside"),
+  initialize: function() {
+    this.model.on("change:issueState", _.bind(function() {
+      this.render();
+    }, this));
+  },
+  template: _.template($("#aside-tmpl").html()),
+  render: function() {
+    this.$el.html(this.template(this.model.toJSON()));
+    return this;
+  }
+});
+
 issues.BodyView = Backbone.View.extend({
   el: $(".wc-Issue-report"),
   mainView: null,
@@ -374,6 +388,7 @@ issues.MainView = Backbone.View.extend({
     var issueModel = {model: this.issue};
     this.metadata = new issues.MetaDataView(issueModel);
     this.body = new issues.BodyView(_.extend(issueModel, {mainView: this}));
+    this.aside = new issues.AsideView(issueModel);
     this.labels = new issues.LabelsView(issueModel);
     this.textArea = new issues.TextAreaView();
     this.imageUpload = new issues.ImageUploadView();

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -5,6 +5,7 @@
   <main class="wc-UISection wc-UISection--backgroundColor" role="main">
     <div class="wc-Issue">
       <section class="wc-UIContent js-Issue is-hidden">
+        {% include "issue/issue-aside.html" %}
         {% include "issue/issue-information.html" %}
         <div class="wc-Issue-commentList js-Issue-commentList">
           {% include "issue/issue-comment-list.html" %}

--- a/webcompat/templates/issue/issue-aside.html
+++ b/webcompat/templates/issue/issue-aside.html
@@ -1,0 +1,28 @@
+<aside class="wc-Issue-aside">
+  <div class="wc-Issue-information wc-Issue-information--fullWidth">
+    <header class="wc-Issue-information-header wc-Issue-information-header--needstriage">
+      <div>Needs Triage</div>
+      <div>#398</div>
+    </header>
+    <div class="wc-Issue-information-content">
+      <h1 class="wc-Issue-title js-Issue-title">
+         youtube.com - desktop site instead of mobile site
+      </h1>
+    </div>
+    <div class="wc-Issue-information-content">
+      <div>Opened: 2016-05-26</div>
+      <div>
+        Repoter:
+        <span class="wc-Issue-reporter">
+          <a class="wc-Link" href="https://github.com/">webcompat</a>
+        </span>
+      </div>
+      <div>Comments: 11</div>
+    </div>
+    <div class="wc-Issue-information-content">
+      <div class="wc-Issue-labels js-Issue-labels">
+        {% include "issue/issue-labels.html" %}
+      </div>
+    </div>
+  </div>
+</aside>

--- a/webcompat/templates/issue/issue-aside.html
+++ b/webcompat/templates/issue/issue-aside.html
@@ -14,7 +14,7 @@
         <div>Opened: <%= createdAt %></div>
         <div>
           Repoter:
-          <span class="wc-Issue-reporter">
+          <span class="wc-Issue-reporter js-Issue-reporter">
             <a class="wc-Link" href="https://github.com/<%= reporter %>"><%= reporter %></a>
           </span>
         </div>

--- a/webcompat/templates/issue/issue-aside.html
+++ b/webcompat/templates/issue/issue-aside.html
@@ -22,9 +22,7 @@
       </div>
     </script>
   </div>
-  <div class="wc-Issue-information-content">
-    <div class="wc-Issue-labels js-Issue-labels">
-      {% include "issue/issue-labels.html" %}
-    </div>
+  <div class="wc-Issue-labels js-Issue-labels">
+    {% include "issue/issue-labels.html" %}
   </div>
 </aside>

--- a/webcompat/templates/issue/issue-aside.html
+++ b/webcompat/templates/issue/issue-aside.html
@@ -1,28 +1,30 @@
 <aside class="wc-Issue-aside">
-  <div class="wc-Issue-information wc-Issue-information--fullWidth">
-    <header class="wc-Issue-information-header wc-Issue-information-header--needstriage">
-      <div>Needs Triage</div>
-      <div>#398</div>
-    </header>
-    <div class="wc-Issue-information-content">
-      <h1 class="wc-Issue-title js-Issue-title">
-         youtube.com - desktop site instead of mobile site
-      </h1>
-    </div>
-    <div class="wc-Issue-information-content">
-      <div>Opened: 2016-05-26</div>
-      <div>
-        Repoter:
-        <span class="wc-Issue-reporter">
-          <a class="wc-Link" href="https://github.com/">webcompat</a>
-        </span>
+  <div class="wc-Issue-information wc-Issue-information--fullWidth" id="js-Issue-aside">
+    <script type="text/template" id="aside-tmpl">
+      <header class="wc-Issue-information-header wc-Issue-information-header--<%= stateClass %>">
+        <div><%= issueState %></div>
+        <div>#<%= number %></div>
+      </header>
+      <div class="wc-Issue-information-content">
+        <h1 class="wc-Issue-title js-Issue-title">
+          <%= title %>
+        </h1>
       </div>
-      <div>Comments: 11</div>
-    </div>
-    <div class="wc-Issue-information-content">
-      <div class="wc-Issue-labels js-Issue-labels">
-        {% include "issue/issue-labels.html" %}
+      <div class="wc-Issue-information-content">
+        <div>Opened: <%= createdAt %></div>
+        <div>
+          Repoter:
+          <span class="wc-Issue-reporter">
+            <a class="wc-Link" href="https://github.com/<%= reporter %>"><%= reporter %></a>
+          </span>
+        </div>
+        <div>Comments: <%= commentNumber %></div>
       </div>
+    </script>
+  </div>
+  <div class="wc-Issue-information-content">
+    <div class="wc-Issue-labels js-Issue-labels">
+      {% include "issue/issue-labels.html" %}
     </div>
   </div>
 </aside>

--- a/webcompat/templates/issue/issue-comment-list.html
+++ b/webcompat/templates/issue/issue-comment-list.html
@@ -1,5 +1,5 @@
 <script type="text/template" id="comment-tmpl">
-  <div class="wc-Comment-body wc-Comment-body--caret">
+  <div class="wc-Comment-body">
     <div class="wc-Comment-wrapper">
       <div class="wc-Comment-header">
         <div class="wc-Comment-owner">

--- a/webcompat/templates/issue/issue-information.html
+++ b/webcompat/templates/issue/issue-information.html
@@ -1,26 +1,9 @@
-<div class="wc-Issue-information">
+<div class="wc-Issue-information" id="js-Issue-information">
   <script type="text/template" id="metadata-tmpl">
-    <header class="wc-Issue-information-header wc-Issue-information-header--<%= stateClass %>">
-      <div><%= issueState %></div>
-      <div>#<%= number %></div>
-    </header>
-    <div class="wc-Issue-information-content">
-      <h1 class="wc-Issue-title js-Issue-title">
-        <%= title %>
-      </h1>
-      <div class="wc-Issue-date">Opened <%= createdAt %> by
-        <span class="wc-Issue-reporter js-Issue-reporter">
-          <a class="wc-Link" href="https://github.com/<%= reporter %>"><%= reporter %></a>
-        </span>. <%= commentNumber %> comments
-      </div>
-    </div>
     <div class="wc-Issue-information-content">
       <div class="js-Issue-markdown wc-Markdown">
         <%= body %>
       </div>
     </div>
   </script>
-</div>
-<div class="wc-Issue-labels js-Issue-labels">
-  {% include "issue/issue-labels.html" %}
 </div>

--- a/webcompat/templates/issue/issue-labels.html
+++ b/webcompat/templates/issue/issue-labels.html
@@ -1,12 +1,16 @@
 <script type="text/template" id="issue-labels-tmpl">
-  <span class="wc-Label wc-Label--large">Labels</span>
-  {% if session.user_id and session.avatar_url %}
-  <span class="wc-Issue-labelEditor js-Issue-labelEditor">
-    <button class="wc-LabelEditorLauncher r-ResetButton wc-Icon wc-Icon--gear js-LabelEditorLauncher" aria-hidden="true">
-      <span class="wc-Accessibility">Edit Labels</span></button>
-  </span>
-  {% endif %}
-   <span class="js-Label-list">
+  <header class="wc-Issue-labelEditor">
+    <div class="wc-Issue-labelEditor-title">
+      Labels
+    </div>
+    {% if session.user_id and session.avatar_url %}
+    <span class="wc-Issue-labelEditor-button js-Issue-labelEditor">
+      <button class="wc-LabelEditorLauncher r-ResetButton wc-Icon wc-Icon--gear js-LabelEditorLauncher" aria-hidden="true">
+        <span class="wc-Accessibility">Edit Labels</span></button>
+    </span>
+    {% endif %}
+  </header>
+   <div class="js-Label-list">
   <% _.each(labels, function(label) { %>
     <span class="wc-Label wc-Label--badge js-Label" style="background-color:#<%=label.color%>">
       <%= label.name %>


### PR DESCRIPTION
OK, let's try this to fixes #1240 and #1259 

![screen recording 2017-03-04 at 12 01 am](https://cloud.githubusercontent.com/assets/1997108/23572256/148af578-006e-11e7-9c4c-432b3e9fb16a.gif)

First step: I put the label editor and some informations on the right side.
For DOM reason and JS, the label editor is under the title on small screen. We need to think about this label Editor on small screen after this PR or maybe during this PR.

We ( @miketaylr ) need to add some JS about this new aside.

But at first, tell me what do you think about this ?

@karlcow @adamopenweb @zoepage @miketaylr @denschub 