### PR TITLE
Test for #980 [not ready to merge]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ cache:
 git:
   depth: 5
 
-addons:
-  firefox: "50.1.0"
-
 env:
   global:
     - ISSUES_REPO_URI=webcompat/webcompat-tests/issues
@@ -28,6 +25,20 @@ env:
     - FAKE_SECRET=688c4546f09624f8c44773b22268064dfca19a59
     # grab latest 4.x release, which is LTS for now
     - TRAVIS_NODE_VERSION="4"
+    - username:
+      secure: "wdMST3NlymxcrnDJlH3PAv5q4Tm8jCyJxQhQs9wJ/dOc36uubJeiCISWahNHEOCLVySrII9M+yZSJETFhvk/nSf7VePqejyLjNkmfDE6Qob92RmMNPGdId4Ktq1EMNi6fELxRDKXiAHPe4X5GReCUm/uzrIs0VcdQ9IK1uZpxMfcmw12UZiMPxpomBjWkbGyZy9BlS49ezcaTuMdpHhCxfpiclxPpJIxsR/VkpAIUsrd/CHj7nybEaf2RjmyKcNA/1xjde6TmyYqooHOmOXAR2s2PHm+8HqD8VuDl5ZNaoDNB27yIUUkNVjFvHVvEP8qXRRNoBS02RQYK6ms1u8dApT6ac7mN7xJTG5rfQPjf41ZMBUsePqwul3X1ADso9YvlaEe39dgET1xFLwIbXBLR78tCcMRgAieNSsf7Cd0/PX8me/iamKsR499SmE96sHSWAO89dHzqeeXbdZnSy4su4p6r1+199NWir1totEJY9ym0x/7x7g9y0eMytvDRTOtopwFJGtFhOJkFB2ssEUd4cD1At2POUegWlV9oXwJgqCFKdXqRNVaPJT0RooR9f3lgVPceX/yXd9Tgo7N4qihZADr3ynwOAvhiJVqZyapT1GUjPYNB1nldbET35BUsdZyjfO1DVBc28RZCN9Uxfa4DN4h9xTwYOe5U7C0m+jLGao="
+    - access_key:
+      secure: "JgymAwFINs9GbCRhOQPmwPj05RsPioLX55cEqHWDQMSAeLe1md5sMP8LIMA7QKT8TIJbxvy6/sR6n7yXnbGL+R09OOY99nl0e3Mf/0gmR2k3GROn5+q3NvXDYeNy9M9Rt9C7eQ6qX2SY9s8HohppIJtna69wsrUu2oAaPUg0CjkrDNucEDS9S6SDlpfY4oDxisLvx2i6tlntsPmkL+/FaxMs/jCjTZ0AVPwcCnL/N+ls+jLC3zHlhPyrwtQCoyMkbdIOM9WA3Vs0el1GjDTThsdhCcgC7SciXHaizOt7z/MCufbmYOVEtxeCHn2s3xCSpb4uVOMqzsmtQDGE7M7J7aLQ7gJRax9VAs0oq3dCKaOJiazURZa7G6qrJG9s7teOjUj6h11ymIeQWJCGXoaAR/yxXfPns/DCzT3yBUr5kkqxPBI4ZBiEIfD7hjv9uQQ0/za76NTvAFP22VWWeHuOub20tYeNb/zpPDVkGqiyMraPwUXub3akezIMZkxg9YiKytLBVEcx28xur0l1xli+Jq3Gj1wXbtCwo5d6F4tciSDVowXEQZVbkBl481KyC7JzWrpW7gKvGSOhr5lXPOtfDxgmgjMVF+mhOoBNYNOJ8FzTRacfSsdR9Y1DfGujS3JeP7L7RPR5eYvsCha3QpaTyOnmXuVVARGIOBrrnDIq6iE="
+
+addons:
+  firefox: "50.1.0"
+  browserstack:
+    username: username
+    access_key: access_key
+    forcelocal: true
+    #only: localhost,5000,0
+    proxyHost: "http://localhost"
+    proxyPort: "5000"
 
 before_install:
   - "export DISPLAY=:99.0"
@@ -58,5 +69,5 @@ before_script:
 # just run the non-auth tests. otherwise, run everything.
 script:
   - nosetests
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then node_modules/.bin/intern-runner config=tests/intern reporters=Console functionalSuites=tests/functional-nonauth ; fi
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then node_modules/.bin/intern-runner config=tests/browserstack_remote BROWSERSTACK_USERNAME="$BROWSERSTACK_USERNAME" BROWSERSTACK_ACCESS_KEY="$BROWSERSTACK_ACCESS_KEY" reporters=Console functionalSuites=tests/functional-nonauth ; fi
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ; then node_modules/.bin/intern-runner config=tests/intern reporters=Console user="$USER" pw="$PW" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
 git:
   depth: 5
 
+addons:
+  firefox: "50.1.0"
+
 env:
   global:
     - ISSUES_REPO_URI=webcompat/webcompat-tests/issues
@@ -25,20 +28,6 @@ env:
     - FAKE_SECRET=688c4546f09624f8c44773b22268064dfca19a59
     # grab latest 4.x release, which is LTS for now
     - TRAVIS_NODE_VERSION="4"
-    - username:
-      secure: "wdMST3NlymxcrnDJlH3PAv5q4Tm8jCyJxQhQs9wJ/dOc36uubJeiCISWahNHEOCLVySrII9M+yZSJETFhvk/nSf7VePqejyLjNkmfDE6Qob92RmMNPGdId4Ktq1EMNi6fELxRDKXiAHPe4X5GReCUm/uzrIs0VcdQ9IK1uZpxMfcmw12UZiMPxpomBjWkbGyZy9BlS49ezcaTuMdpHhCxfpiclxPpJIxsR/VkpAIUsrd/CHj7nybEaf2RjmyKcNA/1xjde6TmyYqooHOmOXAR2s2PHm+8HqD8VuDl5ZNaoDNB27yIUUkNVjFvHVvEP8qXRRNoBS02RQYK6ms1u8dApT6ac7mN7xJTG5rfQPjf41ZMBUsePqwul3X1ADso9YvlaEe39dgET1xFLwIbXBLR78tCcMRgAieNSsf7Cd0/PX8me/iamKsR499SmE96sHSWAO89dHzqeeXbdZnSy4su4p6r1+199NWir1totEJY9ym0x/7x7g9y0eMytvDRTOtopwFJGtFhOJkFB2ssEUd4cD1At2POUegWlV9oXwJgqCFKdXqRNVaPJT0RooR9f3lgVPceX/yXd9Tgo7N4qihZADr3ynwOAvhiJVqZyapT1GUjPYNB1nldbET35BUsdZyjfO1DVBc28RZCN9Uxfa4DN4h9xTwYOe5U7C0m+jLGao="
-    - access_key:
-      secure: "JgymAwFINs9GbCRhOQPmwPj05RsPioLX55cEqHWDQMSAeLe1md5sMP8LIMA7QKT8TIJbxvy6/sR6n7yXnbGL+R09OOY99nl0e3Mf/0gmR2k3GROn5+q3NvXDYeNy9M9Rt9C7eQ6qX2SY9s8HohppIJtna69wsrUu2oAaPUg0CjkrDNucEDS9S6SDlpfY4oDxisLvx2i6tlntsPmkL+/FaxMs/jCjTZ0AVPwcCnL/N+ls+jLC3zHlhPyrwtQCoyMkbdIOM9WA3Vs0el1GjDTThsdhCcgC7SciXHaizOt7z/MCufbmYOVEtxeCHn2s3xCSpb4uVOMqzsmtQDGE7M7J7aLQ7gJRax9VAs0oq3dCKaOJiazURZa7G6qrJG9s7teOjUj6h11ymIeQWJCGXoaAR/yxXfPns/DCzT3yBUr5kkqxPBI4ZBiEIfD7hjv9uQQ0/za76NTvAFP22VWWeHuOub20tYeNb/zpPDVkGqiyMraPwUXub3akezIMZkxg9YiKytLBVEcx28xur0l1xli+Jq3Gj1wXbtCwo5d6F4tciSDVowXEQZVbkBl481KyC7JzWrpW7gKvGSOhr5lXPOtfDxgmgjMVF+mhOoBNYNOJ8FzTRacfSsdR9Y1DfGujS3JeP7L7RPR5eYvsCha3QpaTyOnmXuVVARGIOBrrnDIq6iE="
-
-addons:
-  firefox: "50.1.0"
-  browserstack:
-    username: username
-    access_key: access_key
-    forcelocal: true
-    #only: localhost,5000,0
-    proxyHost: "http://localhost"
-    proxyPort: "5000"
 
 before_install:
   - "export DISPLAY=:99.0"
@@ -69,5 +58,5 @@ before_script:
 # just run the non-auth tests. otherwise, run everything.
 script:
   - nosetests
-  - if [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then node_modules/.bin/intern-runner config=tests/browserstack_remote BROWSERSTACK_USERNAME="$BROWSERSTACK_USERNAME" BROWSERSTACK_ACCESS_KEY="$BROWSERSTACK_ACCESS_KEY" reporters=Console functionalSuites=tests/functional-nonauth ; fi
+  - if [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then node_modules/.bin/intern-runner config=tests/intern reporters=Console functionalSuites=tests/functional-nonauth ; fi
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ; then node_modules/.bin/intern-runner config=tests/intern reporters=Console user="$USER" pw="$PW" ; fi

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">= 4.x"
   },
   "devDependencies": {
+    "browserstack-local": "^1.3.0",
     "cssrecipes-custom-media-queries": "0.3.0",
     "cssrecipes-defaults": "^0.5.0",
     "cssrecipes-grid": "^1.0.0",
@@ -46,7 +47,7 @@
     "build": "grunt",
     "lint": "eslint ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
     "fix": "eslint --fix ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
-    "imagemin":"grunt imagemin",
+    "imagemin": "grunt imagemin",
     "module": "git submodule init && git submodule update",
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
     "virtualenv": "pip install virtualenv && virtualenv env && source env/bin/activate || . env/bin/activate && npm run pip",

--- a/tests/browserstack.js
+++ b/tests/browserstack.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
+// These default settings work OK for most people. The options that *must* be changed below are the
+// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
+define([
+  'intern',
+], function(intern, topic) {
+  'use strict';
+
+  var args = intern.args;
+  var siteRoot = args.siteRoot ? args.siteRoot : 'http://localhost:5000';
+
+  if (topic) {
+    topic.subscribe('/suite/start', function(suite) {
+      console.log('Running: ' + suite.name);
+    });
+  }
+
+  return {
+    // Configuration object for webcompat
+    wc: {
+      pageLoadTimeout: args.wcPageLoadTimeout ? parseInt(args.wcPageLoadTimeout, 10) : 10000,
+      // user and pw need to be passed in as command-line arguments. See CONTRIBUTING.md
+      user: args.user || 'some username',
+      pw: args.pw || 'some password',
+    },
+
+    // The port on which the instrumenting proxy will listen
+    proxyPort: 9000,
+
+    // A fully qualified URL to the Intern proxy
+    //proxyUrl: 'http://127.0.0.1:9090/',
+    siteRoot: siteRoot,
+
+////// Section to run tests on browserstack via travis ci
+    // fix for BrowserStack exceptions (geolocation and webStorage)
+    // fixSessionCapabilities: false,
+
+    capabilities: {
+      //"browserstack.local": false for running tests on travis
+      "browserstack.local": true, 
+      fixSessionCapabilities: false
+    },
+
+    // // Required for BrowserStack, Maximum number of simultaneous integration tests allowed
+    // maxConcurrency: 2,
+
+    // // currently BrowserStack not supporting firefox 47
+    environments: [
+      { browser: 'firefox', browser_version: '51', os : 'OS X', os_version : 'Sierra' },
+      { browser: 'chrome', browser_version: '56', os : 'OS X', os_version : 'Sierra' }
+    ],
+
+    tunnel: 'BrowserStackTunnel',
+    tunnelOptions: {
+      verbose: true,
+      username: args.BROWSERSTACK_USER,
+      accessKey: args.BROWSERSTACK_KEY
+    },
+////// end browserstack test configs
+
+    filterErrorStack: true,
+    reporters: ['Pretty'],
+
+    // Unless you pass in a command-line arg saying otherwise, we run all tests by default.
+    functionalSuites: [ 'tests/functional-all' ],
+    excludeInstrumentation: true
+  };
+
+});

--- a/tests/browserstack.js
+++ b/tests/browserstack.js
@@ -6,15 +6,16 @@
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
 define([
-  'intern',
+  "intern",
 ], function(intern, topic) {
-  'use strict';
+  "use strict";
 
   var args = intern.args;
-  var siteRoot = args.siteRoot ? args.siteRoot : 'http://localhost:5000';
+  var siteRoot = args.siteRoot ? args.siteRoot : "http://localhost:5000";
 
   if (topic) {
-    topic.subscribe('/suite/start', function(suite) {
+    topic.subscribe("/suite/start", function(suite) {
+      /* eslint-disable no-console*/
       console.log('Running: ' + suite.name);
     });
   }
@@ -24,8 +25,8 @@ define([
     wc: {
       pageLoadTimeout: args.wcPageLoadTimeout ? parseInt(args.wcPageLoadTimeout, 10) : 10000,
       // user and pw need to be passed in as command-line arguments. See CONTRIBUTING.md
-      user: args.user || 'some username',
-      pw: args.pw || 'some password',
+      user: args.user || "some username",
+      pw: args.pw || "some password",
     },
 
     // The port on which the instrumenting proxy will listen
@@ -50,11 +51,11 @@ define([
 
     // // currently BrowserStack not supporting firefox 47
     environments: [
-      { browser: 'firefox', browser_version: '51', os : 'OS X', os_version : 'Sierra' },
-      { browser: 'chrome', browser_version: '56', os : 'OS X', os_version : 'Sierra' }
+      { browser: "firefox", browser_version: "51", os : "OS X", os_version : "Sierra" },
+      { browser: "chrome", browser_version: "56", os : "OS X", os_version : "Sierra" }
     ],
 
-    tunnel: 'BrowserStackTunnel',
+    tunnel: "BrowserStackTunnel",
     tunnelOptions: {
       verbose: true,
       username: args.BROWSERSTACK_USER,
@@ -63,10 +64,10 @@ define([
 ////// end browserstack test configs
 
     filterErrorStack: true,
-    reporters: ['Pretty'],
+    reporters: ["Pretty"],
 
     // Unless you pass in a command-line arg saying otherwise, we run all tests by default.
-    functionalSuites: [ 'tests/functional-all' ],
+    functionalSuites: [ "tests/functional-all" ],
     excludeInstrumentation: true
   };
 

--- a/tests/browserstack.js
+++ b/tests/browserstack.js
@@ -16,7 +16,7 @@ define([
   if (topic) {
     topic.subscribe("/suite/start", function(suite) {
       /* eslint-disable no-console*/
-      console.log('Running: ' + suite.name);
+      console.log("Running: " + suite.name);
     });
   }
 

--- a/tests/browserstack_remote.js
+++ b/tests/browserstack_remote.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
+// These default settings work OK for most people. The options that *must* be changed below are the
+// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
+define([
+  "intern",
+], function(intern) { //, topic
+  "use strict";
+
+  var args = intern.args;
+  var siteRoot = args.siteRoot ? args.siteRoot : "http://localhost:5000";
+
+  //if (topic) {
+    //topic.subscribe("/suite/start", function(suite) {
+      //console.log("Running: " + suite.name);
+    //});
+  //}
+
+  return {
+    // Configuration object for webcompat
+    wc: {
+      pageLoadTimeout: args.wcPageLoadTimeout ? parseInt(args.wcPageLoadTimeout, 10) : 10000,
+      // user and pw need to be passed in as command-line arguments. See CONTRIBUTING.md
+      user: args.user || "some username",
+      pw: args.pw || "some password",
+    },
+
+    // The port on which the instrumenting proxy will listen
+    proxyPort: 9000,
+
+    // A fully qualified URL to the Intern proxy
+    //proxyUrl: 'http://127.0.0.1:9090/',
+    siteRoot: siteRoot,
+
+////// Section to run tests on browserstack via travis ci
+    // fix for BrowserStack exceptions (geolocation and webStorage)
+    // fixSessionCapabilities: false,
+
+    capabilities: {
+      //"browserstack.local": false for running tests on travis
+      "browserstack.local": true, 
+      fixSessionCapabilities: false
+    },
+
+    // // Required for BrowserStack, Maximum number of simultaneous integration tests allowed
+    // maxConcurrency: 2,
+
+    // // currently BrowserStack not supporting firefox 47
+    environments: [
+      { browser: "firefox", browser_version: "51", os : "OS X", os_version : "Sierra" },
+      { browser: "chrome", browser_version: "56", os : "OS X", os_version : "Sierra" }
+    ],
+
+    tunnel: "BrowserStackTunnel",
+    tunnelOptions: {
+      verbose: true,
+      username: args.BROWSERSTACK_USERNAME,
+      accessKey: args.BROWSERSTACK_ACCESS_KEY
+    },
+////// end browserstack test configs
+
+    filterErrorStack: true,
+    reporters: ["Pretty"],
+
+    // Unless you pass in a command-line arg saying otherwise, we run all tests by default.
+    functionalSuites: [ "tests/functional-all" ],
+    excludeInstrumentation: true
+  };
+
+});


### PR DESCRIPTION
(edit 033017: updated the BROWSERSTACK_USER value for the new account)
Issues/980/18
@miketaylr this is similar to an old branch, issues/980/15

requires `npm install` (to get a browserstack testing package)
server should be running locally
to run tests triggered locally but hitting browserstack servers (just update BROWSERSTACK_KEY value):
```
node_modules/.bin/intern-runner config=tests/browserstack BROWSERSTACK_USER='webcompatmozilla1' BROWSERSTACK_KEY='replace_with_access_key'
```

(edit 033017) for the BROWSERSTACK_KEY, you need to log into BrowserStack 
* Click the Automate navbar menu option
* Expand the Username + Access Keys on the left top
* Copy the Access Key value

I can't figure out how to make the tests run off travis. also a heads up that the browserstack account is giving an expiration notice (in 20 days). I've made a contact to their support to get an extension and am also making a request to update the account owner email (away from my personal email). will send those details separately.

let me know if you have any questions.

