### PR TITLE
Fixes #1455 - prevent shortcut to open when typing comment

### DIFF
--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -24,7 +24,16 @@ issues.LabelsView = Backbone.View.extend({
     "click .js-LabelEditorLauncher.is-active": "closeEditor"
   },
   keyboardEvents: {
-    "e": "editLabels"
+    "e": "labelWrap"
+  },
+  labelWrap: function(e) {
+    // make sure we're not typing in the search input.
+    if (e.target.nodeName === "TEXTAREA") {
+      return;
+    } else {
+      e.preventDefault();
+      this.editLabels();
+    }
   },
   template: _.template($("#issue-labels-tmpl").html()),
   // this subTemplate will need to be kept in sync with

--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -24,7 +24,7 @@ issues.LabelsView = Backbone.View.extend({
     "click .js-LabelEditorLauncher.is-active": "closeEditor"
   },
   keyboardEvents: {
-    "e": "labelWrap"
+    "l": "labelWrap"
   },
   labelWrap: function(e) {
     // make sure we're not typing in the search input.

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -20,6 +20,7 @@
           <a class="wc-Link wc-GithubLink" href="https://github.com/{{ config['ISSUES_REPO_URI'] }}/{{ number }}"><span class="wc-GithubLink-Icon"></span>View issue on Github</a>
         </p>
         <p>
+          <span class="wc-GithubLink-DesktopOnly">Shortcut: Press <b>l</b> on your keyboard to open the label editor.</span> <br />
           <span class="wc-GithubLink-DesktopOnly">Shortcut: Press <b>g</b> on your keyboard to be taken to the GitHub view of this page.</span>
         </p>
       </section>


### PR DESCRIPTION
r? @miketaylr 

As described in #1455, the label editor opens even when you are typing a comment.
With the fix, it just opens when it doesn't have focus on the textarea. The shortkey was changed from `e` to `l` and info in the footer was added.