### PR TITLE
Fixes #1448 - added grunt build as prestart script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "fix": "eslint --fix ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
     "imagemin":"grunt imagemin",
     "module": "git submodule init && git submodule update",
+    "prestart":"npm run build",
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
     "virtualenv": "pip install virtualenv && virtualenv env && source env/bin/activate || . env/bin/activate && npm run pip",
     "pip": "pip install -r config/requirements.txt",


### PR DESCRIPTION
Added build as prestart to the npm scripts. So it will be called automated before start.