### PR TITLE
Fixes #1462 - Add functional tests for when typing 'g' or 'l' in an issue or issue comment

### DIFF
--- a/tests/functional/comments-auth.js
+++ b/tests/functional/comments-auth.js
@@ -153,7 +153,44 @@ define(
             );
           })
           .end();
-      }
+      },
+
+      "Pressing 'g' inside of comment textarea *doesn't* go to github issue": function() {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues/100"),
+          ".wc-Comment-submit"
+        )
+          .findByCssSelector(".wc-Comment-submit")
+          .click()
+          .type("g")
+          .end()
+          .setFindTimeout(2000)
+          .findByCssSelector(".repo-container .issues-listing")
+          .then(assert.fail, function(err) {
+            assert.isTrue(/NoSuchElement/.test(String(err)));
+          })
+          .end();
+      },
+
+      "Pressing 'l' inside of comment textarea *doesn't* open the label editor box": function() {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues/100"),
+          ".wc-Comment-submit"
+        )
+          .findByCssSelector(".wc-Comment-submit")
+          .click()
+          .type("l")
+          .end()
+          .setFindTimeout(2000)
+          .findByCssSelector(".js-LabelEditorLauncher")
+          .getAttribute("class")
+          .then(function(className) {
+            assert.notInclude(className, "is-active");
+          })
+          .end();
+      },
     });
   }
 );

--- a/tests/functional/issues-auth.js
+++ b/tests/functional/issues-auth.js
@@ -53,7 +53,28 @@ define(
           .then(function(text) {
             assert.equal(text, "Close Issue", "Button says Close not Reopen");
           });
+      },
+
+      "Pressing 'l' opens the label editor box": function () {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues/70"),
+          ".wc-Issue-commentSubmit",
+          true
+        )
+          .findByCssSelector(".wc-Issue-labels")
+          .click()
+          .type("l")
+          .end()
+          .setFindTimeout(0)
+          .findByCssSelector(".js-LabelEditorLauncher")
+          .getAttribute("class")
+          .then(function(className) {
+            assert.include(className, "is-active");
+          })
+          .end();
       }
+
     });
   }
 );

--- a/tests/functional/issues-auth.js
+++ b/tests/functional/issues-auth.js
@@ -59,14 +59,12 @@ define(
         return FunctionalHelpers.openPage(
           this,
           url("/issues/70"),
-          ".wc-Issue-commentSubmit",
-          true
+          ".wc-Issue-commentSubmit"
         )
           .findByCssSelector(".wc-Issue-labels")
           .click()
           .type("l")
           .end()
-          .setFindTimeout(0)
           .findByCssSelector(".js-LabelEditorLauncher")
           .getAttribute("class")
           .then(function(className) {


### PR DESCRIPTION
r? @miketaylr 

The tests are failing sometimes, but it's the same thing as I explained in #1470 