### PR TITLE
Fixes #1515 - fixed encoding param

### DIFF
--- a/tests/functional/issue-list-non-auth.js
+++ b/tests/functional/issue-list-non-auth.js
@@ -463,34 +463,6 @@ define(
             })
             .end()
         );
-      },
-
-      "Results are loaded from the query params": function() {
-        var params = "?q=vladvlad";
-        return FunctionalHelpers.openPage(
-          this,
-          url("/issues", params),
-          ".js-IssueList:nth-of-type(1)"
-        )
-          .findByCssSelector(".wc-IssueList:nth-of-type(1) a")
-          .getVisibleText()
-          .then(function(text) {
-            assert.include(
-              text,
-              "vladvlad",
-              "The search query results show up on the page."
-            );
-          })
-          .end()
-          .getCurrentUrl()
-          .then(function(currUrl) {
-            assert.include(
-              currUrl,
-              "q=vladvlad",
-              "Our params didn't go anywhere."
-            );
-          })
-          .end();
       }
     });
   }

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -489,7 +489,7 @@ issueList.IssueView = Backbone.View.extend(
           var kvArray = param.split("=");
           var key = kvArray[0];
           var value = kvArray[1];
-          this.issues.params[key] = value;
+          this.issues.params[key] = decodeURIComponent(value);
         }, this)
       );
     },

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -232,9 +232,10 @@ issueList.SearchView = Backbone.View.extend({
     // if it's empty and the user searches, show the default results
     // (but only once)
     if (!searchValue.length && this._currentSearch !== "") {
+      this.doSearch("");
       this.currentSearch("");
+      issueList.events.trigger("filter:clear", { removeQ: true });
       this._isEmpty = true;
-      issueList.events.trigger("issues:update");
     }
   }, 350),
   doSearch: _.throttle(function(value) {
@@ -485,12 +486,21 @@ issueList.IssueView = Backbone.View.extend(
           this.issues.setURLState("/api/issues/search", paramsCopy);
         }
       } else if (_.contains(issuesAPICategories, category)) {
-        this.issues.setURLState("/api/issues/category/" + category, params);
+        this.issues.setURLState(
+          "/api/issues/category/" + category,
+          this.removeParamQuery(params)
+        );
       } else {
-        this.issues.setURLState("/api/issues", params);
+        this.issues.setURLState("/api/issues", this.removeParamQuery(params));
       }
 
       this.fetchAndRenderIssues();
+    },
+    removeParamQuery: function(params) {
+      if (params && params.q) {
+        delete params.q;
+      }
+      return params;
     },
     addParamsToModel: function(paramsArray) {
       // this method just puts the params in the model's params property.

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -336,14 +336,18 @@ issueList.IssueView = Backbone.View.extend(
       // There are some params in the URL
       if (urlParams.length !== 0) {
         queryMatch = urlParams.match(this._searchRegex);
+        if (queryMatch) {
+          _.delay(function() {
+            issueList.events.trigger(
+              "search:update",
+              decodeURIComponent(queryMatch[1])
+            );
+          }, 0);
+        }
         if (!this._isLoggedIn && queryMatch) {
           // We're dealing with an un-authed user, with a q param.
           this.doGitHubSearch(urlParams);
           this.updateModelParams(urlParams);
-          _.delay(function() {
-            // TODO: update search input from query param for authed users.
-            issueList.events.trigger("search:update", queryMatch[1]);
-          }, 0);
         } else if (
           (category = window.location.search.match(this._filterRegex))
         ) {

--- a/webcompat/static/js/lib/issue-list.js
+++ b/webcompat/static/js/lib/issue-list.js
@@ -190,6 +190,7 @@ issueList.SearchView = Backbone.View.extend({
   initialize: function() {
     issueList.events.on("search:update", _.bind(this.updateSearchQuery, this));
     issueList.events.on("search:clear", _.bind(this.clearSearchBox, this));
+    issueList.events.on("search:current", _.bind(this.currentSearch, this));
   },
   template: _.template($("#issuelist-search-tmpl").html()),
   render: function(cb) {
@@ -207,6 +208,9 @@ issueList.SearchView = Backbone.View.extend({
   updateSearchQuery: function(data) {
     this.input.val(data);
   },
+  currentSearch: function(data) {
+    this._currentSearch = data;
+  },
   _isEmpty: true,
   _currentSearch: null,
   searchIfNotEmpty: _.debounce(function(e) {
@@ -218,8 +222,8 @@ issueList.SearchView = Backbone.View.extend({
       // don't search if nothing has changed
       // (or user just added whitespace)
       if ($.trim(searchValue) !== this._currentSearch) {
-        this._currentSearch = $.trim(searchValue);
-        this.doSearch(this._currentSearch);
+        this.currentSearch($.trim(searchValue));
+        this.doSearch($.trim(searchValue));
         // clear any filters that have been set.
         issueList.events.trigger("filter:clear", { removeQ: false });
       }
@@ -228,7 +232,7 @@ issueList.SearchView = Backbone.View.extend({
     // if it's empty and the user searches, show the default results
     // (but only once)
     if (!searchValue.length && this._currentSearch !== "") {
-      this._currentSearch = "";
+      this.currentSearch("");
       this._isEmpty = true;
       issueList.events.trigger("issues:update");
     }
@@ -340,6 +344,10 @@ issueList.IssueView = Backbone.View.extend(
           _.delay(function() {
             issueList.events.trigger(
               "search:update",
+              decodeURIComponent(queryMatch[1])
+            );
+            issueList.events.trigger(
+              "search:current",
               decodeURIComponent(queryMatch[1])
             );
           }, 0);


### PR DESCRIPTION
r? @miketaylr 

I have fixed the issue #1515  and more.

- url: param q is encoded with `encodeURIComponent` to avoid `%25`
- input search is set when we refresh page if there is a `q` param
- `_currentSearch` is init directly in `this.issueList = new issueList.IssueView();`  to avoid double search at first page init.
- param `q` is removed of XHR rquest when search input is empty

~~There is still a bug. When you delete the search field. It is necessary to send a request (ok) and delete the param `q` (NOK, the test is here https://github.com/webcompat/webcompat.com/blob/master/webcompat/static/js/lib/issue-list.js#L464)~~


### Edit

Seems to fixe this issue #1023 

~~Last bug: Delete the request parameter https://github.com/webcompat/webcompat.com/blob/master/webcompat/static/js/lib/issue-list.js#L464~~
