### PR TITLE
Fix #1542 - Fixes a UTF-8 decoding error

### DIFF
--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -193,7 +193,8 @@ def create_issue():
     # Logging the ip and url for investigation
     log = app.logger
     log.setLevel(logging.INFO)
-    log.info('{ip} {url}'.format(ip=request.remote_addr, url=form['url']))
+    log.info('{ip} {url}'.format(ip=request.remote_addr,
+                                 url=form['url'].encode('utf-8')))
     # form submission for 3 scenarios: authed, to be authed, anonymous
     if form.get('submit-type') == AUTH_REPORT:
         if g.user:  # If you're already authed, submit the bug.


### PR DESCRIPTION
We had a utf-8 decode error in our logging system. This fixes it. 

```
→ nosetests
...............................................
----------------------------------------------------------------------
Ran 47 tests in 6.596s

OK
```

r? @miketaylr 