### PR TITLE
Fixes #1271 - Adds thumbnails to image upload and link them 

### DIFF
--- a/tests/functional/comments-auth.js
+++ b/tests/functional/comments-auth.js
@@ -148,7 +148,7 @@ define(
           .then(function(val) {
             assert.include(
               val,
-              "![Screenshot of the site issue](http://localhost:5000/uploads/",
+              "[![Screenshot Description](http://localhost:5000/uploads/",
               "The image was correctly uploaded and its URL was copied to the comment text."
             );
           })

--- a/tests/functional/image-uploads-non-auth.js
+++ b/tests/functional/image-uploads-non-auth.js
@@ -94,7 +94,7 @@ define(
             .then(function(val) {
               assert.include(
                 val,
-                "![Screenshot Description](http://localhost:5000/uploads/",
+                "[![Screenshot Description](http://localhost:5000/uploads/",
                 "The data URI was correctly uploaded and its URL was copied to the bug description."
               );
             })
@@ -115,7 +115,7 @@ define(
             .then(function(val) {
               assert.include(
                 val,
-                "![Screenshot Description](http://localhost:5000/uploads/",
+                "[![Screenshot Description](http://localhost:5000/uploads/",
                 "The data URI was correctly uploaded and its URL was copied to the bug description."
               );
             })
@@ -134,7 +134,7 @@ define(
           .then(function(val) {
             assert.include(
               val,
-              "![Screenshot Description](http://localhost:5000/uploads/",
+              "[![Screenshot Description](http://localhost:5000/uploads/",
               "The data URI was correctly uploaded and its URL was copied to the bug description."
             );
           })
@@ -174,7 +174,7 @@ define(
             .then(function(val) {
               assert.notInclude(
                 val,
-                "![Screenshot Description](http://localhost:5000/uploads/",
+                "[![Screenshot Description](http://localhost:5000/uploads/",
                 "The url to the image upload was correctly removed."
               );
             })

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -18,7 +18,7 @@ from werkzeug.datastructures import MultiDict
 # Add webcompat module to import path
 sys.path.append(os.path.realpath(os.pardir))
 
-from webcompat import app
+from webcompat import app  # nopep8
 
 
 class TestingFileStorage(FileStorage):
@@ -74,12 +74,12 @@ class TestUploads(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def testGet(self):
+    def test_get(self):
         '''Test that /upload/ doesn't let you GET.'''
         rv = self.test_client.get('/upload/')
         self.assertEqual(rv.status_code, 404)
 
-    def testRegularUploads(self):
+    def test_regular_uploads(self):
         '''Test that uploaded files return the expected status code.'''
         # Loop over some files and the status codes that we are expecting
         for filename, status_code in (
@@ -115,7 +115,7 @@ class TestUploads(unittest.TestCase):
             rv = test_client.post('/upload/', data=dict())
             self.assertEqual(rv.status_code, status_code)
 
-    def testBase64ScreenshotUploads(self):
+    def test_base64_screenshot_uploads(self):
         '''Test that Base64 screenshots return the expected status codes.'''
         BASE64_PNG = u'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg=='  # nopep8
         BASE64_PNG_GARBAGE = u'data:image/png;base64,garbage!'

--- a/webcompat/api/uploads.py
+++ b/webcompat/api/uploads.py
@@ -7,19 +7,19 @@
 '''Flask Blueprint for image uploads.'''
 
 import base64
+import datetime
+import io
 import json
 import os
 import re
+import uuid
 
-from datetime import date
 from flask import abort
 from flask import Blueprint
 from flask import request
-from io import BytesIO
 from PIL import Image
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import RequestEntityTooLarge
-from uuid import uuid4
 
 from webcompat import app
 
@@ -40,7 +40,16 @@ class Upload(object):
 
     def __init__(self, imagedata):
         self.image_object = self.to_image_object(imagedata)
+        # computing the parameters to be used
+        today = datetime.date.today()
+        self.year = str(today.year)
+        self.month = str(today.month)
+        self.image_id = str(uuid.uuid4())
         self.file_ext = self.get_file_ext()
+        self.image_path = self.img_path(self.month, self.year, self.image_id,
+                                        thumb=False)
+        self.thumb_path = self.img_path(self.month, self.year, self.image_id,
+                                        thumb=True)
 
     def to_image_object(self, imagedata):
         '''Method to return a Pillow Image object from the raw imagedata.'''
@@ -53,11 +62,19 @@ class Upload(object):
                     imagedata.startswith('data:image/')):
                 # Chop off 'data:image/.+;base64,' before decoding
                 imagedata = re.sub('^data:image/.+;base64,', '', imagedata)
-                return Image.open(BytesIO(base64.b64decode(imagedata)))
+                return Image.open(io.BytesIO(base64.b64decode(imagedata)))
             raise TypeError('TypeError: Not a valid image format')
         except TypeError:
             # Not a valid format
             abort(415)
+
+    def img_path(self, month, year, image_id, thumb=False):
+        '''Return the right image path.'''
+        thumb_string = ''
+        if thumb:
+            thumb_string = '-thumb'
+        image_name = image_id + thumb_string + '.' + self.file_ext
+        return os.path.join(year, month, image_name)
 
     def get_file_ext(self):
         '''Method to return the file extension, as determined by Pillow.
@@ -68,24 +85,22 @@ class Upload(object):
             return 'jpg'
         return self.image_object.format.lower()
 
-    def get_filename(self):
+    def get_filename(self, image_path):
         '''Method to return the uploaded filename (with extension).'''
-        return self.get_url().split('/')[-1]
+        return self.get_url(image_path).split('/')[-1]
 
-    def get_url(self):
+    def get_url(self, image_path):
         '''Method to return a URL for the uploaded file.'''
-        return app.config['UPLOADS_DEFAULT_URL'] + self.file_path
+        return app.config['UPLOADS_DEFAULT_URL'] + image_path
 
     def save(self):
         '''Check that the file is allowed, then save to filesystem.'''
         save_parameters = {}
         if self.file_ext not in self.ALLOWED_FORMATS:
             raise TypeError('Image file format not allowed')
-
-        today = date.today()
-        self.file_path = os.path.join(str(today.year), str(today.month),
-                                      str(uuid4()) + '.' + self.file_ext)
-        file_dest = app.config['UPLOADS_DEFAULT_DEST'] + self.file_path
+        # Paths of the images
+        file_dest = app.config['UPLOADS_DEFAULT_DEST'] + self.image_path
+        thumb_dest = app.config['UPLOADS_DEFAULT_DEST'] + self.thumb_path
         dest_dir = os.path.dirname(file_dest)
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
@@ -100,6 +115,10 @@ class Upload(object):
             save_parameters['save_all'] = True
         # unpacking save_parameters
         self.image_object.save(file_dest, **save_parameters)
+        # Creating the thumbnail
+        size = (700, 700)
+        self.image_object.thumbnail(size, Image.BILINEAR)
+        self.image_object.save(thumb_dest, **save_parameters)
 
 
 @uploads.route('/', methods=['POST'])
@@ -123,8 +142,9 @@ def upload():
         upload = Upload(imagedata)
         upload.save()
         data = {
-            'filename': upload.get_filename(),
-            'url': upload.get_url()
+            'filename': upload.get_filename(upload.image_path),
+            'url': upload.get_url(upload.image_path),
+            'thumb_url': upload.get_url(upload.thumb_path)
         }
         return (json.dumps(data), 201, {'content-type': JSON_MIME})
     except (TypeError, IOError):

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -427,7 +427,7 @@ function BugForm() {
         // Note: this could fail in weird ways depending on how
         // the user has edited the descField.
         this.descField.val(function(idx, value) {
-          return value.replace(/!\[.+\.(?:bmp|gif|jpe*g*)\)$/, "");
+          return value.replace(/\[!\[[^\]]+\]\([^\)]+\)\]\([^\.]+.(?:bmp|gif|jpe*g*)\)$/, "");
         });
       }, this)
     );
@@ -449,7 +449,7 @@ function BugForm() {
       method: "POST",
       url: "/upload/",
       success: _.bind(function(response) {
-        this.addImageURL(response.url);
+        this.addImageURL(response);
         this.uploadLoader.removeClass("is-active");
         this.enableSubmits();
       }, this),
@@ -475,11 +475,13 @@ function BugForm() {
     this.uploadField.val(this.uploadField.get(0).defaultValue);
   };
   /*
-    copy over the URL of a newly uploaded image asset to the bug
-    description textarea.
+    create the markdown with the URL of a newly uploaded image
+    and its thumbnail URL assets to the bug description
   */
-  this.addImageURL = function(url) {
-    var imageURL = ["![Screenshot Description](", url, ")"].join("");
+  this.addImageURL = function(response) {
+    var img_url = response.url;
+    var thumb_url = response.thumb_url;
+    var imageURL = ["[![Screenshot Description](", thumb_url, ")](", img_url, ")"].join("");
     this.descField.val(function(idx, value) {
       return value + "\n\n" + imageURL;
     });

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -427,7 +427,10 @@ function BugForm() {
         // Note: this could fail in weird ways depending on how
         // the user has edited the descField.
         this.descField.val(function(idx, value) {
-          return value.replace(/\[!\[[^\]]+\]\([^\)]+\)\]\([^\.]+.(?:bmp|gif|jpe*g*)\)$/, "");
+          return value.replace(
+            /\[!\[[^\]]+\]\([^\)]+\)\]\([^\.]+.(?:bmp|gif|jpe*g*)\)$/,
+            ""
+          );
         });
       }, this)
     );
@@ -481,7 +484,13 @@ function BugForm() {
   this.addImageURL = function(response) {
     var img_url = response.url;
     var thumb_url = response.thumb_url;
-    var imageURL = ["[![Screenshot Description](", thumb_url, ")](", img_url, ")"].join("");
+    var imageURL = [
+      "[![Screenshot Description](",
+      thumb_url,
+      ")](",
+      img_url,
+      ")"
+    ].join("");
     this.descField.val(function(idx, value) {
       return value + "\n\n" + imageURL;
     });

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -229,13 +229,14 @@ issues.ImageUploadView = Backbone.View.extend({
     var DELIMITER = "\n\n";
     var textarea = $(".js-Comment-text");
     var textareaVal = textarea.val();
-    var imageURL = _.template("![Screenshot of the site issue](<%= url %>)");
-    var compiledImageURL = imageURL({ url: response.url });
+    var img_url = response.url;
+    var thumb_url = response.thumb_url;
+    var imageURL = ["[![Screenshot Description](", thumb_url, ")](", img_url, ")"].join("");
 
     if (!$.trim(textareaVal)) {
-      textarea.val(compiledImageURL);
+      textarea.val(imageURL);
     } else {
-      textarea.val(textareaVal + DELIMITER + compiledImageURL);
+      textarea.val(textareaVal + DELIMITER + ImageURL);
     }
   },
   // Adapted from bugform.js

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -231,12 +231,18 @@ issues.ImageUploadView = Backbone.View.extend({
     var textareaVal = textarea.val();
     var img_url = response.url;
     var thumb_url = response.thumb_url;
-    var imageURL = ["[![Screenshot Description](", thumb_url, ")](", img_url, ")"].join("");
+    var imageURL = [
+      "[![Screenshot Description](",
+      thumb_url,
+      ")](",
+      img_url,
+      ")"
+    ].join("");
 
     if (!$.trim(textareaVal)) {
       textarea.val(imageURL);
     } else {
-      textarea.val(textareaVal + DELIMITER + ImageURL);
+      textarea.val(textareaVal + DELIMITER + imageURL);
     }
   },
   // Adapted from bugform.js


### PR DESCRIPTION
* Changes functional tests for image upload
* Handles the markup on the client side when uploading images
* Handles the image resizing on the python side

```
→ nosetests -v
API access to comments greater than 30 returns pagination in Link ... ok
API issue for a non existent number returns JSON 404. ... ok
API issue search with bad keywords returns JSON 404. ... ok
API access to labels without auth returns JSON 200. ... ok
API with wrong parameter returns JSON 404. ... ok
API setting labels without auth returns JSON 403 error code. ... ok
API access to user activity without auth returns JSON 401. ... ok
API with wrong category returns JSON 404. ... ok
API with wrong route returns JSON 404. ... ok
Checks that domain name is extracted. ... ok
Checks that metadata is processed and wrapped. ... ok
Checks that URL is normalized. ... ok
Test HTTP Links formating. ... ok
Test browser parsing via get_browser helper method. ... ok
Test browser name parsing via get_browser_name helper method. ... ok
Test name extraction from Dict via get_name helper method. ... ok
Test OS parsing via get_os helper method. ... ok
Test version string composition from Dict ... ok
Test that API params are correctly converted to Search API. ... ok
normalize_api_params shouldn't transform unknown params. ... ok
Test HTTP Links parsing for GitHub only. ... ok
test_rewrite_and_sanitize_link (tests.test_helpers.TestHelpers) ... ok
Test we're correctly rewriting the passed in link. ... ok
Test that we're removing access_token parameters. ... ok
Check Cache-Control for issues. ... ok
Check ETAG for issues. ... ok
Checks if we receive a 304 Not Modified. ... ok
Page title format for different URIs. ... ok
Test that Base64 screenshots return the expected status codes. ... ok
Test that /upload/ doesn't let you GET. ... ok
Test that uploaded files return the expected status code. ... ok
Test that /about exists. ... ok
Test that asks user to log in before displaying activity. ... ok
Test POST to /csp-report w/ correct content-type returns 204. ... ok
Test POST w/ wrong content-type to /csp-report returns 400. ... ok
Test that the home page exists. ... ok
Test issues and integer for: ... ok
Test that the /issues/<number> exists, and does not redirect. ... ok
Test that the /issues route gets 200 and does not redirect. ... ok
Webhook related tests. ... ok
Test that the /login route 302s to GitHub. ... ok
Sends 400 to POST on /issues/new with missing parameters. ... ok
Test that /issues/new exists. ... ok
Checks 500 is not accepted for /issues/new POST. ... --------------------------------------------------------------------------------
INFO in views [/Users/karl/code/webcompat.com/webcompat/views.py:198]:
127.0.0.1 http://example.com
--------------------------------------------------------------------------------
ok
Test that /privacy exists. ... ok
Rate Limit URI sends 410 Gone. ... ok
Test that the /tools/cssfixme route gets 200. ... ok
Test that the /tools/cssfixme route gets 200 with ?url query. ... ok
Test that the /tools/cssfixme route gets 200 with bad ?url query. ... ok

----------------------------------------------------------------------
Ran 49 tests in 7.023s

OK

```

And functional tests have two failures but which seems unrelated to my case.

```
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged dataURI preview
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged blob preview
✓ firefox on any platform - Image Uploads (non-auth) - remove image upload button
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged dataURI preview
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged blob preview
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged dataURI image upload worked
✓ firefox on any platform - Image Uploads (non-auth) - postMessaged blob image upload worked
✓ firefox on any platform - Image Uploads (non-auth) - remove image upload button
× firefox on any platform - Image Uploads (non-auth) - uploaded image file preview
Error: [POST http://localhost:4444/wd/hub/session/5f70df34-ff7a-483b-9989-7e4800f72a7b/element/16/value / {"value":["/var/folders/bg/lmsn8jdx47748dbg0nrh2m8h0000gn/T/5f70df34-ff7a-483b-9989-7e4800f72a7b/upload402813535228457702file/green_square.png"]}] Expected [object Undefined] undefined to be a string
Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:48:19 -0700'
System info: host: 'irori.local', ip: '192.168.11.7', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.12.4', java.version: '1.8.0_111'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Capabilities [{moz:profile=/var/folders/bg/lmsn8jdx47748dbg0nrh2m8h0000gn/T/rust_mozprofile.0C4XPt3FNkUw, rotatable=false, timeouts={implicit=0, pageLoad=300000, script=30000}, pageLoadStrategy=normal, platform=ANY, specificationLevel=0, moz:accessibilityChecks=false, acceptInsecureCerts=false, browserVersion=53.0, platformVersion=16.5.0, moz:processID=97832, browserName=firefox, platformName=darwin}]
Session ID: c798b7a9-9c7d-0041-bd5b-4c905d5e8c3f
  at Test.uploaded image file preview [as test]  <tests/functional/image-uploads-non-auth.js:69:12>
× firefox on any platform - Image Uploads (non-auth) - uploaded image file upload worked
Error: [POST http://localhost:4444/wd/hub/session/5f70df34-ff7a-483b-9989-7e4800f72a7b/element/22/value / {"value":["/var/folders/bg/lmsn8jdx47748dbg0nrh2m8h0000gn/T/5f70df34-ff7a-483b-9989-7e4800f72a7b/upload8546394691103083768file/green_square.png"]}] Expected [object Undefined] undefined to be a string
Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:48:19 -0700'
System info: host: 'irori.local', ip: '192.168.11.7', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.12.4', java.version: '1.8.0_111'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Capabilities [{moz:profile=/var/folders/bg/lmsn8jdx47748dbg0nrh2m8h0000gn/T/rust_mozprofile.0C4XPt3FNkUw, rotatable=false, timeouts={implicit=0, pageLoad=300000, script=30000}, pageLoadStrategy=normal, platform=ANY, specificationLevel=0, moz:accessibilityChecks=false, acceptInsecureCerts=false, browserVersion=53.0, platformVersion=16.5.0, moz:processID=97832, browserName=firefox, platformName=darwin}]
Session ID: c798b7a9-9c7d-0041-bd5b-4c905d5e8c3f
  at Test.uploaded image file upload worked [as test]  <tests/functional/image-uploads-non-auth.js:129:12>

tests/intern
Tunnel: Starting

Total: [✓✓×✓✓×✓] 7/7
Passed: 5  Failed: 2  Skipped: 0

Fx ANY:     [✓✓×✓✓×✓] 7/7, 2 fail
```

The two errors are explicitly saying:

`Expected [object Undefined] undefined to be a string`

Oh and the functional tests are still super unstable locally. 

r? @miketaylr 