### PR TITLE
Fix #1228 - Improves webhooks to send labels at once

### DIFF
--- a/config/secrets.py.example
+++ b/config/secrets.py.example
@@ -7,33 +7,38 @@
 '''This file contains secrets and sensitive file-system locations and
 settings that we don't want to be public.'''
 
-from environment import *
+import os
+import environment as env
 
 # Secret key for signing cookies. Can be ignored for local testing.
 SECRET_KEY = '~*change me*~'
-HOOK_SECRET_KEY = '~*change me*~'
+
+if env.LOCALHOST:
+    HOOK_SECRET_KEY = 'SECRETS'
+else:
+    HOOK_SECRET_KEY = '~*change me*~'
 
 # Image uploading settings. PRODUCTION and STAGING can be ignored for
 # local testing.
-if PRODUCTION:
+if env.PRODUCTION:
     UPLOADS_DEFAULT_DEST = ''
     UPLOADS_DEFAULT_URL = ''
-elif STAGING:
+elif env.STAGING:
     UPLOADS_DEFAULT_DEST = ''
     UPLOADS_DEFAULT_URL = ''
-elif LOCALHOST:
-    UPLOADS_DEFAULT_DEST = BASE_DIR + '/uploads/'
+elif env.LOCALHOST:
+    UPLOADS_DEFAULT_DEST = env.BASE_DIR + '/uploads/'
     UPLOADS_DEFAULT_URL = 'http://localhost:5000/uploads/'
 
 
 # Database backup path.
-if LOCALHOST:
-    BACKUP_DEFAULT_DEST = BASE_DIR + '/backups/'
+if env.LOCALHOST:
+    BACKUP_DEFAULT_DEST = env.BASE_DIR + '/backups/'
 else:
     BACKUP_DEFAULT_DEST = ''
 
 # Production GiHub Issues repo URI. Can be ignored for local testing.
-if PRODUCTION:
+if env.PRODUCTION:
     ISSUES_REPO_URI = ''
 # Staging and Local instances use the same test repo
 else:
@@ -45,12 +50,12 @@ else:
 # [1]<https://github.com/organizations/webcompat/settings/applications/>
 # PRODUCTION and STAGING can be ignored for local testing.
 # Production = webcompat.com
-if PRODUCTION:
+if env.PRODUCTION:
     GITHUB_CLIENT_ID = ''
     GITHUB_CLIENT_SECRET = ''
     GITHUB_CALLBACK_URL = ''
 # Staging = staging.webcompat.com
-elif STAGING:
+elif env.STAGING:
     GITHUB_CLIENT_ID = ''
     GITHUB_CLIENT_SECRET = ''
     GITHUB_CALLBACK_URL = ''

--- a/tests/fixtures/webhooks/new_event_invalid.json
+++ b/tests/fixtures/webhooks/new_event_invalid.json
@@ -1,0 +1,7 @@
+{
+  "action": "closed",
+  "issue": {
+    "number": 600,
+    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/"
+  }
+}

--- a/tests/fixtures/webhooks/new_event_valid.json
+++ b/tests/fixtures/webhooks/new_event_valid.json
@@ -1,0 +1,7 @@
+{
+  "action": "opened",
+  "issue": {
+    "number": 600,
+    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/"
+  }
+}

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -84,15 +84,6 @@ class TestURLs(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertNotEqual(rv.status_code, 307)
 
-    def test_labeler_webhook(self):
-        '''Webhook related tests.'''
-        headers = {'X-GitHub-Event': 'ping'}
-        rv = self.app.get('/webhooks/labeler', headers=headers)
-        self.assertEqual(rv.status_code, 403)
-        rv = self.app.post('/webhooks/labeler', headers=headers)
-        # A random post should 401, only requests from GitHub will 200
-        self.assertEqual(rv.status_code, 401)
-
     def test_csp_report_uri(self):
         '''Test POST to /csp-report w/ correct content-type returns 204.'''
         headers = {'Content-Type': 'application/csp-report'}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -18,11 +18,7 @@ from webcompat.webhooks import helpers
 sys.path.append(os.path.realpath(os.pardir))
 import webcompat  # nopep8
 
-
-# Any request that depends on parsing HTTP Headers (basically anything
-# on the index route, will need to include the following: environ_base=headers
-headers = {'HTTP_USER_AGENT': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; '
-                               'rv:31.0) Gecko/20100101 Firefox/31.0')}
+# The key is being used for testing and computing the signature.
 key = app.config['HOOK_SECRET_KEY']
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Tests for our webhooks."""
+
+import json
+import os
+import sys
+import unittest
+
+from webcompat import app
+from webcompat.webhooks import helpers
+
+# Add webcompat module to import path
+sys.path.append(os.path.realpath(os.pardir))
+import webcompat  # nopep8
+
+
+# Any request that depends on parsing HTTP Headers (basically anything
+# on the index route, will need to include the following: environ_base=headers
+headers = {'HTTP_USER_AGENT': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; '
+                               'rv:31.0) Gecko/20100101 Firefox/31.0')}
+key = app.config['HOOK_SECRET_KEY']
+
+
+# Some machinery for opening our test files
+def event_data(filename):
+    '''return a tuple with the content and its signature.'''
+    current_root = os.path.realpath(os.curdir)
+    events_path = 'tests/fixtures/webhooks'
+    path = os.path.join(current_root, events_path, filename)
+    with open(path, 'r') as f:
+        json_event = json.dumps(json.load(f))
+    signature = 'sha1={sig}'.format(
+        sig=helpers.get_payload_signature(key, json_event))
+    return json_event, signature
+
+
+class TestWebhook(unittest.TestCase):
+    def setUp(self):
+        webcompat.app.config['TESTING'] = True
+        self.app = webcompat.app.test_client()
+        self.headers = {'content-type': 'application/json'}
+        self.test_url = '/webhooks/labeler'
+        self.issue_body = """
+        <!-- @browser: Firefox 55.0 -->
+        <!-- @ua_header: Mozilla/5.0 (what) Gecko/20100101 Firefox/55.0 -->
+        <!-- @reported_with: web -->
+
+        **URL**: https://www.example.com/
+        **Browser / Version**: Firefox 55.0
+        <!-- @browser: Chrome 48.0 -->
+        """
+        self.issue_body2 = """
+        <!-- @browser: Foobar -->
+        """
+
+    def tearDown(self):
+        pass
+
+    def test_forbidden_get(self):
+        """GET is forbidden on labeler webhook."""
+        rv = self.app.get(self.test_url, headers=self.headers)
+        self.assertEqual(rv.status_code, 404)
+
+    def test_fail_on_missing_signature(self):
+        """POST without signature on labeler webhook is forbidden."""
+        self.headers.update({'X-GitHub-Event': 'ping'})
+        rv = self.app.post(self.test_url, headers=self.headers)
+        self.assertEqual(rv.status_code, 401)
+
+    def test_fail_on_bogus_signature(self):
+        """POST without bogus signature on labeler webhook is forbidden."""
+        json_event, signature = event_data('new_event_valid.json')
+        self.headers.update({'X-GitHub-Event': 'ping',
+                             'X-Hub-Signature': 'Boo!'})
+        rv = self.app.post(self.test_url,
+                           data=json_event,
+                           headers=self.headers)
+        self.assertEqual(rv.status_code, 401)
+
+    def test_fail_on_invalid_event_type(self):
+        """POST with event not being 'issues' or 'ping' fails."""
+        json_event, signature = event_data('new_event_valid.json')
+        self.headers.update({'X-GitHub-Event': 'failme',
+                             'X-Hub-Signature': signature})
+        rv = self.app.post(self.test_url,
+                           data=json_event,
+                           headers=self.headers)
+        self.assertEqual(rv.status_code, 403)
+
+    def test_success_on_ping_event(self):
+        """POST with PING events just return a 200 and contains pong."""
+        json_event, signature = event_data('new_event_valid.json')
+        self.headers.update({'X-GitHub-Event': 'ping',
+                             'X-Hub-Signature': signature})
+        rv = self.app.post(self.test_url,
+                           data=json_event,
+                           headers=self.headers)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn('pong', rv.data)
+
+    def test_fails_on_action_not_opened(self):
+        """POST with action different of opened fails."""
+        json_event, signature = event_data('new_event_invalid.json')
+        self.headers.update({'X-GitHub-Event': 'issues',
+                             'X-Hub-Signature': signature})
+        rv = self.app.post(self.test_url,
+                           data=json_event,
+                           headers=self.headers)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn('cool story, bro.', rv.data)
+
+    def test_extract_browser_label(self):
+        """Extract browser label name."""
+        browser_label = helpers.extract_browser_label(self.issue_body)
+        self.assertEqual(browser_label, 'browser-firefox')
+        browser_label_none = helpers.extract_browser_label(self.issue_body2)
+        self.assertEqual(browser_label_none, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -15,7 +15,6 @@ from flask import abort
 from flask import Blueprint
 from flask import request
 
-from helpers import dump_to_db
 from helpers import parse_and_set_label
 from helpers import set_label
 from helpers import signature_check
@@ -52,7 +51,6 @@ def hooklistener():
                     # Setting "Needs Triage" label by default
                     # to all the new issues raised
                     set_label('status-needstriage', issue_number)
-                    dump_to_db(issue_title, issue_body, issue_number)
                     return ('gracias, amigo.', 200)
                 else:
                     return ('cool story, bro.', 200)

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -4,59 +4,70 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-'''Flask Blueprint for our "webhooks" module, which we use to do cool things
-with GitHub events and actions.
+"""Flask Blueprint for our "webhooks" module.webhooks
 
-See https://developer.github.com/webhooks/ for what is possible.'''
+See https://developer.github.com/webhooks/ for what is possible."""
 
 import json
+import logging
 
 from flask import abort
 from flask import Blueprint
 from flask import request
 
-from helpers import parse_and_set_label
-from helpers import set_label
+from helpers import extract_browser_label
+from helpers import set_labels
 from helpers import signature_check
 
 from webcompat import app
 
-
 webhooks = Blueprint('webhooks', __name__, url_prefix='/webhooks')
 
 
-@webhooks.route('/labeler', methods=['GET', 'POST'])
+@webhooks.route('/labeler', methods=['POST'])
 def hooklistener():
-    '''Listen for the "issues" webhook event, parse the body
+    """Listen for the "issues" webhook event.
 
-       Method posts back labels and dumps data to a local db.
-       Only in response to the 'opened' action, though.
-    '''
-    if request.method == 'GET':
-        abort(403)
-    elif request.method == 'POST':
-        event_type = request.headers.get('X-GitHub-Event')
-        post_signature = request.headers.get('X-Hub-Signature')
-        if post_signature:
-            key = app.config['HOOK_SECRET_KEY']
-            payload = json.loads(request.data)
-            if not signature_check(key, post_signature, request.data):
-                abort(401)
-            if event_type == 'issues':
-                if payload.get('action') == 'opened':
-                    issue_body = payload.get('issue')['body']
-                    issue_title = payload.get('issue')['title']
-                    issue_number = payload.get('issue')['number']
-                    parse_and_set_label(issue_body, issue_number)
-                    # Setting "Needs Triage" label by default
-                    # to all the new issues raised
-                    set_label('status-needstriage', issue_number)
-                    return ('gracias, amigo.', 200)
-                else:
-                    return ('cool story, bro.', 200)
-            elif event_type == 'ping':
-                return ('pong', 200)
-            else:
-                abort(403)
-        else:
+    - Only in response to the 'opened' action (for now).
+    - Add label needstriage to the issue
+    - Add label for the browser name
+    """
+    event_type = request.headers.get('X-GitHub-Event')
+    post_signature = request.headers.get('X-Hub-Signature')
+    if post_signature:
+        key = app.config['HOOK_SECRET_KEY']
+        payload = json.loads(request.data)
+        if not signature_check(key, post_signature, request.data):
             abort(401)
+        if event_type == 'issues':
+            if payload.get('action') == 'opened':
+                # Setting "Needs Triage" label by default
+                # to all the new issues raised
+                labels = ['status-needstriage']
+                issue_body = payload.get('issue')['body']
+                issue_number = payload.get('issue')['number']
+                browser_label = extract_browser_label(issue_body)
+                if browser_label:
+                    labels.append(browser_label)
+                # Sending a request to set labels
+                response = set_labels(labels, issue_number)
+                if response.status_code == 200:
+                    return ('gracias, amigo.', 200,
+                            {'Content-Type': 'plain/text'})
+                else:
+                    # Logging the ip and url for investigation
+                    log = app.logger
+                    log.setLevel(logging.INFO)
+                    msg = 'failed to set labels on issue {issue}'.format(
+                        issue=issue_number)
+                    log.info(msg)
+            else:
+                return ('cool story, bro.', 200,
+                        {'Content-Type': 'plain/text'})
+        elif event_type == 'ping':
+            return ('pong', 200, {'Content-Type': 'plain/text'})
+        else:
+            abort(403)
+    else:
+        # No signature.
+        abort(401)

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -66,11 +66,18 @@ def compare_digest(x, y):
 
 def signature_check(key, post_signature, payload):
     '''Checks the HTTP POST legitimacy.'''
-    sha_name, signature = post_signature.split('=')
-    if sha_name != 'sha1':
+    if post_signature.startswith('sha1='):
+        sha_name, signature = post_signature.split('=')
+    else:
         return False
     if not signature:
         return False
     # HMAC requires its key to be bytes, but data is strings.
+    hexmac = get_payload_signature(key, payload)
+    return compare_digest(hexmac, signature.encode('utf-8'))
+
+
+def get_payload_signature(key, payload):
+    '''Compute the payload signature given a key.'''
     mac = hmac.new(key, msg=payload, digestmod=hashlib.sha1)
-    return compare_digest(mac.hexdigest(), signature.encode('utf-8'))
+    return mac.hexdigest()

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -11,9 +11,6 @@ import re
 import requests
 
 from webcompat import app
-from webcompat.db import issue_db
-from webcompat.db import WCIssue
-from webcompat.helpers import extract_url
 
 
 def api_post(endpoint, payload, issue):
@@ -52,9 +49,6 @@ def set_label(label, issue_number):
 
 
 def dump_to_db(title, body, issue_number):
-    url = extract_url(body)
-    issue_db.add(WCIssue(issue_number, title, url, body))
-    issue_db.commit()
 
 
 def compare_digest(x, y):

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -13,17 +13,7 @@ import requests
 from webcompat import app
 
 
-def api_post(endpoint, payload, issue):
-    '''Helper method to post junk to GitHub.'''
-    headers = {
-        'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])
-    }
-    uri = 'https://api.github.com/repos/{0}/{1}/{2}'.format(
-        app.config['ISSUES_REPO_URI'], issue, endpoint)
-    requests.post(uri, data=json.dumps(payload), headers=headers)
-
-
-def parse_and_set_label(body, issue_number):
+def extract_browser_label(body):
     '''Parse the labels from the body in comment:
 
     <!-- @browser: value -->. Currently this only handles a single label,
@@ -37,18 +27,21 @@ def parse_and_set_label(body, issue_number):
         # ('browser', 'firefox')
         browser = match_list.groups(0)[1].lower()
         dash_browser = '-'.join(browser.split())
-        set_label('browser-' + dash_browser, issue_number)
+        return 'browser-{name}'.format(name=dash_browser)
+    else:
+        return None
 
 
-def set_label(label, issue_number):
+def set_labels(payload, issue_number):
     '''Do a GitHub POST request to set a label for the issue.'''
     # POST /repos/:owner/:repo/issues/:number/labels
     # ['Label1', 'Label2']
-    payload = [label]
-    api_post('labels', payload, issue_number)
-
-
-def dump_to_db(title, body, issue_number):
+    headers = {
+        'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])
+    }
+    uri = 'https://api.github.com/repos/{0}/{1}/labels'.format(
+        app.config['ISSUES_REPO_URI'], issue_number)
+    return requests.post(uri, data=json.dumps(payload), headers=headers)
 
 
 def compare_digest(x, y):

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -8,9 +8,9 @@ import hashlib
 import hmac
 import json
 import re
-import requests
 
 from webcompat import app
+from webcompat.helpers import proxy_request
 
 
 def extract_browser_label(body):
@@ -33,15 +33,19 @@ def extract_browser_label(body):
 
 
 def set_labels(payload, issue_number):
-    '''Do a GitHub POST request to set a label for the issue.'''
-    # POST /repos/:owner/:repo/issues/:number/labels
-    # ['Label1', 'Label2']
+    '''Do a GitHub POST request to set a label for the issue.
+
+    POST /repos/:owner/:repo/issues/:number/labels
+    ['Label1', 'Label2']
+    '''
     headers = {
         'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])
     }
-    uri = 'https://api.github.com/repos/{0}/{1}/labels'.format(
+    path = 'repos/{0}/{1}/labels'.format(
         app.config['ISSUES_REPO_URI'], issue_number)
-    return requests.post(uri, data=json.dumps(payload), headers=headers)
+    return proxy_request('post', path,
+                         headers=headers,
+                         data=json.dumps(payload))
 
 
 def compare_digest(x, y):


### PR DESCRIPTION
r? @miketaylr 

Instead of sending two requests which might have created the issue #1553, we are now sending one request only.
We also created a bunch of additional tests in their own file.
Comments in each commit have additional details explaining the context. 

You can test locally the Webhook by doing.

```
# start webcompat.com on localhost
python run.py
# In another shell
http POST http://localhost:5000/webhooks/labeler 'Content-Type:application/json' 'X-GitHub-Event: issues' 'X-Hub-Signature:sha1=43da93fa444d40c2bbec6c3b055ef29859870c79' < /path/to/webcompat.com/tests/fixtures/webhooks/new_event_valid.json
```

Testing

```
nosetests --verbosity=2 --nocapture 
API access to comments greater than 30 returns pagination in Link ... ok
API issue for a non existent number returns JSON 404. ... ok
API issue search with bad keywords returns JSON 404. ... ok
API access to labels without auth returns JSON 200. ... ok
API with wrong parameter returns JSON 404. ... ok
API setting labels without auth returns JSON 403 error code. ... ok
API access to user activity without auth returns JSON 401. ... ok
API with wrong category returns JSON 404. ... ok
API with wrong route returns JSON 404. ... ok
Checks that domain name is extracted. ... ok
Checks that metadata is processed and wrapped. ... ok
Checks that URL is normalized. ... ok
Test HTTP Links formating. ... ok
Test browser parsing via get_browser helper method. ... ok
Test browser name parsing via get_browser_name helper method. ... ok
Test name extraction from Dict via get_name helper method. ... ok
Test OS parsing via get_os helper method. ... ok
Test version string composition from Dict ... ok
Test that API params are correctly converted to Search API. ... ok
normalize_api_params shouldn't transform unknown params. ... ok
Test HTTP Links parsing for GitHub only. ... ok
test_rewrite_and_sanitize_link (tests.test_helpers.TestHelpers) ... ok
Test we're correctly rewriting the passed in link. ... ok
Test that we're removing access_token parameters. ... ok
Check Cache-Control for issues. ... ok
Check ETAG for issues. ... ok
Checks if we receive a 304 Not Modified. ... ok
Page title format for different URIs. ... ok
Test that Base64 screenshots return the expected status codes. ... ok
Test that /upload/ doesn't let you GET. ... ok
Test that uploaded files return the expected status code. ... ok
Test that /about exists. ... ok
Test that asks user to log in before displaying activity. ... ok
Test POST to /csp-report w/ correct content-type returns 204. ... ok
Test POST w/ wrong content-type to /csp-report returns 400. ... ok
Test that the home page exists. ... ok
Test issues and integer for: ... ok
Test that the /issues/<number> exists, and does not redirect. ... ok
Test that the /issues route gets 200 and does not redirect. ... ok
Test that the /login route 302s to GitHub. ... ok
Sends 400 to POST on /issues/new with missing parameters. ... ok
Test that /issues/new exists. ... ok
Checks 500 is not accepted for /issues/new POST. ... ok
Test that /privacy exists. ... ok
Rate Limit URI sends 410 Gone. ... ok
Test that the /tools/cssfixme route gets 200. ... ok
Test that the /tools/cssfixme route gets 200 with ?url query. ... ok
Test that the /tools/cssfixme route gets 200 with bad ?url query. ... ok
Extract browser label name. ... ok
POST without bogus signature on labeler webhook is forbidden. ... ok
POST with event not being 'issues' or 'ping' fails. ... ok
POST without signature on labeler webhook is forbidden. ... ok
POST with action different of opened fails. ... ok
GET is forbidden on labeler webhook. ... ok
POST with PING events just return a 200 and contains pong. ... ok

----------------------------------------------------------------------
Ran 55 tests in 6.471s

OK
```

or for just testing the webhook.

```
nosetests --verbosity=2 --nocapture tests/test_webhook.py
```