### PR TITLE
Fixes #1571 - image dnd

### DIFF
--- a/webcompat/static/css/development/components/upload-form.css
+++ b/webcompat/static/css/development/components/upload-form.css
@@ -38,7 +38,9 @@
   }
 
     /* state */
-    .wc-UploadForm-wrapper.is-hidden {
+    .wc-UploadForm-wrapper.is-hidden,
+    .wc-UploadForm-icon.is-hidden,
+    .wc-UploadForm-label.is-hidden {
       display: none;
     }
 

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -410,13 +410,13 @@ function BugForm() {
 
     // hide upload image errors (this will no-op if the user never saw one)
     $(".wc-Form-helpMessage--imageUpload").remove();
-// TODO do not understand need
-    //$(".wc-UploadForm-label").show();
+    $(".wc-UploadForm-label").show();
 
     removeBanner.removeClass("is-hidden");
     removeBanner.attr("tabIndex", "0");
     uploadIcon.addClass("is-hidden");
     uploadLabel.addClass("is-hidden");
+    uploadLabel.hide();
     //uploadWrapper.addClass("is-hidden");
     removeBanner.on(
       "click",
@@ -427,6 +427,7 @@ function BugForm() {
         removeBanner.attr("tabIndex", "-1");
         uploadIcon.removeClass("is-hidden");
         uploadLabel.removeClass("is-hidden");
+        uploadLabel.show();
         //uploadWrapper.removeClass("is-hidden");
         removeBanner.off("click");
 

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -405,14 +405,19 @@ function BugForm() {
   this.showRemoveUpload = function(label) {
     var removeBanner = $(".wc-UploadForm-button");
     var uploadWrapper = $(".wc-UploadForm-wrapper");
+    var uploadIcon = $(".wc-UploadForm-icon");
+    var uploadLabel = $(".wc-UploadForm-label");
 
     // hide upload image errors (this will no-op if the user never saw one)
     $(".wc-Form-helpMessage--imageUpload").remove();
-    $(".wc-UploadForm-label").show();
+// TODO do not understand need
+    //$(".wc-UploadForm-label").show();
 
     removeBanner.removeClass("is-hidden");
     removeBanner.attr("tabIndex", "0");
-    uploadWrapper.addClass("is-hidden");
+    uploadIcon.addClass("is-hidden");
+    uploadLabel.addClass("is-hidden");
+    //uploadWrapper.addClass("is-hidden");
     removeBanner.on(
       "click",
       _.bind(function() {
@@ -420,7 +425,9 @@ function BugForm() {
         label.css("background", "none");
         removeBanner.addClass("is-hidden");
         removeBanner.attr("tabIndex", "-1");
-        uploadWrapper.removeClass("is-hidden");
+        uploadIcon.removeClass("is-hidden");
+        uploadLabel.removeClass("is-hidden");
+        //uploadWrapper.removeClass("is-hidden");
         removeBanner.off("click");
 
         // remove the last embedded image URL

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -498,8 +498,13 @@ function BugForm() {
       img_url,
       ")"
     ].join("");
+    var delimeter = "[![Screenshot Description](";
     this.descField.val(function(idx, value) {
-      return value + "\n\n" + imageURL;
+      if (value.includes(delimeter)) {
+        return value.split(delimeter)[0] + "\n\n" + imageURL;
+      } else {
+        return value + "\n\n" + imageURL;
+      }
     });
   };
   /*


### PR DESCRIPTION
placeholder: this code is not ready to merge; it has only been pushed as a point of reference for conversation about how to approach the issue solution; explanation why the requested change is non trivial and breaks some existing functionality and design (which already works pretty well)

ref:
[note to self] possible tech to update drag and drop response:
* https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
  * add a drop file handler to outermost label
* https://developer.mozilla.org/en-US/docs/Web/API/File
* https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer

@zoepage I'm sharing a partial fix for #1571. I'm unclear how to move forward because making the requested changes (upload a second image to replace existing) breaks existing functionality and design.

previously the developer designed the file input control to have 2 specific states:
* empty: no image uploaded; the user can upload via dnd or open file dialog
* filled: image is uploaded; the control is not interactive (the whole section is hidden) until the image is removed by the Remove image upload button

in the pr code, I have the fix so you can now upload a second image (replacing the first) but this change now causes the input to have mixed state (some aspects of empty state from above are true and some aspects of filled state from above are true too). I think the original design to have 2 distinct states is better.

I'm not sure how to move forward. should the original developer have input as to how to fix this? do I need to go through an approval process to redesign how the input works? I do not know who to ask questions for this to get unstuck. thanks