### PR TITLE
Fix #1592 - Add priority labels for ranking

### DIFF
--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -150,15 +150,17 @@ issues.LabelEditorView = Backbone.View.extend({
     }
   },
   updateView: function(evt) {
-    // We try to make sure only one "status"-type label is set
-    // If the change event comes from a "status"-type label,
-    // enumerate all checked "status"-type labels and uncheck
+    // We try to make sure only one "status" or "priority"-type label is set
+    // If the change event comes from a "status" or "priority"-type label,
+    // enumerate all checked "status" or "priority"-type labels and uncheck
     // the others.
     var checked;
+    var remotename = $(evt.target).data("remotename");
     if (
-      $(evt.target).data("remotename").match(/^status/) && evt.target.checked
+      remotename.match(/^(status|priority)/) && evt.target.checked
     ) {
-      checked = $('input[type=checkbox][data-remotename^="status"]:checked');
+      var prefix = remotename.split("-")[0];
+      checked = $('input[type=checkbox][data-remotename^="' + prefix + '"]:checked');
       _.each(checked, function(item) {
         if (item !== evt.target) {
           item.checked = false;

--- a/webcompat/static/js/lib/models/label-list.js
+++ b/webcompat/static/js/lib/models/label-list.js
@@ -24,7 +24,7 @@ var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 issues.LabelList = Backbone.Model.extend({
   initialize: function() {
-    this.set("namespaceRegex", /(browser|closed|os|status)-(.+)/i);
+    this.set("namespaceRegex", /(browser|closed|os|priority|status)-(.+)/i);
     // Temporarily set pagination to 100 labels per page, until
     // we fix Issue #781
     this.set("defaultLabelURL", "/api/issues/labels?per_page=100");


### PR DESCRIPTION
1. Whitelist "priority"-prefix label in label-list.js
2. Only one "priority"-prefix label is checked in labels.js
   Extend "status"-prefix label's implementation

r?= @miketaylr or you could suggest others to review :)