### PR TITLE
Fixes #1613. Check form validation in image upload success handler.

### DIFF
--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -454,7 +454,7 @@ function BugForm() {
       success: _.bind(function(response) {
         this.addImageURL(response);
         this.uploadLoader.removeClass("is-active");
-        this.enableSubmits();
+        this.checkForm();
       }, this),
       error: _.bind(function(response) {
         var msg;


### PR DESCRIPTION
Blindly enabling them is bad. >_<

r? @cch5ng (this shouldn't create conflicts for you, AFAICT!)