### PR TITLE
image dnd change [not ready to merge]

### DIFF
--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -47,6 +47,7 @@ function BugForm() {
   this.uploadField = this.inputs.image.el;
   this.urlField = this.inputs.url.el;
   this.descField = $("#description");
+  this.uploadLabel = $(".wc-UploadForm");
 
   this.init = function() {
     this.checkParams();
@@ -55,6 +56,8 @@ function BugForm() {
     this.urlField.on("blur input", _.bind(this.checkURLValidity, this));
     this.descField.on("focus", _.bind(this.checkProblemTypeValidity, this));
     this.problemType.on("change", _.bind(this.checkProblemTypeValidity, this));
+    this.uploadLabel.on("drop", _.bind(this.handleImageDrop, this));
+    this.uploadLabel.on("dragover", _.bind(this.handleImageDrag, this));
     this.uploadField.on("change", _.bind(this.checkImageTypeValidity, this));
     this.osField
       .add(this.browserField)
@@ -90,6 +93,40 @@ function BugForm() {
       false
     );
   };
+
+// test
+  this.handleImageDrop = function(ev) {
+    console.log('image was dropped');
+//    console.log('ev.target.value: ' + ev.target.value);
+
+//TODO get attribute for style if string value includes "url" then filled
+    if (this.uploadLabel.value.length) {
+      ev.preventDefault();
+    }
+    // If dropped items aren't files, reject them
+    var dt = ev.dataTransfer;
+    if (dt.items) {
+      // Use DataTransferItemList interface to access the file(s)
+      for (var i=0; i < dt.items.length; i++) {
+        if (dt.items[i].kind == "file") {
+          var f = dt.items[i].getAsFile();
+          console.log("... file[" + i + "].name = " + f.name);
+        }
+      }
+    } else {
+      // Use DataTransfer interface to access the file(s)
+      for (var i=0; i < dt.files.length; i++) {
+        console.log("... file[" + i + "].name = " + dt.files[i].name);
+      }  
+    }
+
+  }
+
+// test
+  this.handleImageDrag = function(ev) {
+    console.log('image was dragged');
+    ev.preventDefault();
+  }
 
   this.resampleIfNecessaryAndUpload = function(screenshotData) {
     // The final size of Base64-encoded binary data is ~equal to

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -94,38 +94,40 @@ function BugForm() {
     );
   };
 
-// test
+// test #1571
   this.handleImageDrop = function(ev) {
-    console.log('image was dropped');
-//    console.log('ev.target.value: ' + ev.target.value);
+    console.log('start drop event')
 
-//TODO get attribute for style if string value includes "url" then filled
-    if (this.uploadLabel.value.length) {
+    var imageFilled = false;
+    if ($('.wc-UploadForm-wrapper.is-hidden').length) {
+      console.log('image is filled')
+      imageFilled = true;
+    }
+    if (imageFilled) {
+      console.log('want to prevent image drop')
       ev.preventDefault();
-    }
-    // If dropped items aren't files, reject them
-    var dt = ev.dataTransfer;
-    if (dt.items) {
-      // Use DataTransferItemList interface to access the file(s)
-      for (var i=0; i < dt.items.length; i++) {
-        if (dt.items[i].kind == "file") {
-          var f = dt.items[i].getAsFile();
-          console.log("... file[" + i + "].name = " + f.name);
-        }
-      }
     } else {
-      // Use DataTransfer interface to access the file(s)
-      for (var i=0; i < dt.files.length; i++) {
-        console.log("... file[" + i + "].name = " + dt.files[i].name);
-      }  
+      console.log('want to allow image drop')
+      console.log('image was dropped');
     }
-
   }
 
-// test
+// test #1571
   this.handleImageDrag = function(ev) {
-    console.log('image was dragged');
-    ev.preventDefault();
+    console.log('start drag event');
+
+    var imageFilled = false;
+    if ($('.wc-UploadForm-wrapper.is-hidden').length) {
+      console.log('image is filled')
+      imageFilled = true;
+    }
+    if (imageFilled) {
+      console.log('want to prevent image drop (from drag)')
+      ev.preventDefault();
+    } else {
+      console.log('want to allow image drop (from drag)')
+    }
+
   }
 
   this.resampleIfNecessaryAndUpload = function(screenshotData) {


### PR DESCRIPTION
not ready to merge, the branch is used to discuss approaches to solve #1571
(also a continuation of thoughts from #1593); branch version increased b/c it is based on a more recent master...

(update 062517) high level paths to approach #1571 
* plan A: use html drag and drop api to put drop event listener on the label wrapper (around the image input + input label); hopefully get the file info and be able to replace an existing input image file
  * plan A first choice route:
    * use combo of html drag and drop + file reader api
    * for 2nd image dnd event, want to get the new file uri (there is an existing function for this) => (update 062817, unfortunately it appears impossible to both accept the 2nd drag/drop action and get the 2nd file uri)
    * for 2nd image dnd event, want to prevent replacing the browser url with the new image file url/uri
    * want to replace the existing image with the newly dropped image programmatically (ie not via the normal drag/drop response)
  * plan A, second choice route (local branch issues/1571/3): there is a quick partial fix available that disables dragging a 2nd image altogether; it doesn't replace the first image but it also doesn't replace the app view with just a new image url in the browser
* plan B: support 2nd image drag and drop (prefer to avoid this because requires breaking a lot of existing functionality/design)

@zoepage in this latest version, there is a proof of concept for partial fix. html dnd api could be used to prevent the behavior where the second image drag and drop event replaces the entire site. instead, the 2nd image dnd will do nothing (the first image will remain in place). in this scenario the user would need to remove the first image using the remove button and then could drag another image over.

note that preventDefault() had to be applied to both target label's drop and dragover events in order for this partial fix to work. but on initial view html dnd is still not simple for the requested behavior to replace an existing image with 2nd image dnd (it is still hard to get the dropped file info but I haven't looked much into referenced file api too).

coverage for modern desktop browsers looks pretty good. mobile browsers not so much (but I assume that is ok?)

to enable the behavior of replacing an existing image with 2nd image dnd event requires more work and breaks existing design/functionality to do so.

this code requires refactoring and I left in commented console statements (commented due to the linter errors).

reference:
https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
http://caniuse.com/dragndrop/embed/eras=-4,2
