### PR TITLE
#1565 update issues link to filter out type-media github issues [not ready to merge]

### DIFF
--- a/webcompat/templates/shared/shared-nav-links.html
+++ b/webcompat/templates/shared/shared-nav-links.html
@@ -3,7 +3,7 @@
   <span class="wc-Navbar-link-label">Contribute</span>
 </a>
 <a class="wc-Navbar-link js-issues-link"
-    href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc"
+    href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=-label%3Atype-media"
 >
   <span class="wc-Navbar-link-icon wc-Icon wc-Icon--list" aria-hidden="true"></span>
   <span class="wc-Navbar-link-label">All issues</span>


### PR DESCRIPTION
hmmm, (update 070617), I think the hack is actually broken. I will rethink and retest and come back with better info.

---

this is just a quick hackey initial fix

it might not get used as I believe #1551 is planned to be closed after talking with the media group. but perhaps this logic might be useful later on.

caveats:
* this only affects the issues list from the All Issues nav link
* it results in some prefilled text in the Search input field; but it still allows the user to add more search filter text
* it only works if the user is logged into github
* cases where the filter is not applied (not sure where to find the code right before the api get is made)
  * index.html (triage list + when you search from index.html)
    * probably when you click the View all link from the triage list area
  * my activity page

---
update: as I believe this is a low priority issue, I will put it on the backburner and continue to think and investigate the code to make a cleaner fix. but will probably be working on other issues first starting from this week.