### PR TITLE
Fixes #1656 - adding `npm test`to package.json

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -68,6 +68,16 @@ In a separate terminal window or tab, run the tests:
 
 ```bash
 node_modules/.bin/intern-runner config=tests/intern
+
+or
+
+npm run test:js
+```
+
+You can also run the functional tests as well as the python tests in a seperate tab, after starting the server with:
+
+```
+npm test
 ```
 
 Shortly after running this command, you should see the browser open and various pages appear and disappear automatically for a minute or two. The tests are complete when the browser window closes and you see a report of how many passed or failed in the terminal window that you ran the `intern-runner` command in.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -9,7 +9,13 @@
 
 You can run the Python unit tests from the project root with the `nosetests` command.
 
-Running functional tests is a bit more involved (see the next section).
+You can also run them with following:
+
+```
+npm run test:python
+```
+
+Running functional tests is a bit more involved. You can also run both test suites at once (see the next section).
 
 Tests are also run automatically on [Travis](https://travis-ci.org/webcompat/webcompat.com) for each commit. If you would like to skip running tests for a given commit, you can use use the magical `[ci skip]` string in your commit message. See the [Travis docs](http://docs.travis-ci.com/user/how-to-skip-a-build/#Not-All-Commits-Need-CI-Builds) for more info.
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
     "pip": "pip install -r config/requirements.txt",
     "config": "cp config/secrets.py.example config/secrets.py",
     "project-update": "pip install --upgrade pip && npm update",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "test": "npm run test:js && npm run test:python",
+    "test:js": "node_modules/.bin/intern-runner config=tests/intern",
+    "test:python": "nosetests"
   },
   "lint-staged": {
     "*.js": "lint:JS",


### PR DESCRIPTION
To make the test runner command easier to remember, I've made `npm test` available.

`npm test` runs both test suites.
`npm run test:js` runs functional tests.
`npm run test:python` runs python tests.

I've also updated the docs. 


r? @miketaylr && @brizental 