### PR TITLE
Fixes #1704 - Fixes Safari testing failures.

### DIFF
--- a/tests/functional/comments-auth.js
+++ b/tests/functional/comments-auth.js
@@ -134,25 +134,42 @@ define(
       },
 
       "Add a screenshot to a comment": function() {
-        return FunctionalHelpers.openPage(
+        var remote = FunctionalHelpers.openPage(
           this,
           url("/issues/100"),
-          ".wc-Comment-body"
-        )
-          .findById("image")
-          .type("tests/fixtures/green_square.png")
-          .sleep(1000)
-          .end()
-          .findByCssSelector(".js-Comment-text")
-          .getProperty("value")
-          .then(function(val) {
-            assert.include(
-              val,
-              "[![Screenshot Description](http://localhost:5000/uploads/",
-              "The image was correctly uploaded and its URL was copied to the comment text."
-            );
-          })
-          .end();
+          ".wc-Comment-body",
+            true
+          );
+          return (
+            remote
+              // Find image upload input.
+              .findById("image")
+              .then(function(el) {
+                el
+                  // Type fixture image path into it.
+                  .type(require.toUrl("../fixtures/green_square.png"))
+                  .then(function() {
+                    remote
+                      .end()
+                      // Find the comment textarea.
+                      .findByCssSelector(".js-Comment-text")
+                      .then(function(el) {
+                        el
+                          // Get it's value.
+                          .getProperty("value")
+                          .then(function(val) {
+                            // Check that the value is what expected.
+                            assert.include(
+                              val,
+                              "[![Screenshot Description](http://localhost:5000/uploads/",
+                              "The image was correctly uploaded and its URL was copied to the comment text."
+                            );
+                          });
+                      });
+                  });
+              })
+              .end()
+          );
       },
 
       "Pressing 'g' inside of comment textarea *doesn't* go to github issue": function() {

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -48,6 +48,10 @@ define(["intern"], function(intern, topic) {
       {
         browserName: "chrome",
         marionette: true
+      },
+      {
+        browserName: "safari",
+        marionette: true
       }
     ],
 


### PR DESCRIPTION
r? @miketaylr 

This is not ready for merge, it's just an example of the way I found out to fix Safari testing issues.

So, I realized that most of the Safari issues that I have been getting are Promises that don't finish in time (maybe all of them are, but I'm not yet sure). So I just applied the method I thought about when trying to fix #1470 . I think maybe this has something to do with the way Safari handles promises, and since Intern.js is all promises, that could be an issue. I'll look into it and edit here later.

It works, but the code gets kinda confusing. It's what I was talking about when I mentioned callback hell in #1470 lol.