### PR TITLE
Fixes #1730 - Removes the GitHub link from issues list

### DIFF
--- a/webcompat/templates/list-issue/issuelist-issue.jst
+++ b/webcompat/templates/list-issue/issuelist-issue.jst
@@ -57,10 +57,4 @@
      </ul>
   </div>
 <% } %>
-<p>
-  <a class="wc-Link wc-GithubLink" href="https://github.com/{{ config['ISSUES_REPO_URI'] }}/{{ number }}"><span class="wc-GithubLink-Icon"></span>View issues on Github</a>
-</p>
-<p>
-  <span class="wc-GithubLink-DesktopOnly">Shortcut: Press <b>g</b> on your keyboard to be taken to the GitHub view of this page.</span>
-</p>
 </script>


### PR DESCRIPTION
This is a quick fix following the discussion in #1730.
I opened "Add github view to the search results" #1732 to properly reinstate it.

@miketaylr r?