### PR TITLE
Fixes #1631 - Warns user and aborts tests if server isn't right or if it's not in test mode.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "env": {
     "browser": true
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "module": "git submodule init && git submodule update",
     "prestart": "npm run build",
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
-    "start:test": "source env/bin/activate || . env/bin/activate && python run.py -t",
+    "start:test": "npm run build && source env/bin/activate || . env/bin/activate && python run.py -t",
     "virtualenv": "pip install virtualenv && virtualenv env && source env/bin/activate || . env/bin/activate && npm run pip",
     "pip": "pip install -r config/requirements.txt",
     "config": "cp config/secrets.py.example config/secrets.py",

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -5,17 +5,11 @@
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
 // packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
-define(["intern"], function(intern, topic) {
+
+define(["intern"], function(intern) {
   "use strict";
   var args = intern.args;
   var siteRoot = args.siteRoot ? args.siteRoot : "http://localhost:5000";
-
-  if (topic) {
-    topic.subscribe("/suite/start", function(suite) {
-      /* eslint-disable no-console*/
-      console.log("Running: " + suite.name);
-    });
-  }
 
   return {
     // Configuration object for webcompat
@@ -23,6 +17,21 @@ define(["intern"], function(intern, topic) {
       pageLoadTimeout: args.wcPageLoadTimeout
         ? parseInt(args.wcPageLoadTimeout, 10)
         : 10000
+    },
+
+    setup: function() {
+      define("FunctionalHelpers", ["tests/functional/lib/helpers"], function(
+        FunctionalHelpers
+      ) {
+        return {
+          checkServer: FunctionalHelpers.checkServer
+        };
+      });
+      var serverPromise;
+      require(["FunctionalHelpers"], function(FunctionalHelpers) {
+        serverPromise = FunctionalHelpers.checkServer();
+      });
+      return serverPromise;
     },
 
     // The port on which the instrumenting proxy will listen
@@ -33,7 +42,7 @@ define(["intern"], function(intern, topic) {
     siteRoot: siteRoot,
     tunnel: "SeleniumTunnel",
     tunnelOptions: {
-      // this tells SeleniumTunnel to download geckodriver
+      // this tells SeleniumTunnel to download geckodriver and chromedriver
       drivers: ["firefox", "chrome"]
     },
 


### PR DESCRIPTION
So, to check that the server is in test mode, I make a request to our API and check that it's returning fixture data. This took a little while longer, because I had to find a workaround to add external modules to the `intern.js` config file, since you can't add them as you would on the test suites, because it's not loaded as an AMD module. I don't feel that my solution looks very good, but it works and I asked in the intern Gitter chat and the guys said it was a fine way to do it.

Anyways, I also removed code to login with real data to GitHub. I know that @miketaylr was kind of against it, but I found out that we actually removed the code that did that in #1604 , so it didn't work anyways... I think we could just open a new issue for that if you guys think it's necessary to have the option to test without fixture data. 

I also removed the `visibleByClass` method, because it wasn't used anywhere and Leadfoot has a similar method ([findDisplayedByClassName](https://theintern.io/leadfoot/module-leadfoot_Command.html#findDisplayedByClassName)).

Lastly, I noticed that when you start the server in non-test mode it runs grunt before starting the server, but not in test mode. So I fixed that.

Hope it's alright to add all this to the same PR. I didn't think it was necessary to open new issues for these things.

r? @miketaylr @zoepage 