### PR TITLE
Fixes #1751 - Remove status-needstriage label in webhook

### DIFF
--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -106,9 +106,8 @@ def new_opened_issue(payload):
     '''When a new issue is opened, we set a couple of things.
 
     - Browser label
-    - status-needstriage
     '''
-    labels = ['status-needstriage']
+    labels = []
     issue_body = payload.get('issue')['body']
     issue_number = payload.get('issue')['number']
     browser_label = extract_browser_label(issue_body)


### PR DESCRIPTION
Use milestone to replace status-* so don't use webhook to add
status-needstriage when new issue created.