### PR TITLE
Fixes #1754 - Handle color schemes for milestones

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -25,18 +25,18 @@ LOCALHOST = not PRODUCTION and not STAGING
 # BUG STATUS
 # The id will be initialized when the app is started.
 STATUSES = {
-    u'needstriage': {'id': 0, 'order': 1, 'state': 'open', 'color': ''},
-    u'needsdiagnosis': {'id': 0, 'order': 2, 'state': 'open', 'color': ''},
-    u'needscontact': {'id': 0, 'order': 3, 'state': 'open', 'color': ''},
-    u'contactready': {'id': 0, 'order': 4, 'state': 'open', 'color': ''},
-    u'sitewait': {'id': 0, 'order': 5, 'state': 'open', 'color': ''},
-    u'duplicate': {'id': 0, 'order': 1, 'state': 'closed', 'color': ''},
-    u'fixed': {'id': 0, 'order': 2, 'state': 'closed', 'color': ''},
-    u'incomplete': {'id': 0, 'order': 3, 'state': 'closed', 'color': ''},
-    u'invalid': {'id': 0, 'order': 4, 'state': 'closed', 'color': ''},
-    u'non-compat': {'id': 0, 'order': 5, 'state': 'closed', 'color': ''},
-    u'wontfix': {'id': 0, 'order': 6, 'state': 'closed', 'color': ''},
-    u'worksforme': {'id': 0, 'order': 7, 'state': 'closed', 'color': ''}
+    u'needstriage': {'id': 0, 'order': 1, 'state': 'open', 'color': '#ff9900'},
+    u'needsdiagnosis': {'id': 0, 'order': 2, 'state': 'open', 'color': '#ff8364'},
+    u'needscontact': {'id': 0, 'order': 3, 'state': 'open', 'color': '#e11d21'},
+    u'contactready': {'id': 0, 'order': 4, 'state': 'open', 'color': '#a1ebbf'},
+    u'sitewait': {'id': 0, 'order': 5, 'state': 'open', 'color': '#006b75'},
+    u'duplicate': {'id': 0, 'order': 1, 'state': 'closed', 'color': '#cccccc'},
+    u'fixed': {'id': 0, 'order': 2, 'state': 'closed', 'color': '#009800'},
+    u'incomplete': {'id': 0, 'order': 3, 'state': 'closed', 'color': '#d93f0b'},
+    u'invalid': {'id': 0, 'order': 4, 'state': 'closed', 'color': '#e6e6e6'},
+    u'non-compat': {'id': 0, 'order': 5, 'state': 'closed', 'color': '#b60205'},
+    u'wontfix': {'id': 0, 'order': 6, 'state': 'closed', 'color': '#000000'},
+    u'worksforme': {'id': 0, 'order': 7, 'state': 'closed', 'color': '#d4c5f9'}
     }
 
 # We don't need to compute for every requests.


### PR DESCRIPTION
Basically re-use current color schemes from webcompat.com/web-bugs/labels.
For non-compat milestone, use type-flash and nsfw one. r?=@karlcow