### PR TITLE
Fixes #1836 - Moves initialization of milestones status to config

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-'''This module handles application configuration and secrets.'''
+"""This module handles application configuration and secrets."""
 
 from collections import namedtuple
 import json

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -7,9 +7,64 @@
 '''This module handles application configuration and secrets.'''
 
 from collections import namedtuple
+import json
+import os
+import sys
+import urlparse
 
-from environment import *
-from secrets import *
+import requests
+
+from environment import *  # nopep8
+from secrets import *  # nopep8
+
+
+def initialize_status():
+    """Map the status name with the milestone id on GitHub.
+
+    The project needs the mapping in between milestones and their id
+    to be able to query status related things. It uses a backup version
+    when the request to GitHub fails.
+    """
+    print('Statuses Initialization…')
+    REPO_ROOT = ISSUES_REPO_URI.rpartition('/issues')[0]
+    milestones_url_path = os.path.join('repos', REPO_ROOT, 'milestones')
+    milestones_url = urlparse.urlunparse(
+        ('https', 'api.github.com', milestones_url_path, '', '', ''))
+    milestones_path = os.path.join(DATA_PATH, 'milestones.json')
+    try:
+        # Get the milestone from the network
+        print('Fetching milestones from Github…')
+        r = requests.get(milestones_url)
+        milestones_content = r.content
+        if r.status_code == 200:
+            with open(milestones_path, 'w') as f:
+                f.write(r.content)
+            print('Milestones saved in data/')
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        # Not working, let's use the cached copy
+        # This might fail the first time.
+        print(MILESTONE_ERROR.format(msg=error))
+        with open(milestones_path, 'r') as f:
+            milestones_content = f.read()
+    finally:
+        # save in data/ the current version
+        if milestones_content:
+            app.config['STATUSES'] = convert_milestones(milestones_content)
+            app.config['JSON_STATUSES'] = json.dumps(app.config['STATUSES'])
+            print('Milestones in memory')
+            return True
+        else:
+            return False
+
+
+def convert_milestones(milestones_content):
+    """Convert the JSON milestones from GitHub to a simple dict."""
+    milestone_full = json.loads(milestones_content)
+    for milestone in milestone_full:
+        STATUSES[milestone['title']]['id'] = milestone['number']
+    return STATUSES
+
 
 THREADS_PER_PAGE = 8
 
@@ -67,3 +122,8 @@ EXTRA_LABELS = [
     'type-webvr',
     'type-stylo'
 ]
+
+from webcompat import app
+# We need the milestones
+if not initialize_status():
+    sys.exit('Milestones are not initialized.')

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -13,9 +13,11 @@ from flask_github import GitHub
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
+# Define the application
 app = Flask(__name__, static_url_path='')
-app.config.from_object('config')
 
+# Configurations
+app.config.from_object('config')
 # set limit of 5.5MB for file uploads
 # in practice, this is ~4MB (5.5 / 1.37)
 # after the data URI is saved to disk


### PR DESCRIPTION
The milestones were in run.py which is visible only for people developing the project on local. We moved to the config file so that the application is aware of the milestone if started directly from the app. 

You can test this with on the shell. 

```
export FLASK_APP=/Users/karl/code/webcompat.com/webcompat/__init__.py
flask run
```
This is equivalent of what uwsgi would do. 

unittests are all good.

```
→ nosetests
................................................................
----------------------------------------------------------------------
Ran 64 tests in 4.019s

OK
```

r? @miketaylr 