### PR TITLE
Fixes #1851. Add milestone for new issues via our new issue webhook.

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -110,12 +110,12 @@ class TestForm(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_build_formdata(self):
-        """The data body sent to GitHup API."""
+        """The data body sent to GitHub API."""
         form_object = {'foo': 'bar'}
         actual = form.build_formdata(form_object)
 
         # we just need to test that nothing breaks
         # even if the data are empty
-        expected = {'body': u'<!-- @browser: None -->\n<!-- @ua_header: None -->\n<!-- @reported_with: None -->\n\n**URL**: None\n\n**Browser / Version**: None\n**Operating System**: None\n**Tested Another Browser**: Unknown\n\n**Problem type**: Unknown\n**Description**: None\n**Steps to Reproduce**:\nNone\n\n\n\n_From [webcompat.com](https://webcompat.com/) with \u2764\ufe0f_', 'milestone': 1, 'title': 'None - unknown'}  # nopep8
+        expected = {'body': u'<!-- @browser: None -->\n<!-- @ua_header: None -->\n<!-- @reported_with: None -->\n\n**URL**: None\n\n**Browser / Version**: None\n**Operating System**: None\n**Tested Another Browser**: Unknown\n\n**Problem type**: Unknown\n**Description**: None\n**Steps to Reproduce**:\nNone\n\n\n\n_From [webcompat.com](https://webcompat.com/) with \u2764\ufe0f_', 'title': 'None - unknown'}  # nopep8
         self.assertIs(type(actual), dict)
         self.assertEqual(actual, expected)

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -244,8 +244,7 @@ def build_formdata(form_object):
             image_url=form_object.get('image_upload').get('url'))
     # Append "from webcompat.com" message to bottom (for GitHub issue viewers)
     body += u'\n\n{0}'.format(GITHUB_HELP)
-    rv = {'title': summary, 'body': body,
-          'milestone': app.config['STATUSES']['needstriage']['id']}
+    rv = {'title': summary, 'body': body}
     extra_label = form_object.get('label', None)
     if extra_label and extra_label in app.config['EXTRA_LABELS']:
         rv.update({'labels': [extra_label]})

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -19,7 +19,6 @@ from helpers import extract_priority_label
 from helpers import is_github_hook
 from helpers import get_issue_info
 from helpers import new_opened_issue
-from helpers import set_labels
 from helpers import signature_check
 
 from webcompat import app

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -143,4 +143,6 @@ def new_opened_issue(payload):
         labels.append(browser_label)
     if priority_label:
         labels.append(priority_label)
-    return set_labels(labels, issue_number)
+    milestone = app.config['STATUSES']['needstriage']['id']
+    return update_issue({'labels': labels, 'milestone': milestone},
+                        issue_number)

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -39,18 +39,20 @@ def extract_browser_label(body):
         return None
 
 
-def set_labels(payload, issue_number):
-    """Does a GitHub POST request to set a label for the issue.
+def update_issue(payload, issue_number):
+    """Does a GitHub PATCH request to set labels and milestone for the issue.
 
-    POST /repos/:owner/:repo/issues/:number/labels
-    ['Label1', 'Label2']
+    PATCH /repos/:owner/:repo/issues/:number
+    {
+        "milestone": 2,
+        "labels": ['Label1', 'Label2']
+    }
     """
     headers = {
         'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])
     }
-    path = 'repos/{0}/{1}/labels'.format(
-        app.config['ISSUES_REPO_URI'], issue_number)
-    return proxy_request('post', path,
+    path = 'repos/{0}/{1}'.format(app.config['ISSUES_REPO_URI'], issue_number)
+    return proxy_request('patch', path,
                          headers=headers,
                          data=json.dumps(payload))
 

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -133,6 +133,8 @@ def new_opened_issue(payload):
     '''When a new issue is opened, we set a couple of things.
 
     - Browser label
+    - Priority label
+    - Issue milestone
     '''
     labels = []
     issue_body = payload.get('issue')['body']


### PR DESCRIPTION
Otherwise, this will fail for non-anonymous users, unless they are repo collaborators.

Note: I didn't change the name of the `/labeler` webhook. If someone feels strongly about that, please file a followup issue. Something like `/newissue` would make more sense.

r? @karlcow 
r? @zoepage 

(Note: I tested this on staging (after I removed basic auth so the webhook would work))