### PR TITLE
Issue #1882 - Whitelist webcompat.github.io in the CSP

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -490,13 +490,13 @@ def add_csp(response):
     added to all responses.'''
     response.headers['Content-Security-Policy'] = (
         "default-src 'self'; " +
-        "object-src 'none'; " +
+        "object-src https://webcompat.github.io; " +
         "connect-src 'self' https://api.github.com; " +
         "font-src 'self'; " +
-        "img-src 'self' https://www.google-analytics.com https://*.githubusercontent.com data:; " +  # nopep8
+        "img-src 'self' https://www.google-analytics.com https://*.githubusercontent.com https://webcompat.github.io data:; " +  # nopep8
         "manifest-src 'self'; " +
         "script-src 'self' https://www.google-analytics.com https://api.github.com; " +  # nopep8
-        "style-src 'self' 'unsafe-inline'; " +
+        "style-src 'self' 'unsafe-inline' https://webcompat.github.io; " +
         "report-uri /csp-report"
     )
 


### PR DESCRIPTION
As discussed, this is temporary and will be reverted before releasing the refactored changes.

We want to embed SVGs and CSS files from the design repo. Since SVGs can be both an object and an image, depending on their use, I added both image and object src rules, as well as style white-list entries.

Submitting this PR against `refactor` as a base, since we have no intentions of releasing this to production, and it will only be useful during the refactoring work.

r? @miketaylr 