### PR TITLE
Issue #1891. Port the report form to the new style.

### DIFF
--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -52,11 +52,10 @@ radio_message = u'Problem type required.'
 username_message = u'A valid username must be {0} characters long'.format(
     random.randrange(0, 99))
 
-desc_label = (u'Please describe what was wrong'
-              u' <span class="wc-Form-required">*</span>')
+desc_label = u'Please describe what was wrong'
 desc_message = u'An issue description is required.'
 
-url_label = u'Site URL <span class="wc-Form-required">*</span>'
+url_label = u'Site URL'
 browser_test_label = u'Did you test in another browser?'
 textarea_label = u'What steps did you take before this problem occurred?'
 

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -259,7 +259,7 @@ issues.ImageUploadView = Backbone.View.extend({
 
     this.inputMap[id].valid = false;
     $(this.inputMap[id].elm)
-      .parents(".wc-Form-group")
+      .parents(".js-Form-group")
       .removeClass("wc-Form-noError js-no-error")
       .addClass("wc-Form-error js-form-error");
 
@@ -272,12 +272,12 @@ issues.ImageUploadView = Backbone.View.extend({
   makeValid: function(id) {
     this.inputMap[id].valid = true;
     $(this.inputMap[id].elm)
-      .parents(".wc-Form-group")
+      .parents(".js-Form-group")
       .removeClass("wc-Form-error js-form-error")
       .addClass("wc-Form-noError js-no-error");
 
     $(this.inputMap[id].elm)
-      .parents(".wc-Form-group")
+      .parents(".js-Form-group")
       .find(".wc-Form-helpInline")
       .remove();
 

--- a/webcompat/templates/home-page/form.html
+++ b/webcompat/templates/home-page/form.html
@@ -1,166 +1,159 @@
-<section class="wc-UISection js-ReportForm wc-ReportForm {% if form.errors %}is-opened{% else %}is-closed{% endif %}"
-         id="js-ReportForm"
+<section
+  class="wc-UISection js-ReportForm wc-ReportForm {% if form.errors %}is-opened{% else %}is-closed{% endif %} grid"
+  id="js-ReportForm"
 >
-  <div class="wc-UIContent">
-    <form
-      class="wc-Form"
-      method="post"
-      enctype="multipart/form-data"
-      action="/issues/new"
-      novalidate
-    >
-      {%- if request.url_rule.endpoint == 'create_issue' %}
-      <h3 class="wc-Title--s">Report Site Issue</h3>
-      {%- endif %}
-      <div class="r-Grid r-Grid--withGutter">
-        <div class="r-Grid-cell r-minM--1of2">
-          <div class="wc-Form-group js-Form-group">
-            <div class="wc-Form-information">
-              {{ form.url.label(class_='wc-Form-label') }}
-              {% if form.url.errors %}
-                {% for error in form.url.errors %}
-                  <span class="wc-Form-helpMessage">{{ error }}</span>
-                {% endfor %}
-              {% endif %}
-            </div>
-            <span class="wc-Form-validation">
-            {{ form.url(class_='wc-Form-item required',
-               placeholder='e.g. https://example.com',
-               required=True, type='url', pattern='') }}
-            </span>
-          </div>
+  {%- if request.url_rule.endpoint == 'create_issue' %}
+    <h1 class="headline-1">Report Site Issue</h1>
+  {%- endif %}
 
-          <div class="wc-Form-group js-Form-group">
-            <fieldset class="{% if form.problem_category.errors %}is-error{% endif %}">
-              <div class="wc-Form-information">
-                <label class="wc-Form-label" for="problem_type">Type of bug <span class="wc-Form-required">*</span></label>
-                {% if form.problem_category.errors %}{% for error in form.problem_category.errors %}
-                <span class="wc-Form-helpMessage">{{ error }}</span>
-                {% endfor %}{% endif %}
-              </div>
-                {% for subradio in form.problem_category %}
-                <div class="wc-Form-radio">
-                  {{ subradio }} {{ subradio.label }}
-                </div>
-                {% endfor %}
-            </fieldset>
-          </div>
-
-          <div class="wc-Form-group js-Form-group">
-            <div class="wc-Form-information">
-              {{ form.description.label(class_='wc-Form-label') }}
-              {% if form.description.errors %}
-                {% for error in form.description.errors %}
-                  <span class="wc-Form-helpMessage">{{ error }}</span>
-                {% endfor %}
-              {% endif %}
-            </div>
-            <span class="wc-Form-validation">
-            {{ form.description(class_='wc-Form-item required',
-               placeholder="e.g. The video doesn't play",
-               required=True, type='text', pattern='') }}
-            </span>
-          </div>
-          <div class="wc-Form-group js-Form-group">
-            {{ form.steps_reproduce.label(class_='wc-Form-label') }}
-            {{ form.steps_reproduce(class_='wc-Form-item wc-Form-item--textarea',
-               rows=4,
-               placeholder="Please be as detailed as possible.") }}
-          </div>
+  <form
+    action="/issues/new"
+    class="form grid-row"
+    enctype="multipart/form-data"
+    method="post"
+    novalidate
+  >
+    <div class="grid-cell">
+      <div class="form-text form-element js-Form-group">
+        <div class="js-Form-information">
+          {{ form.url.label(class_='form-label form-required wc-Form-label') }}
+          {% if form.url.errors %}
+            {% for error in form.url.errors %}
+              <span class="wc-Form-helpMessage">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
         </div>
-        <div class="r-Grid-cell r-minM--1of2">
+        <span class="wc-Form-validation">
+          {{ form.url(class_='form-field text-field wc-Form-item required',
+             placeholder='e.g. https://example.com',
+             required=True, type='url', pattern='') }}
+        </span>
+      </div>
+      <div class="form-radio form-element js-Form-group">
+        <div class="js-Form-information">
+          <label class="form-label form-required wc-Form-label" for="problem_category">Type of bug</label>
+          {% if form.problem_category.errors %}
+            {% for error in form.problem_category.errors %}
+              <span class="wc-Form-helpMessage">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
+        </div>
 
-          <div class="wc-Form-group wc-Form-group--biggerOffset js-Form-group {% if form.url.errors %}is-error{% endif %}">
-            {{ form.browser.label(class_='wc-Form-label') }}
-            <span class="wc-Form-validation">
-            {{ form.browser(class_='wc-Form-item') }}
-            </span>
-            <span class="wc-Form-validation js-bug-form-os">
-            {{ form.os(class_='wc-Form-item') }}
-            </span>
+        {% for subradio in form.problem_category %}
+          {{ subradio(class_='input-radio') }}
+          {{ subradio.label(class_='form-label label-radio') }}
+        {% endfor %}
+      </div>
+      <div class="form-text form-element js-Form-group">
+        <div class="js-Form-information">
+          {{ form.description.label(class_='form-label form-required wc-Form-label') }}
+          {% if form.description.errors %}
+            {% for error in form.description.errors %}
+              <span class="wc-Form-helpMessage">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
+        </div>
+        <span class="wc-Form-validation">
+          {{ form.description(class_='form-field text-field wc-Form-item required',
+             placeholder="e.g. The video doesn't play",
+             required=True) }}
+        </span>
+      </div>
+      <div class="form-text form-element js-Form-group">
+        {{ form.steps_reproduce.label(class_='form-label wc-Form-label') }}
+        {{ form.steps_reproduce(class_='form-field text-field wc-Form-item',
+           rows=4,
+           placeholder="Please be as detailed as possible.") }}
+      </div>
+    </div>
+    <div class="grid-cell">
+      <div class="form-text form-element js-Form-group">
+        {{ form.browser.label(class_='wc-Form-label') }}
+        <span class="wc-Form-validation">
+          {{ form.browser(class_='form-field text-field wc-Form-item') }}
+          <span class="form-input-validation check"></span>
+        </span>
+        <span class="wc-Form-validation js-bug-form-os">
+          {{ form.os(class_='form-field text-field wc-Form-item') }}
+          <span class="form-input-validation error"></span>
+        </span>
+      </div>
+      <div class="form-radio form-element js-Form-group">
+        <div class="js-Form-information">
+          {{ form.browser_test.label(class_='wc-Form-label') }}
+          {% if form.browser_test.errors %}
+            {% for error in form.browser_test.errors %}
+              <span class="wc-Form-helpMessage">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
+        </div>
+        {% for subradio in form.browser_test %}
+          {{ subradio(class_='input-radio') }}
+          {{ subradio.label(class_='form-label label-radio') }}
+        {% endfor %}
+      </div>
+      <div class="form-upload form-element js-image-upload js-Form-group">
+        <label class="wc-UploadForm wc-UploadForm--homePage js-image-upload-label" for="image">
+          {{ form.image(class_='form-input input-upload wc-ButtonUpload', accept='.jpe,.jpg,.jpeg,.gif,.png,.bmp') }}
+          {% if form.image.errors %}
+            {% for error in form.image.errors %}
+            <span class="wc-Form-helpMessage--imageUpload">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
+          <div class="wc-UploadForm-wrapper">
+            <label class="form-label label-upload wc-UploadForm-label">
+              <svg class="icon icon-big wc-UploadForm-icon" role="presentation">
+                <use class="icon-upload" href="#svg-upload-2">Upload</use>
+              </svg>
+              Upload screenshot
+            </label>
           </div>
-
-          <div class="wc-Form-group js-Form-group">
-            <fieldset class="{% if form.browser_test.errors %}is-error{% endif %}">
-              <div class="wc-Form-information">
-                {{ form.browser_test.label(class_='wc-Form-label') }}
-                {% if form.browser_test.errors %}{% for error in form.browser_test.errors %}
-                <span class="wc-Form-helpMessage">{{ error }}</span>
-                {% endfor %}{% endif %}
-              </div>
-                <div class="wc-Form-radio">
-                {% for subradio in form.browser_test %}
-                  {{ subradio }} {{ subradio.label }}
-                {% endfor %}
-                </div>
-            </fieldset>
-          </div>
-
-            <div class="js-image-upload wc-Form-group js-Form-group {% if form.image.errors %}is-error{% endif %}">
-              <label
-                class="wc-UploadForm wc-UploadForm--homePage js-image-upload-label"
-                for="image"
-              >
-                <div class="wc-UploadForm-wrapper">
-                  <div class="wc-UploadForm-icon" aria-hidden="true">
-                    <span class="wc-Icon wc-Icon--cloud-upload"></span>
-                  </div>
-                  <label class="wc-UploadForm-label">Upload screenshot</label>
-                  {% if form.image.errors %}
-                    {% for error in form.image.errors %}
-                    <span class="wc-Form-helpMessage--imageUpload">{{ error }}</span>
-                    {% endfor %}
-                  {% endif %}
-                  {{ form.image(class_='wc-ButtonUpload', accept='.jpe,.jpg,.jpeg,.gif,.png,.bmp') }}
-                </div>
-                <button
-                  class="wc-UploadForm-button is-hidden r-ResetButton"
-                  role="button"
-                  type="button"
-                  tabindex="-1"
-                >
-                  <img
-                    class="wc-Upload-Loader js-Upload-Loader"
-                    src="/img/upload-loader.svg"
-                    alt="Uploading image"
-                  >
-                    Remove image upload
-                  </button>
-              </label>
-            </div>
-
-            <div class="wc-ReportForm-actions">
-              <div class="wc-ReportForm-actions-button">
-                <button name="submit-type"
-                        value="github-proxy-report"
-                        class="wc-Button wc-Button--default js-Button"
-                        id="submitanon"
-                >
-                        Report Anonymously
-                </button>
-                <button name="submit-type"
-                        value="github-auth-report"
-                        class="wc-Button wc-Button--action js-Button"
-                        id="submitgithub"
-                        type="submit"
-                >
-                  {% if session.username %}Report as {{ session.username }}{% else %}Report via GitHub{% endif %}
-                </button>
-              </div>
-            </div>
-          </div>
-
+          <button
+            class="wc-UploadForm-button is-hidden r-ResetButton"
+            role="button"
+            type="button"
+            tabindex="-1"
+          >
+            <img
+              class="wc-Upload-Loader js-Upload-Loader"
+              src="/img/upload-loader.svg"
+              alt="Uploading image"
+            >
+            Remove image upload
+          </button>
+        </label>
+      </div>
+      <div class="form-button form-element js-Form-group">
+        <button
+          class="button button-primary wc-Button wc-Button--default js-Button"
+          id="submitanon"
+          type="button"
+          value="github-proxy-report"
+        >
+          Report Anonymously
+        </button>
+        <button
+          class="button button-primary wc-Button wc-Button--default js-Button"
+          id="submitgithub"
+          name="submit-type"
+          type="submit"
+          value="github-auth-report"
+        >
+          {% if session.username %}Report as {{ session.username }}{% else %}Report via GitHub{% endif %}
+        </button>
+      </div>
+      <div class="is-hidden" aria-hidden="true">
+        <div class="form-text form-element js-Form-group">
+          {{ form.username.label(class_='form-label wc-Form-label') }}
+          {% if form.username.errors %}
+            {% for error in form.username.errors %}
+              <span class="wc-Form-helpMessage">{{ error }}</span>
+            {% endfor %}
+          {% endif %}
+          {{ form.username(class_='u-formInput') }}
         </div>
       </div>
-      <div class="wc-Form-item is-hidden" aria-hidden="true">
-        <div class="wc-Form-group js-Form-group {% if form.username.errors %}is-error{% endif %}">
-          {{ form.username.label }}{% if form.username.errors %}{% for error in form.username.errors %}
-            <span class="wc-Form-helpMessage">{{ error }}</span>
-            {% endfor %}{% endif %}
-            {{ form.username(class_='u-formInput') }}
-          </div>
-      </div>
-      {{ form.hidden_tag() }}
-    </form>
-  </div>
+    </div>
+    {{ form.hidden_tag() }}
+  </form>
 </section>


### PR DESCRIPTION
Ports the report form to the new style. Some things are left:

* Which headline level should the "Report Site Issue" headline on /issues/new have? I've used a `<h1>`, not sure what the plans here were.
* Spacing between labels and the "required" asterisk is highly dependent on whether there is a line feed or not. Should be independent of code white space
* Labels are not bold, but the "Type of Bug" headline is. Feels kinda inconsistent and probably needs addressing.
* The uploader needs some more CSS work, possibly some JS work (it seems to work, but the styles are broken. Not sure if there are other issues left to fix, we'll probably see that if we fix the styles)
* If we want to get rid of all `wc-*` classes, we need to do a lot of JS refactoring.

r? @zoepage 