### PR TITLE
No issue. Don't build all branches on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@
 sudo: required
 dist: trusty
 
+# Only run travis on the master branch (and PRs), not all branches
+branches:
+  only:
+    - master
+
 language: python
 
 python:


### PR DESCRIPTION
This `.travis.yml` change causes Travis not to build all branches, but only the `master` branch. All other branches will be merged via PRs only anyway, and PRs still get checked, so there is no need to have Travis pre-building those branches for every push.

This reduces the amount of jobs during the refactor period as well. We have a few known-failures and those emails are kinda annoying.

Requesting to merge this into `master`, since I see no harm in having this a permanent change. In general, having Travis build only the stuff we need is good. ❤️ for Travis!

r? @zoepage 
fyi! @miketaylr (skipping your review here so we can have this merged today, but feel free to revert. :))