### PR TITLE
Fixes #1917 - Add routes for new contributor sites

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -48,6 +48,31 @@ class TestURLs(unittest.TestCase):
         rv = self.app.get('/privacy')
         self.assertEqual(rv.status_code, 200)
 
+    def test_contributors(self):
+        '''Test that /contributors exists.'''
+        rv = self.app.get('/contributors')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_contributors_contribute(self):
+        '''Test that /contributors/contribute exists.'''
+        rv = self.app.get('/contributors/contribute')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_contributors_diagnose_bug(self):
+        '''Test that /contributors/diagnose-bug exists.'''
+        rv = self.app.get('/contributors/diagnose-bug')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_contributors_reproduce_bug(self):
+        '''Test that /contributors/reproduce-bug exists.'''
+        rv = self.app.get('/contributors/reproduce-bug')
+        self.assertEqual(rv.status_code, 200)
+
+    def test_contributors_site_outreach(self):
+        '''Test that /contributors/site-outreach exists.'''
+        rv = self.app.get('/contributors/site-outreach')
+        self.assertEqual(rv.status_code, 200)
+
     def test_activity_page_401_if_not_logged_in(self):
         '''Test that asks user to log in before displaying activity.'''
         rv = self.app.get('/me')

--- a/webcompat/templates/contributors.html
+++ b/webcompat/templates/contributors.html
@@ -2,80 +2,29 @@
 {% block title %}Contributors{% endblock %}
 {% block body %}
 <div>
-{% include "shared/nav.html" %}
-<main role="main">
-  <div class="wc-Hero wc-Hero--contributors">
-    <div class="wc-UIContent">
-      <div class="wc-Hero-wrapper">
-        <div class="wc-Hero-textContributors ">
-          <h1 class="wc-Title wc-Title--xl">
-            <span class="wc-Hero-title js-Hero-title">Welcome aboard!<br/>Get started below...</span>
-          </h1>
-        </div>
-        <div class="wc-Hero-SVG is-active js-Hero-svg">
-          {# TODO - we removed outdated images - include "shared/LightbulbwithBug.svg" #}
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="contributors">
-    <div class="contributors__item">
-      <div class="contributors__item__header">
-        <div class="wc-UIContent contributors__item__title">
-          <h2 id="reproduce">
-            <button class="contributors__item__btn is-active r-ResetButton" type="button">
-              How to Reproduce a Bug
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--disabled wc-Icon--minus" aria-hidden="true"></span>
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--active wc-Icon--plus" aria-hidden="true"></span>
-            </button>
-          </h2>
+  {% include "shared/nav.html" %}
+  <main role="main">
+    <section class="grid grid-show-gap">
+      <div class="grid-row">
+        <aside class="grid-cell x1-fix">
+          <ol class="sub-nav" class="sub-nav">
+            <li class="sub-nav-header">Table of Contents</li>
+            <li><a href="/contributors/contribute/"></a>Join Us</a></li>
+            <li>
+              Get Started
+              <ol class="nested-sub-nav">
+                <li class="sub-nav-active"><a href="/contributors/reproduce-a-bug/">Reproduce a Bug</a></li>
+                <li><a href="/contributors/diagnose-a-bug/">Diagnose a Bug</a></li>
+                <li><a href="/contributors/site-outreach/">Site outreach</a></li>
+              </ol>
+            </li>
+          </ol>
+        </aside>
+        <div class="grid-cell x1">
+          <section>{% include "contributors/reproduce-bug.html" %}</section>
         </div>
       </div>
-      <div class="contributors__item__content wc-UIContent is-open">{% include "contributors/reproduce-bug.html" %}</div>
-    </div>
-    <div class="contributors__item">
-      <div class="contributors__item__header">
-        <div class="wc-UIContent contributors__item__title">
-          <h2 id="diagnose">
-            <button class="contributors__item__btn r-ResetButton" type="button">
-              How to Diagnose a Bug
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--disabled wc-Icon--minus" aria-hidden="true"></span>
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--active wc-Icon--plus" aria-hidden="true"></span>
-            </button>
-          </h2>
-        </div>
-      </div>
-      <div class="contributors__item__content wc-UIContent">{% include "contributors/diagnose-bug.html" %}</div>
-    </div>
-    <div class="contributors__item">
-      <div class="contributors__item__header">
-        <div class="wc-UIContent contributors__item__title">
-          <h2 id="outreach">
-            <button class="contributors__item__btn r-ResetButton" type="button">
-              How to Do Site Outreach
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--disabled wc-Icon--minus" aria-hidden="true"></span>
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--active wc-Icon--plus" aria-hidden="true"></span>
-            </button>
-          </h2>
-        </div>
-      </div>
-      <div class="contributors__item__content wc-UIContent">{% include "contributors/site-outreach.html" %}</div>
-    </div>
-    <div class="contributors__item">
-      <div class="contributors__item__header">
-        <div class="wc-UIContent contributors__item__title">
-          <h2 id="contribute">
-            <button class="contributors__item__btn r-ResetButton" type="button">
-              Contribute to this site
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--disabled wc-Icon--minus" aria-hidden="true"></span>
-              <span class="wc-Icon wc-Icon--contributors wc-Icon--contributors--active wc-Icon--plus" aria-hidden="true"></span>
-            </button>
-          </h2>
-        </div>
-      </div>
-      <div class="contributors__item__content page wc-UIContent">{% include "contributors/contribute.html" %}</div>
-    </div>
-  </div>
+    </section>
   </main>
 </div>
 {% endblock %}

--- a/webcompat/templates/contributors.html
+++ b/webcompat/templates/contributors.html
@@ -9,19 +9,20 @@
         <aside class="grid-cell x1-fix">
           <ol class="sub-nav" class="sub-nav">
             <li class="sub-nav-header">Table of Contents</li>
-            <li><a href="/contributors/contribute/"></a>Join Us</a></li>
+            <li class="sub-nav-active"><a href="/contributors">Join Us</a></li>
             <li>
               Get Started
               <ol class="nested-sub-nav">
-                <li class="sub-nav-active"><a href="/contributors/reproduce-a-bug/">Reproduce a Bug</a></li>
-                <li><a href="/contributors/diagnose-a-bug/">Diagnose a Bug</a></li>
-                <li><a href="/contributors/site-outreach/">Site outreach</a></li>
+                <li><a href="/contributors/reproduce-bug">Reproduce a Bug</a></li>
+                <li><a href="/contributors/diagnose-bug">Diagnose a Bug</a></li>
+                <li><a href="/contributors/site-outreach">Site outreach</a></li>
+                <li><a href="/contributors/contribute">Contribute</a></li>
               </ol>
             </li>
           </ol>
         </aside>
         <div class="grid-cell x1">
-          <section>{% include "contributors/reproduce-bug.html" %}</section>
+          <section>Join us!</section>
         </div>
       </div>
     </section>

--- a/webcompat/templates/contributors/contribute.html
+++ b/webcompat/templates/contributors/contribute.html
@@ -1,3 +1,42 @@
-<ul class="contributors__list">
-  <li class="contributors__list__item"><span>Head on over to <a href="https://github.com/webcompat/webcompat.com/issues/">GitHub</a> to file an issue for bugs or new features. <a href="https://github.com/webcompat/webcompat.com/blob/master/CONTRIBUTING.md">Contributions welcome!</a></span></li>
-</ul>
+{% extends "layout.html" %}
+{% block title %}Contributors{% endblock %}
+{% block body %}
+<div>
+  {% include "shared/nav.html" %}
+  <main role="main">
+    <section class="grid grid-show-gap">
+      <div class="grid-row">
+        <aside class="grid-cell x1-fix">
+          <ol class="sub-nav" class="sub-nav">
+            <li class="sub-nav-header">Table of Contents</li>
+            <li><a href="/contributors">Join Us</a></li>
+            <li>
+              Get Started
+              <ol class="nested-sub-nav">
+                <li><a href="/contributors/reproduce-bug">Reproduce a Bug</a></li>
+                <li><a href="/contributors/diagnose-bug">Diagnose a Bug</a></li>
+                <li><a href="/contributors/site-outreach">Site outreach</a></li>
+                <li class="sub-nav-active"><a href="/contributors/contribute">Contribute</a></li>
+              </ol>
+            </li>
+          </ol>
+        </aside>
+        <div class="grid-cell x1">
+          <section>
+            <ul class="contributors__list">
+              <li class="contributors__list__item"><span>Head on over to <a href="https://github.com/webcompat/webcompat.com/issues/">GitHub</a> to file an issue for bugs or new features. <a href="https://github.com/webcompat/webcompat.com/blob/master/CONTRIBUTING.md">Contributions welcome!</a></span></li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+{% endblock %}
+{%- block extrascripts -%}
+{%- if config.PRODUCTION or config.STAGING -%}
+<script src="{{ url_for('static', filename='js/contributors.min.js')|bust_cache }}"></script>
+{% else %}
+<script src="{{ url_for('static', filename='js/lib/contributors.js') }}"></script>
+{%- endif %}
+{%- endblock %}

--- a/webcompat/templates/contributors/diagnose-bug.html
+++ b/webcompat/templates/contributors/diagnose-bug.html
@@ -1,32 +1,70 @@
-<ul class="contributors__list">
-  <li class="contributors__list__item"><span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a> or <a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needstriage&sort=created&direction=desc">Needs Triage"</a></span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
-    </div></li>
-  <li class="contributors__list__item"><span>Check to see if the bug has been reproduced already</span></li>
-  <li class="contributors__list__item"><span>If not, try to reproduce the bug</span></li>
-  <li class="contributors__list__item"><span>If the bug is NOT reproducible, write a comment on the issue</span></li>
-  <li class="contributors__list__item"><span>If the bug is reproducible, try to reproduce on other browsers or OS</span></li>
-  <li class="contributors__list__item">
-    <span>Check the console to see if there are any errors</span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/6consolesnapshot.png" alt="Developer Console Screenshot"/>
-    </div>
-  </li>
-  <li class="contributors__list__item"><span>Google any errors</span></li>
-  <li class="contributors__list__item"><span>Write a comment with your findings on the issue</span></li>
-  <li class="contributors__list__item">
-    <span>If you know how to fix the issue, or have information related to a fix, add it in a comment</span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/9commentsnapshot.png" alt="Bug Comments Screenshot"/>
-    </div>
-  </li>
-  <li class="contributors__list__item"><span>If not, post what you tried on the issue</span></li>
-</ul>
-<section id="diagnose-ref" class="references">
-<p>There are a wide list of references on how to diagnose bugs for desktop and mobile.</p>
-<ul>
-  <li><a href="https://developer.chrome.com/devtools/docs/remote-debugging">Chrome Remote Debugging (Android)</a></li>
-  <li><a href="https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging">Firefox Remote Debugging (Android and Firefox OS)</a></li>
-</ul>
-</section>
+{% extends "layout.html" %}
+{% block title %}Contributors{% endblock %}
+{% block body %}
+<div>
+  {% include "shared/nav.html" %}
+  <main role="main">
+    <section class="grid grid-show-gap">
+      <div class="grid-row">
+        <aside class="grid-cell x1-fix">
+          <ol class="sub-nav" class="sub-nav">
+            <li class="sub-nav-header">Table of Contents</li>
+            <li><a href="/contributors">Join Us</a></li>
+            <li>
+              Get Started
+              <ol class="nested-sub-nav">
+                <li><a href="/contributors/reproduce-bug">Reproduce a Bug</a></li>
+                <li class="sub-nav-active"><a href="/contributors/diagnose-bug">Diagnose a Bug</a></li>
+                <li><a href="/contributors/site-outreach">Site outreach</a></li>
+                <li><a href="/contributors/contribute">Contribute</a></li>
+              </ol>
+            </li>
+          </ol>
+        </aside>
+        <div class="grid-cell x1">
+          <section>
+            <ul class="contributors__list">
+              <li class="contributors__list__item"><span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a> or <a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needstriage&sort=created&direction=desc">Needs Triage"</a></span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
+                </div></li>
+              <li class="contributors__list__item"><span>Check to see if the bug has been reproduced already</span></li>
+              <li class="contributors__list__item"><span>If not, try to reproduce the bug</span></li>
+              <li class="contributors__list__item"><span>If the bug is NOT reproducible, write a comment on the issue</span></li>
+              <li class="contributors__list__item"><span>If the bug is reproducible, try to reproduce on other browsers or OS</span></li>
+              <li class="contributors__list__item">
+                <span>Check the console to see if there are any errors</span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/6consolesnapshot.png" alt="Developer Console Screenshot"/>
+                </div>
+              </li>
+              <li class="contributors__list__item"><span>Google any errors</span></li>
+              <li class="contributors__list__item"><span>Write a comment with your findings on the issue</span></li>
+              <li class="contributors__list__item">
+                <span>If you know how to fix the issue, or have information related to a fix, add it in a comment</span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/9commentsnapshot.png" alt="Bug Comments Screenshot"/>
+                </div>
+              </li>
+              <li class="contributors__list__item"><span>If not, post what you tried on the issue</span></li>
+            </ul>
+            <section id="diagnose-ref" class="references">
+            <p>There are a wide list of references on how to diagnose bugs for desktop and mobile.</p>
+            <ul>
+              <li><a href="https://developer.chrome.com/devtools/docs/remote-debugging">Chrome Remote Debugging (Android)</a></li>
+              <li><a href="https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging">Firefox Remote Debugging (Android and Firefox OS)</a></li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+{% endblock %}
+{%- block extrascripts -%}
+{%- if config.PRODUCTION or config.STAGING -%}
+<script src="{{ url_for('static', filename='js/contributors.min.js')|bust_cache }}"></script>
+{% else %}
+<script src="{{ url_for('static', filename='js/lib/contributors.js') }}"></script>
+{%- endif %}
+{%- endblock %}

--- a/webcompat/templates/contributors/reproduce-bug.html
+++ b/webcompat/templates/contributors/reproduce-bug.html
@@ -1,16 +1,55 @@
-<ul class="contributors__list">
-  <li class="contributors__list__item">
-    <span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a>"</span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
-    </div>
-  </li>
-  <li class="contributors__list__item"><span>Make sure you have the same browser/OS running (if possible)</span></li>
-  <li class="contributors__list__item"><span>See if you can reproduce the problem as described</span></li>
-  <li class="contributors__list__item">
-    <span>Comment on the issue with your findings</span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/4issuesnapshot.png" alt="Issue Comment Screenshot"/>
-    </div>
-  </li>
-</ul>
+{% extends "layout.html" %}
+{% block title %}Contributors{% endblock %}
+{% block body %}
+<div>
+  {% include "shared/nav.html" %}
+  <main role="main">
+    <section class="grid grid-show-gap">
+      <div class="grid-row">
+        <aside class="grid-cell x1-fix">
+          <ol class="sub-nav" class="sub-nav">
+            <li class="sub-nav-header">Table of Contents</li>
+            <li><a href="/contributors">Join Us</a></li>
+            <li>
+              Get Started
+              <ol class="nested-sub-nav">
+                <li class="sub-nav-active"><a href="/contributors/reproduce-bug">Reproduce a Bug</a></li>
+                <li><a href="/contributors/diagnose-bug">Diagnose a Bug</a></li>
+                <li><a href="/contributors/site-outreach">Site outreach</a></li>
+                <li><a href="/contributors/contribute">Contribute</a></li>
+              </ol>
+            </li>
+          </ol>
+        </aside>
+        <div class="grid-cell x1">
+          <section>
+            <ul class="contributors__list">
+              <li class="contributors__list__item">
+                <span>Find a bug that "<a href="https://webcompat.com/issues?page=1&per_page=50&state=open&stage=needsdiagnosis&sort=created&direction=desc">Needs Diagnosis</a>"</span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/1browsesnapshot.png" alt="Browse Issues Screenshot"/>
+                </div>
+              </li>
+              <li class="contributors__list__item"><span>Make sure you have the same browser/OS running (if possible)</span></li>
+              <li class="contributors__list__item"><span>See if you can reproduce the problem as described</span></li>
+              <li class="contributors__list__item">
+                <span>Comment on the issue with your findings</span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/4issuesnapshot.png" alt="Issue Comment Screenshot"/>
+                </div>
+              </li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+{% endblock %}
+{%- block extrascripts -%}
+{%- if config.PRODUCTION or config.STAGING -%}
+<script src="{{ url_for('static', filename='js/contributors.min.js')|bust_cache }}"></script>
+{% else %}
+<script src="{{ url_for('static', filename='js/lib/contributors.js') }}"></script>
+{%- endif %}
+{%- endblock %}

--- a/webcompat/templates/contributors/site-outreach.html
+++ b/webcompat/templates/contributors/site-outreach.html
@@ -1,83 +1,122 @@
-<ul class="contributors__list">
-  <li class="contributors__list__item">
-    <span>Find a bug that is labeled "<a href='https://webcompat.com/issues?page=1&per_page=50&state=open&stage=contactready&sort=created&direction=desc'>Ready for Outreach</a>"</span>
-    <div class="contributors__list__screenshot">
-      <img src="../img/1readyforoutreach.png" alt="Ready for Outreach Bugs Screenshot"/>
-    </div>
-  </li>
-  <li class="contributors__list__item"><span>Now it's time to track down someone to help get the fix implemented, but first a few tips on doing outreach:</span></li>
-  <ul class="contributors__list contributors__list--lvl_down">
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be tactful</strong> People we are trying to reach have their own set of constraints, bosses, economic choices, etc. "Your web site sucks" will not lead anywhere, except NOT getting the site fixed.</span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be humble</strong> We are no better, we also do mistakes in our own practices. We recommend things which might change one day because of the technical/economical circumstances.</span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Let it go</strong> Sometimes it just doesn't work. The person at the end of the other line may say "no" or worse, not answer. It can be very frustrating. Accept it and move on.</span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be passionate</strong> The passion is in being able to find the right contact in a company without harassing them.  Every effort helps.</span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Share with consideration</strong> Share any contact you attempted or made in the issue comments section.  It helps everyone to know the status so they can pitch in or not repeat work. That said -  be careful to not disclose private information such as names and emails. You may simply say: "I contacted someone at $COMPANY", "Someone from $COMPANY said this..."</span></li>
-  </ul>
-  <li class="contributors__list__item"><span>If it is a browser bug, consider reporting it to the browser vendor:</span></li>
-  <ul class="contributors__list contributors__list--lvl_down">
-    <li class="contributors__list__item contributors__list__item--lvl_down">
-      <span>Chrome bug reports: <a title="Chrome bug reports" href="https://crbug.com/new">http://crbug.com/new</a></span>
-      <div class="contributors__list__screenshot">
-        <img src="../img/chromebugreport.jpg" alt="Chrome Bug Report Screenshot"/>
+{% extends "layout.html" %}
+{% block title %}Contributors{% endblock %}
+{% block body %}
+<div>
+  {% include "shared/nav.html" %}
+  <main role="main">
+    <section class="grid grid-show-gap">
+      <div class="grid-row">
+        <aside class="grid-cell x1-fix">
+          <ol class="sub-nav" class="sub-nav">
+            <li class="sub-nav-header">Table of Contents</li>
+            <li><a href="/contributors">Join Us</a></li>
+            <li>
+              Get Started
+              <ol class="nested-sub-nav">
+                <li><a href="/contributors/reproduce-bug">Reproduce a Bug</a></li>
+                <li><a href="/contributors/diagnose-bug">Diagnose a Bug</a></li>
+                <li class="sub-nav-active"><a href="/contributors/site-outreach">Site outreach</a></li>
+                <li><a href="/contributors/contribute">Contribute</a></li>
+              </ol>
+            </li>
+          </ol>
+        </aside>
+        <div class="grid-cell x1">
+          <section>
+            <ul class="contributors__list">
+              <li class="contributors__list__item">
+                <span>Find a bug that is labeled "<a href='https://webcompat.com/issues?page=1&per_page=50&state=open&stage=contactready&sort=created&direction=desc'>Ready for Outreach</a>"</span>
+                <div class="contributors__list__screenshot">
+                  <img src="../img/1readyforoutreach.png" alt="Ready for Outreach Bugs Screenshot"/>
+                </div>
+              </li>
+              <li class="contributors__list__item"><span>Now it's time to track down someone to help get the fix implemented, but first a few tips on doing outreach:</span></li>
+              <ul class="contributors__list contributors__list--lvl_down">
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be tactful</strong> People we are trying to reach have their own set of constraints, bosses, economic choices, etc. "Your web site sucks" will not lead anywhere, except NOT getting the site fixed.</span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be humble</strong> We are no better, we also do mistakes in our own practices. We recommend things which might change one day because of the technical/economical circumstances.</span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Let it go</strong> Sometimes it just doesn't work. The person at the end of the other line may say "no" or worse, not answer. It can be very frustrating. Accept it and move on.</span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Be passionate</strong> The passion is in being able to find the right contact in a company without harassing them.  Every effort helps.</span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Share with consideration</strong> Share any contact you attempted or made in the issue comments section.  It helps everyone to know the status so they can pitch in or not repeat work. That said -  be careful to not disclose private information such as names and emails. You may simply say: "I contacted someone at $COMPANY", "Someone from $COMPANY said this..."</span></li>
+              </ul>
+              <li class="contributors__list__item"><span>If it is a browser bug, consider reporting it to the browser vendor:</span></li>
+              <ul class="contributors__list contributors__list--lvl_down">
+                <li class="contributors__list__item contributors__list__item--lvl_down">
+                  <span>Chrome bug reports: <a title="Chrome bug reports" href="https://crbug.com/new">http://crbug.com/new</a></span>
+                  <div class="contributors__list__screenshot">
+                    <img src="../img/chromebugreport.jpg" alt="Chrome Bug Report Screenshot"/>
+                  </div>
+                </li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span>Firefox bug reports: <a title="Firefox bug reports" href="https://bugzilla.mozilla.org/enter_bug.cgi">https://bugzilla.mozilla.org/enter_bug.cgi</a></span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span>Safari bug reports: <a title="Safari bug reports" href="http://bugreport.apple.com">http://bugreport.apple.com</a></span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span>Opera bug reports : <a title="Opera bug reports" href="https://bugs.opera.com/wizard/">https://bugs.opera.com/wizard/</a></span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span>Internet Explorer bug reports : <a title="IE bug reports" href="https://connect.microsoft.com/IE">https://connect.microsoft.com/IE</a></span></li>
+              </ul>
+              <li class="contributors__list__item"><span>If it's a web site, track down the site owner.  Try:</span></li>
+              <ul class="contributors__list contributors__list--lvl_down">
+                <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Does the web site have a Twitter account?</strong> If the Twitter account seems to be run by a person, it can be a good start for initial contact.  Ask who you should contact with the fix.  If the Twitter account is just broadcasting information, move on.</span></li>
+                <li class="contributors__list__item contributors__list__item--lvl_down">
+                  <span><strong>Does the web site have a support email or an issue tracker?</strong>  This is a simple one, but there's no guarantee that your request will be addressed.  Most of the time the responses are automatic but it's better than nothing. If in return you get an ID and/or a URI, put it in the issue comments.</span>
+                  <div class="contributors__list__screenshot">
+                    <img src="../img/2lastbullet_comment.jpg" alt="GitHub Comment Screenshot"/>
+                  </div>
+                </li>
+                <li class="contributors__list__item contributors__list__item--lvl_down">
+                  <span><strong>Search for a human working there</strong> Try:
+                  <ul>
+                    <li><strong>LinkedIn.</strong>
+                      This doesn't necessary work with all countries, but worth trying. You can start for example in your favorite search engine with:Web developer $COMPANY_NAME site:linkedin.com. This will list names of people who are likely to work there, some of them in their profile will have contact information and often Twitter accounts, personal web sites or emails.
+                    </li>
+                    <li><strong>Twitter.</strong>
+                      Some people put their company affiliation in Twitter.  Tweet or DM them if possible and ask who to contact. Always check if the Twitter account is active. Some people haven't used their account for ages. If so, move on.
+                    </li>
+                    <li><strong>SlideShare.</strong>
+                      When you can't find the information about a developer, you might want to try to search something such as $COMPANY_NAME site:slideshare.net or any appropriate keywords that will make you closer to a contact. Some companies have their developers speaking at conferences about issues with performances, etc. Be careful of talks related to sales or marketing. In the slides, there is often the contact information of the developer.
+                      <div class="contributors__list__screenshot">
+                        <img src="../img/slideshare.jpg" alt="SlideShare Screenshot"/>
+                      </div>
+                    </li>
+                    <li><strong>GitHub, etc.</strong>
+                      Search by individual person or by company names. Many developers have either company projects online and/or their personal projects. As usual be careful to not abuse or harass people with your requests.
+                    </li>
+                    <li><strong>Web designer.</strong>
+                      Sometimes when you can't reach a web developer, you may try to reach web designers who have also their own type of social networks such as <a title="dribbble.com" href="https://dribbble.com/">dribbble.com</a>. Usually they have contacts with web developers and may be able to give an introduction. In some web agencies, the web designer will be a good initial contact. Again, be tactful and don't make the life of the web designer harder in his/her own company.
+                      <div class="contributors__list__screenshot">
+                        <img src="../img/webdesigner.jpg" alt="Dribble Screenshot"/>
+                      </div>
+                    </li>
+                    <li><strong>Corporate emails.</strong>
+                      This may work time to time. When you know the person is working in a specific company (You have last and first name), but you have been unable to find any contacts at all through twitter and so on. You might want to find out through search engines and/or people working at this company how the email addresses have been created. You may find that the pattern is firstname.lastname@company.example.org or lastnameF@ etc. You can try to send an email. The person will be probably surprised on how did you get the email address. So there is a risk to anger the person. Be gentle and explain. Try <a href="http://www.email-format.com/i/browse/" target="_blank">this email format tool</a>.
+                    </li>
+                    <li><strong>whois.</strong>
+                      Some Web sites have their contact information in the <a href="https://www.google.com/search?q=google+whois" target="_blank"> whois</a> of the Web site. It's becoming rarer and rarer, because people receive spam because of it.
+                    </li>
+                    <li><strong>Check the terms and conditions or privacy policy for email addresses.</strong>
+                      There could be hidden in long blocks of text so a search for  @ is helpful.  There may also be links in a website's footer to an investor or media relations page which could have a contact address, but be careful  not to annoy the company by sending mails about bugs to addresses that are clearly not relevant (e.g. investors@example.com).
+                    </li>
+                    <li><strong>Friend of a friend.</strong>
+                      You are likely well connected in the industry. And it's why, if you are a Mozilla contributor in a specific  country, you are a very important asset for the work we are doing. Local social networks in between companies is a lot denser. Search your LinkedIn,  Twitter and Github for connections who might be connected to that company.
+                    </li>
+                    <li><strong>Find the home site.</strong>
+                      Sometimes a Web site belongs to a bigger company (think about a Game company with many brands, or a TV  broadcaster, different services such as Google, Yahoo!, etc.), finding the home site will help understand the structure of the company and might lead to  the department which is really in charge of the Web site.
+                    </li>
+                    <li><strong>Check for unique technologies that can search for.</strong>
+                      Sometimes you may have additional hints about the technology used on the Web site and the type of people related to the site through the hiring page of the company. In small company Web sites, you will discover the programming languages which are used, these will help reduce the search.
+                    </li>
+                  </ul>
+                </span>
+              </li>
+            </ul>
+          </section>
+        </div>
       </div>
-    </li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span>Firefox bug reports: <a title="Firefox bug reports" href="https://bugzilla.mozilla.org/enter_bug.cgi">https://bugzilla.mozilla.org/enter_bug.cgi</a></span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span>Safari bug reports: <a title="Safari bug reports" href="http://bugreport.apple.com">http://bugreport.apple.com</a></span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span>Opera bug reports : <a title="Opera bug reports" href="https://bugs.opera.com/wizard/">https://bugs.opera.com/wizard/</a></span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span>Internet Explorer bug reports : <a title="IE bug reports" href="https://connect.microsoft.com/IE">https://connect.microsoft.com/IE</a></span></li>
-  </ul>
-  <li class="contributors__list__item"><span>If it's a web site, track down the site owner.  Try:</span></li>
-  <ul class="contributors__list contributors__list--lvl_down">
-    <li class="contributors__list__item contributors__list__item--lvl_down"><span><strong>Does the web site have a Twitter account?</strong> If the Twitter account seems to be run by a person, it can be a good start for initial contact.  Ask who you should contact with the fix.  If the Twitter account is just broadcasting information, move on.</span></li>
-    <li class="contributors__list__item contributors__list__item--lvl_down">
-      <span><strong>Does the web site have a support email or an issue tracker?</strong>  This is a simple one, but there's no guarantee that your request will be addressed.  Most of the time the responses are automatic but it's better than nothing. If in return you get an ID and/or a URI, put it in the issue comments.</span>
-      <div class="contributors__list__screenshot">
-        <img src="../img/2lastbullet_comment.jpg" alt="GitHub Comment Screenshot"/>
-      </div>
-    </li>
-    <li class="contributors__list__item contributors__list__item--lvl_down">
-      <span><strong>Search for a human working there</strong> Try:
-      <ul>
-        <li><strong>LinkedIn.</strong>
-          This doesn't necessary work with all countries, but worth trying. You can start for example in your favorite search engine with:Web developer $COMPANY_NAME site:linkedin.com. This will list names of people who are likely to work there, some of them in their profile will have contact information and often Twitter accounts, personal web sites or emails.
-        </li>
-        <li><strong>Twitter.</strong>
-          Some people put their company affiliation in Twitter.  Tweet or DM them if possible and ask who to contact. Always check if the Twitter account is active. Some people haven't used their account for ages. If so, move on.
-        </li>
-        <li><strong>SlideShare.</strong>
-          When you can't find the information about a developer, you might want to try to search something such as $COMPANY_NAME site:slideshare.net or any appropriate keywords that will make you closer to a contact. Some companies have their developers speaking at conferences about issues with performances, etc. Be careful of talks related to sales or marketing. In the slides, there is often the contact information of the developer.
-          <div class="contributors__list__screenshot">
-            <img src="../img/slideshare.jpg" alt="SlideShare Screenshot"/>
-          </div>
-        </li>
-        <li><strong>GitHub, etc.</strong>
-          Search by individual person or by company names. Many developers have either company projects online and/or their personal projects. As usual be careful to not abuse or harass people with your requests.
-        </li>
-        <li><strong>Web designer.</strong>
-          Sometimes when you can't reach a web developer, you may try to reach web designers who have also their own type of social networks such as <a title="dribbble.com" href="https://dribbble.com/">dribbble.com</a>. Usually they have contacts with web developers and may be able to give an introduction. In some web agencies, the web designer will be a good initial contact. Again, be tactful and don't make the life of the web designer harder in his/her own company.
-          <div class="contributors__list__screenshot">
-            <img src="../img/webdesigner.jpg" alt="Dribble Screenshot"/>
-          </div>
-        </li>
-        <li><strong>Corporate emails.</strong>
-          This may work time to time. When you know the person is working in a specific company (You have last and first name), but you have been unable to find any contacts at all through twitter and so on. You might want to find out through search engines and/or people working at this company how the email addresses have been created. You may find that the pattern is firstname.lastname@company.example.org or lastnameF@ etc. You can try to send an email. The person will be probably surprised on how did you get the email address. So there is a risk to anger the person. Be gentle and explain. Try <a href="http://www.email-format.com/i/browse/" target="_blank">this email format tool</a>.
-        </li>
-        <li><strong>whois.</strong>
-          Some Web sites have their contact information in the <a href="https://www.google.com/search?q=google+whois" target="_blank"> whois</a> of the Web site. It's becoming rarer and rarer, because people receive spam because of it.
-        </li>
-        <li><strong>Check the terms and conditions or privacy policy for email addresses.</strong>
-          There could be hidden in long blocks of text so a search for  @ is helpful.  There may also be links in a website's footer to an investor or media relations page which could have a contact address, but be careful  not to annoy the company by sending mails about bugs to addresses that are clearly not relevant (e.g. investors@example.com).
-        </li>
-        <li><strong>Friend of a friend.</strong>
-          You are likely well connected in the industry. And it's why, if you are a Mozilla contributor in a specific  country, you are a very important asset for the work we are doing. Local social networks in between companies is a lot denser. Search your LinkedIn,  Twitter and Github for connections who might be connected to that company.
-        </li>
-        <li><strong>Find the home site.</strong>
-          Sometimes a Web site belongs to a bigger company (think about a Game company with many brands, or a TV  broadcaster, different services such as Google, Yahoo!, etc.), finding the home site will help understand the structure of the company and might lead to  the department which is really in charge of the Web site.
-        </li>
-        <li><strong>Check for unique technologies that can search for.</strong>
-          Sometimes you may have additional hints about the technology used on the Web site and the type of people related to the site through the hiring page of the company. In small company Web sites, you will discover the programming languages which are used, these will help reduce the search.
-        </li>
-      </ul>
-      </span>
-    </li>
-</ul>
+    </section>
+  </main>
+</div>
+{% endblock %}
+{%- block extrascripts -%}
+{%- if config.PRODUCTION or config.STAGING -%}
+<script src="{{ url_for('static', filename='js/contributors.min.js')|bust_cache }}"></script>
+{% else %}
+<script src="{{ url_for('static', filename='js/lib/contributors.js') }}"></script>
+{%- endif %}
+{%- endblock %}

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -32,7 +32,7 @@
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Sans+Pro:300,400|PT+Mono" rel="stylesheet">
   <link href="https://webcompat.github.io/design/css/main.css" type="text/css" rel="stylesheet">
 </head>
-<body data-username="{{ session.username }}">
+<body class="body-webcompat" {data-username="{{ session.username }}">
 {% include "shared/svg-icons.html" %}
 <div class="wc-UIViewport">
   {% block body %}{% endblock %}

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -327,6 +327,37 @@ def contributors():
         get_user_info()
     return render_template('contributors.html')
 
+@app.route('/contributors/contribute')
+@cache_policy(private=True, uri_max_age=0, must_revalidate=True)
+def contributors_contribute():
+    """Route to display contributors/contribute page."""
+    if g.user:
+        get_user_info()
+    return render_template('contributors/contribute.html')
+
+@app.route('/contributors/diagnose-bug')
+@cache_policy(private=True, uri_max_age=0, must_revalidate=True)
+def contributors_diagnose_bug():
+    """Route to display contributors/diagnose-bug page."""
+    if g.user:
+        get_user_info()
+    return render_template('contributors/diagnose-bug.html')
+
+@app.route('/contributors/reproduce-bug')
+@cache_policy(private=True, uri_max_age=0, must_revalidate=True)
+def contributors_reproduce_bug():
+    """Route to display contributors/reproduce-bug page."""
+    if g.user:
+        get_user_info()
+    return render_template('contributors/reproduce-bug.html')
+
+@app.route('/contributors/site-outreach')
+@cache_policy(private=True, uri_max_age=0, must_revalidate=True)
+def contributors_site_outreach():
+    """Route to display contributors/site-outreach page."""
+    if g.user:
+        get_user_info()
+    return render_template('contributors/site-outreach.html')
 
 @app.route('/tools/cssfixme')
 def cssfixme():


### PR DESCRIPTION
This adds the new structure for the contributors pages which looks like 👇🏻

![contributors](https://user-images.githubusercontent.com/962099/32982563-c1cbf7a2-cc86-11e7-83cf-c44c0c2ac71c.gif)

The templates could have some logic to avoid code duplication, but I'm not sure if that's needed at this stage.

Also this branch is rebased with the added routes added by @denschub.

I only copied the content of each specific route that was there before. :)