### PR TITLE
Issue #1921 - Add contact page

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -48,6 +48,11 @@ class TestURLs(unittest.TestCase):
         rv = self.app.get('/privacy')
         self.assertEqual(rv.status_code, 200)
 
+    def test_contact(self):
+        '''Test that /contact exists.'''
+        rv = self.app.get('/contact')
+        self.assertEqual(rv.status_code, 200)
+
     def test_activity_page_401_if_not_logged_in(self):
         '''Test that asks user to log in before displaying activity.'''
         rv = self.app.get('/me')

--- a/webcompat/templates/contact.html
+++ b/webcompat/templates/contact.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block title %}Contact{% endblock %}
+{% block body %}
+{% include "shared/nav.html" %}
+  <section class="grid">
+    <article class="grid-row">
+      <div class="grid-cell x3">
+        <h1 class="headline-1">TODO: Contact</h1>
+        <p>Et repellendus voluptatum nobis aut iure sint vel eaque. Nesciunt id architecto alias. Fugiat et quas explicabo. Aspernatur maiores explicabo aut. Autem autem quibusdam sit molestiae maiores blanditiis quis est. Ut laborum qui est dolorem itaque omnis sit incidunt.</p>
+      </div>
+    </article>
+  </section>
+{% endblock %}

--- a/webcompat/templates/shared/footer.html
+++ b/webcompat/templates/shared/footer.html
@@ -12,7 +12,7 @@
           </a>
         </li>
         <li class="footer-item">
-          <a class="footer-item-link" aria-label="downloads a text file with all conributors and contacts" href="/humans.txt">
+          <a class="footer-item-link" aria-label="get contact information" href="/contact">
             Contact
           </a>
         </li>

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -318,6 +318,14 @@ def privacy():
         get_user_info()
     return render_template('privacy.html')
 
+@app.route('/contact')
+@cache_policy(private=True, uri_max_age=0, must_revalidate=True)
+def contact():
+    """Route to display contact page."""
+    if g.user:
+        get_user_info()
+    return render_template('contact.html')
+
 
 @app.route('/contributors')
 @cache_policy(private=True, uri_max_age=0, must_revalidate=True)


### PR DESCRIPTION
Adds the `/contact` route, a test for it, and an empty content page. Fixes #1921.

r? @zoepage