### PR TITLE
 Fixes #1977 - Adds optional browser argument for functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@
 # ref: https://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/
 sudo: required
 dist: trusty
-group: travis_latest
+group: deprecated-2017Q4
 
-env:
-  - MOZ_HEADLESS=1
-  
 addons:
-  firefox: latest
+  firefox: "55.0.2"
 
 # Only run travis on the master branch (and PRs), not all branches
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@
 # ref: https://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/
 sudo: required
 dist: trusty
+group: travis_latest
+
+env:
+  - MOZ_HEADLESS=1
+  
+addons:
+  firefox: latest
 
 # Only run travis on the master branch (and PRs), not all branches
 branches:
@@ -26,21 +33,19 @@ git:
 env:
   global:
     - ISSUES_REPO_URI=webcompat/webcompat-tests/issues
-    # grab latest 4.x release, which is LTS for now
-    - TRAVIS_NODE_VERSION="4"
 
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install node
+  - node --version
   - travis_retry npm install
   - travis_retry npm run pip
   - travis_retry npm run config
   - which firefox
   - java -version
-  - firefox --version
   # lint python
   - pep8 --ignore=E402 webcompat/ tests/ config/secrets.py.example
   - python run.py -t &
@@ -48,8 +53,10 @@ install:
 before_script:
   - "sleep 2"
   # lint JS in default eslint task
-  - npm run lint
-  - npm run build
+  - npm run lint --force
+  - npm run build --force
+  # Check that server is actually running
+  - curl localhost:5000
 
 # now run the tests!
 script:

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -101,6 +101,18 @@ To run a single test suite, where foo.js is the file found in the `tests/functio
 node_modules/.bin/intern-runner config=tests/intern functionalSuites=tests/functional/foo.js 
 ```
 
+Right now the tests are running in Chrome and Firefox as a default. You can specify which browsers you want to test with using the `browsers` argument. Like this:
+
+```bash
+npm run test:js browsers=safari,firefox
+
+or 
+
+node_modules/.bin/intern-runner config=tests/intern browsers=safari,firefox
+```
+
+For a list of the recognized browser names, just refer to [Browser enum](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_Browser.html)
+
 ## Adding Fixtures
 
 To indicate that the app should send fixture data, use the `@mockable_response` decorator for an API endpoint.

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -29,7 +29,6 @@ define(
           .setFindTimeout(timeout)
           // Wait until the `readySelector` element is found to return.
           .findByCssSelector(readySelector)
-          .end()
           .then(null, function(err) {
             return context.remote
               .getCurrentUrl()
@@ -41,6 +40,7 @@ define(
                 throw err;
               });
           })
+          .end()
       );
     }
 

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -14,7 +14,7 @@ define(["intern"], function(intern) {
   var environments = [];
   var browsers = args.browsers
     ? args.browsers.replace(/\s/g, "").split(",")
-    : ["chrome", "firefox"];
+    : ["firefox"];
 
   browsers.forEach(function(b) {
     environments.push({

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -61,16 +61,6 @@ define(["intern"], function(intern) {
     // Only one browser at a time. Takes longer, but gets less intermittent errors.
     maxConcurrency: 1,
 
-    // Note: this is temporary until the fix for the following is released (should be Firefox 56):
-    // https://github.com/mozilla/geckodriver/issues/858. It can be removed then.
-    capabilities: {
-      "moz:firefoxOptions": {
-        prefs: {
-          "dom.file.createInChild": true
-        }
-      }
-    },
-
     environments: environments,
 
     filterErrorStack: true,

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -11,6 +11,18 @@ define(["intern"], function(intern) {
   var args = intern.args;
   var siteRoot = args.siteRoot ? args.siteRoot : "http://localhost:5000";
 
+  var environments = [];
+  var browsers = args.browsers
+    ? args.browsers.replace(/\s/g, "").split(",")
+    : ["chrome", "firefox"];
+
+  browsers.forEach(function(b) {
+    environments.push({
+      browserName: b.toLowerCase(),
+      marionette: true
+    });
+  });
+
   return {
     // Configuration object for webcompat
     wc: {
@@ -59,15 +71,7 @@ define(["intern"], function(intern) {
       }
     },
 
-    environments: [
-      {
-        browserName: "firefox",
-        marionette: true
-      },
-      {
-        browserName: "chrome"
-      }
-    ],
+    environments: environments,
 
     filterErrorStack: true,
     reporters: ["Pretty"],

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -55,11 +55,21 @@ define(["intern"], function(intern) {
     tunnel: "SeleniumTunnel",
     tunnelOptions: {
       // this tells SeleniumTunnel to download geckodriver and chromedriver
-      drivers: ["firefox", "chrome"]
+      drivers: ["firefox"]
     },
 
     // Only one browser at a time. Takes longer, but gets less intermittent errors.
     maxConcurrency: 1,
+
+    // Note: this is temporary until the fix for the following is released (should be Firefox 56):
+    // https://github.com/mozilla/geckodriver/issues/858. It can be removed then.
+    capabilities: {
+      "moz:firefoxOptions": {
+        prefs: {
+          "dom.file.createInChild": true
+        }
+      }
+    },
 
     environments: environments,
 


### PR DESCRIPTION
I also removed  the temporary fix for Firefox 56, because I noticed that the issue (https://github.com/mozilla/geckodriver/issues/858) had already been closed, didn't think it was worth it creating a whole new issue for that.

r? @miketaylr 

Chrome tests are failing, but I don't think it has something to do with this PR. Since I tested them before changing anything and they were already failing... So I think the build will fail in Travis, unfortunately.