### PR TITLE
Fix #1740 - Handles double schemes URL.

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -17,6 +17,7 @@ class TestForm(unittest.TestCase):
     def setUp(self):
         """Set up."""
         webcompat.app.config['TESTING'] = True
+        self.maxDiff = None
         self.app = webcompat.app.test_client()
 
     def tearDown(self):
@@ -48,6 +49,12 @@ class TestForm(unittest.TestCase):
 
         r = form.normalize_url('//example.com')
         self.assertEqual(r, 'http://example.com')
+
+        r = form.normalize_url('http://https://bad.example.com')
+        self.assertEqual(r, 'https://bad.example.com')
+
+        r = form.normalize_url('http://param.example.com/?q=foo#bar')
+        self.assertEqual(r, 'http://param.example.com/?q=foo#bar')
 
         r = form.normalize_url('')
         self.assertIsNone(r)
@@ -135,4 +142,9 @@ class TestForm(unittest.TestCase):
         # even if the data are empty
         expected = {'body': u'<!-- @browser: None -->\n<!-- @ua_header: None -->\n<!-- @reported_with: None -->\n\n**URL**: None\n\n**Browser / Version**: None\n**Operating System**: None\n**Tested Another Browser**: Unknown\n\n**Problem type**: Unknown\n**Description**: None\n**Steps to Reproduce**:\nNone\n\n\n\n_From [webcompat.com](https://webcompat.com/) with \u2764\ufe0f_', 'title': 'None - unknown'}  # nopep8
         self.assertIs(type(actual), dict)
+        self.assertEqual(actual, expected)
+        form_object = {'url': 'http://https://example.com/'}
+        actual = form.build_formdata(form_object)
+        # testing with a strange URL.
+        expected = {'body': u'<!-- @browser: None -->\n<!-- @ua_header: None -->\n<!-- @reported_with: None -->\n\n**URL**: https://example.com/\n\n**Browser / Version**: None\n**Operating System**: None\n**Tested Another Browser**: Unknown\n\n**Problem type**: Unknown\n**Description**: None\n**Steps to Reproduce**:\nNone\n\n\n\n_From [webcompat.com](https://webcompat.com/) with \u2764\ufe0f_', 'title': 'example.com - unknown'}  # nopep8
         self.assertEqual(actual, expected)

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -140,7 +140,10 @@ def normalize_url(url):
         return None
     url = url.strip()
     parsed = urlparse.urlparse(url)
-
+    # Handle the case when URL has the form http://https://example.com
+    if parsed.netloc in ['http:', 'https:'] and parsed.path.startswith('//'):
+        url = url.split('//', 1)[1]
+    # Clean the URL.
     if url.startswith(BAD_SCHEMES) and not url.startswith(SCHEMES):
         # if url starts with a bad scheme, parsed.netloc will be empty,
         # so we use parsed.path instead
@@ -238,7 +241,7 @@ def build_formdata(form_object):
 
     formdata = {
         'metadata': get_metadata(metadata_keys, form_object),
-        'url': form_object.get('url'),
+        'url': normalized_url,
         'browser': normalize_metadata(form_object.get('browser')),
         'os': normalize_metadata(form_object.get('os')),
         'problem_type': get_radio_button_label(


### PR DESCRIPTION
Added tests and working.

```
→ nosetests -v --nocapture tests/test_form.py
Statuses Initialization…
Fetching milestones from Github…
Milestones saved in data/
Milestones in memory
The data body sent to GitHub API. ... ok
Check that domain name is extracted. ... ok
Checks we return the right form with the appropriate data. ... ok
HTML comments need the right values depending on the keys. ... ok
Check that metadata is processed and wrapped. ... ok
Avoid some type of strings. ... ok
Check that URL is normalized. ... ok
Check that appropriate radio button label is returned. ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.005s

OK
```

The rest of the unit tests are passing.

```
→ nosetests 
........................................................................
----------------------------------------------------------------------
Ran 72 tests in 2.347s

OK
```

This helps a bit with #1997 (by chance).

Because it touches the same area than issue #1995 
Once #1998 is merged, I will be happy to rebase this pull request upon the latest version of the master.

r? @miketaylr 
r? @zoepage 
