### PR TITLE
Fixes #2006: Add support for multiple `label` and `details` params.

### DIFF
--- a/tests/functional/reporting-non-auth.js
+++ b/tests/functional/reporting-non-auth.js
@@ -287,6 +287,21 @@ define(
           .end();
       },
 
+      "multiple details params add info to description": function() {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues/new?details=" + DETAILS_STRING + "&details=wowow"),
+          "#description"
+        )
+          .findByCssSelector("#steps_reproduce")
+          .getProperty("value")
+          .then(function(text) {
+            assert.include(text, "NS_ERROR_DOM_MEDIA_DEMUXER_ERR");
+            assert.include(text, "wowow");
+          })
+          .end();
+      },
+
       "details param: + decoded as space": function() {
         return FunctionalHelpers.openPage(
           this,

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -81,10 +81,14 @@ class TestForm(unittest.TestCase):
         """Check that metadata is processed and wrapped."""
         TEST_DICT = {'cool': 'dude', 'wow': 'ok'}
         EXPECTED_SINGLE = '<!-- @cool: dude -->\n'
+        EXPECTED_SINGLE_COMMA = '<!-- @cool: dude, wow -->\n'
         EXPECTED_MULTIPLE = '<!-- @cool: dude -->\n<!-- @wow: ok -->\n'
 
         r = form.wrap_metadata(('cool', 'dude'))
         self.assertEqual(r, EXPECTED_SINGLE)
+
+        r = form.wrap_metadata(('cool', 'dude, wow'))
+        self.assertEqual(r, EXPECTED_SINGLE_COMMA)
 
         r = form.get_metadata(('cool', 'wow'), TEST_DICT)
         self.assertEqual(r, EXPECTED_MULTIPLE)
@@ -135,7 +139,7 @@ class TestForm(unittest.TestCase):
                  ('bad_bird <script>', ''),
                  ('bad_bird <script-->>', ''),
                  ('a' * 300, ''),
-                 (None, None)
+                 (None, None),
                  ]
         for meta_value, expected in cases:
             self.assertEqual(form.normalize_metadata(meta_value), expected)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -135,6 +135,7 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(rv.data, 'Not an interesting hook')
 
     def test_extract_metadata(self):
+        """Extract dictionary of metadata for an issue body."""
         expected = {'reported_with': 'web',
                     'extra_labels': 'type-media, type-stylo',
                     'ua_header': ('Mozilla/5.0 (what) Gecko/20100101 '

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -50,7 +50,7 @@ class TestWebhook(unittest.TestCase):
         <!-- @browser: Firefox 55.0 -->
         <!-- @ua_header: Mozilla/5.0 (what) Gecko/20100101 Firefox/55.0 -->
         <!-- @reported_with: web -->
-        <!-- @extra_label: type-media -->
+        <!-- @extra_labels: type-media, type-stylo -->
 
         **URL**: https://www.example.com/
         **Browser / Version**: Firefox 55.0
@@ -59,6 +59,7 @@ class TestWebhook(unittest.TestCase):
 
         self.issue_body2 = """
         <!-- @browser: Foobar -->
+        <!-- @extra_labels: type-foobar -->
         """
         self.issue_body3 = """
         **URL**: https://www.google.com/
@@ -134,7 +135,8 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(rv.data, 'Not an interesting hook')
 
     def test_extract_metadata(self):
-        expected = {'reported_with': 'web', 'extra_label': 'type-media',
+        expected = {'reported_with': 'web',
+                    'extra_labels': 'type-media, type-stylo',
                     'ua_header': ('Mozilla/5.0 (what) Gecko/20100101 '
                                   'Firefox/55.0'),
                     'browser': 'Firefox 55.0'}
@@ -157,14 +159,16 @@ class TestWebhook(unittest.TestCase):
             actual = helpers.extract_browser_label(metadata_dict)
             self.assertEqual(expected, actual)
 
-    def test_extract_extra_label(self):
+    def test_extract_extra_labels(self):
         """Extract 'extra' label."""
         metadata_tests = [
-            ({'extra_label': 'type-media'}, 'type-media'),
-            ({'burgers': 'french fries'}, None)
+            ({'extra_labels': 'type-media'}, ['type-media']),
+            ({'extra_labels': 'cool, dude'}, ['cool', 'dude']),
+            ({'extra_labels': u'weather-☁'}, ['weather-\xe2\x98\x81']),
+            ({'burgers': 'french fries'}, None),
         ]
         for metadata_dict, expected in metadata_tests:
-            actual = helpers.extract_extra_label(metadata_dict)
+            actual = helpers.extract_extra_labels(metadata_dict)
             self.assertEqual(expected, actual)
 
     def test_extract_priority_label(self):
@@ -176,6 +180,17 @@ class TestWebhook(unittest.TestCase):
             self.assertEqual(priority_label, 'priority-critical')
         priority_label_none = helpers.extract_priority_label(self.issue_body)
         self.assertEqual(priority_label_none, None)
+
+    def test_get_issue_labels(self):
+        """Extract list of labels from an issue body."""
+        labels_tests = [
+            (self.issue_body, ['browser-firefox', 'type-media', 'type-stylo']),
+            (self.issue_body2, ['type-foobar']),
+            (self.issue_body3, ['browser-firefox-mobile-tablet'])
+        ]
+        for issue_body, expected in labels_tests:
+            actual = helpers.get_issue_labels(issue_body)
+            self.assertEqual(sorted(expected), sorted(actual))
 
     def test_is_github_hook(self):
         """Validation tests for GitHub Webhooks."""

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -128,8 +128,15 @@ def wrap_metadata(metadata):
 
 def get_metadata(metadata_keys, form_object):
     """Return relevant metadata hanging off the form as a single string."""
+    extra_labels = []
+    if 'extra_labels' in metadata_keys:
+        extra_labels = [normalize_metadata(label)
+                        for label in form_object.get('extra_labels')
+                        if label in app.config['EXTRA_LABELS']]
+        metadata_keys.remove('extra_labels')
     metadata = [(key, form_object.get(key)) for key in metadata_keys]
     metadata = [(md[0], normalize_metadata(md[1])) for md in metadata]
+    metadata.extend(extra_labels)
     # Now, "wrap the metadata" and return them all as a single string
     return ''.join([wrap_metadata(md) for md in metadata])
 
@@ -236,9 +243,9 @@ def build_formdata(form_object):
         summary = u'{0} - {1}'.format(normalized_url, problem_summary)
 
     metadata_keys = ['browser', 'ua_header', 'reported_with']
-    extra_label = form_object.get('extra_label', None)
-    if extra_label in app.config['EXTRA_LABELS']:
-        metadata_keys.append('extra_label')
+    extra_labels = form_object.get('extra_labels', None)
+    if extra_labels:
+        metadata_keys.append('extra_labels')
 
     formdata = {
         'metadata': get_metadata(metadata_keys, form_object),

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -176,17 +176,25 @@ function BugForm() {
       $("[value=" + problemType[1] + "]").click();
     }
 
-    // If we got a details param, add that to the end of the steps to reproduce field
-    var details = location.href.match(/details=([^&]*)/);
+    // If we have one or more details params,
+    // add that to the end of the steps to reproduce textarea
+    var details = location.href.match(/details=([^&]*)/g);
     if (details !== null) {
       this.stepsToReproduceField.val(function(idx, value) {
         return (
           value +
           "\n" +
-          // The content of the details param may be encoded via
-          // application/x-www-form-urlencoded, so we need to change the
-          // + (SPACE) to %20 before decoding
-          decodeURIComponent(details[1].replace(/\+/g, "%20"))
+          decodeURIComponent(
+            details
+              .map(function(item) {
+                return item.replace(/details=/, "");
+              })
+              .join("\n")
+              // The content of the details param may be encoded via
+              // application/x-www-form-urlencoded, so we need to change the
+              // + (SPACE) to %20 before decoding
+              .replace(/\+/g, "%20")
+          )
         );
       });
     }

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -176,9 +176,10 @@ def create_issue():
         # HTML <form>, so we stick them in the session cookie so they survive
         # the scenario where the user decides to do authentication, and they
         # can then be passed on to form.py
-        for param in ['src', 'label']:
-            if request.args.get(param):
-                session[param] = request.args.get(param)
+        if request.args.get('src'):
+            session['src'] = request.args.get('src')
+        if request.args.get('label'):
+            session['label'] = request.args.getlist('label')
         return render_template('new-issue.html', form=bug_form)
     # copy the form so we can add the full UA string to it.
     if request.form:
@@ -207,7 +208,8 @@ def create_issue():
             return redirect(url_for('index'))
     form['ua_header'] = request.headers.get('User-Agent')
     form['reported_with'] = session.pop('src', 'web')
-    form['extra_label'] = session.pop('label', None)
+    # Reminder: label is a list, if it exists
+    form['extra_labels'] = session.pop('label', None)
     # Logging the ip and url for investigation
     log = app.logger
     log.setLevel(logging.INFO)


### PR DESCRIPTION
Our test situation seems FUBAR in Firefox 57+ right now, but these new functional tests pass in Chrome, and nosetests are good.

<img width="556" alt="screen shot 2018-01-08 at 10 37 03 pm" src="https://user-images.githubusercontent.com/67283/34705246-c1981278-f4c4-11e7-943a-a08f94c7df0f.png">

<img width="798" alt="screen shot 2018-01-08 at 10 40 54 pm" src="https://user-images.githubusercontent.com/67283/34705290-170d379c-f4c5-11e7-8b13-d72dc06912ae.png">





r? @karlcow 
r? @zoepage 