### PR TITLE
Fixes #2019. Append extra labels in correct format.

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -5,6 +5,8 @@
 
 import unittest
 
+from werkzeug import MultiDict
+
 import webcompat
 from webcompat import form
 
@@ -128,6 +130,17 @@ class TestForm(unittest.TestCase):
         form_object = {'blah': 'goo', 'hello': 'moshi', 'sky': 'blue'}
         actual = form.get_metadata(metadata_keys, form_object)
         expected = u'<!-- @sky: blue -->\n<!-- @earth: None -->\n'
+        self.assertEqual(actual, expected)
+        form_object = MultiDict([
+            ('reported_with', u'desktop-reporter'),
+            ('url', u'http://localhost:5000/issues/new'),
+            ('extra_labels', [u'type-stylo', u'type-webrender-enabled']),
+            ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
+            ('browser', u'Firefox 59.0')])
+        metadata_keys = ['browser', 'ua_header', 'reported_with',
+                         'extra_labels']
+        actual = form.get_metadata(metadata_keys, form_object)
+        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-stylo, type-webrender-enabled -->\n'  # nopep8
         self.assertEqual(actual, expected)
 
     def test_normalize_metadata(self):

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -136,7 +136,8 @@ def get_metadata(metadata_keys, form_object):
         metadata_keys.remove('extra_labels')
     metadata = [(key, form_object.get(key)) for key in metadata_keys]
     metadata = [(md[0], normalize_metadata(md[1])) for md in metadata]
-    metadata.extend(extra_labels)
+    if extra_labels:
+        metadata.append(('extra_labels', u', '.join(extra_labels)))
     # Now, "wrap the metadata" and return them all as a single string
     return ''.join([wrap_metadata(md) for md in metadata])
 


### PR DESCRIPTION
The intermediary metadata list expects a list of tuples, with the
metadata key being the first member of the tuple, and its value the
second.

Also, adds an assertion to explicitly test getting `extra_labels` metadata, since it gets special handling.