### PR TITLE
Fixes #1585. Add a method to define img-src CSP policy directive.

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -474,6 +474,17 @@ def add_sec_headers(response):
     response.headers['X-Frame-Options'] = 'DENY'
 
 
+def get_img_src_policy():
+    """Return the img-src policy directive, depending on environment.
+
+    We allow webcompat.com-hosted images on localhost servers for convenience.
+    """
+    policy = "img-src 'self' https://www.google-analytics.com https://*.githubusercontent.com data:; "  # nopep8
+    if app.config['LOCALHOST']:
+        policy = "img-src 'self' https://webcompat.com https://www.google-analytics.com https://*.githubusercontent.com data:; "  # nopep8
+    return policy
+
+
 def add_csp(response):
     """Add a Content-Security-Policy header to response.
 
@@ -485,7 +496,7 @@ def add_csp(response):
         "object-src 'none'; " +
         "connect-src 'self' https://api.github.com; " +
         "font-src 'self'; " +
-        "img-src 'self' https://www.google-analytics.com https://*.githubusercontent.com data:; " +  # nopep8
+        get_img_src_policy() +
         "manifest-src 'self'; " +
         "script-src 'self' https://www.google-analytics.com https://api.github.com; " +  # nopep8
         "style-src 'self' 'unsafe-inline'; " +


### PR DESCRIPTION
This allows us to whitelist https://webcompat.com for localhost servers.

r? @karlcow 