### PR TITLE
Fixes #2171 - add test for 404 label search

### DIFF
--- a/tests/fixtures/api/issues.2c36ce8c0fec0c185101ba8f6b203f48.json
+++ b/tests/fixtures/api/issues.2c36ce8c0fec0c185101ba8f6b203f48.json
@@ -1,0 +1,6 @@
+{
+	"_fixture": true,
+	"total_count": 0,
+	"incomplete_results": false,
+	"items": []
+}

--- a/tests/fixtures/api/issues/search.5e5381153d0090cbe83977d63930e858.json
+++ b/tests/fixtures/api/issues/search.5e5381153d0090cbe83977d63930e858.json
@@ -1,0 +1,352 @@
+{
+  "_fixture": true,
+  "total_count": 3,
+  "incomplete_results": false,
+  "items": [
+    {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1371",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1371/labels{/name}",
+      "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1371/comments",
+      "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1371/events",
+      "html_url": "https://github.com/webcompat/webcompat-tests/issues/1371",
+      "id": 296904917,
+      "number": 1371,
+      "title": "candyforthemassesdbhjsadnasbhjdksbdasbndkbaskbdasbdhasbdas.org - desktop site instead of mobile site",
+      "user": {
+        "login": "webcompat-bot",
+        "id": 8862693,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/8862693?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/webcompat-bot",
+        "html_url": "https://github.com/webcompat-bot",
+        "followers_url": "https://api.github.com/users/webcompat-bot/followers",
+        "following_url": "https://api.github.com/users/webcompat-bot/following{/other_user}",
+        "gists_url": "https://api.github.com/users/webcompat-bot/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/webcompat-bot/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/webcompat-bot/subscriptions",
+        "organizations_url": "https://api.github.com/users/webcompat-bot/orgs",
+        "repos_url": "https://api.github.com/users/webcompat-bot/repos",
+        "events_url": "https://api.github.com/users/webcompat-bot/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/webcompat-bot/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 148714215,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-android",
+          "name": "browser-android",
+          "color": "f7c6c7",
+          "default": false
+        },
+        {
+          "id": 90454697,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-chrome",
+          "name": "browser-chrome",
+          "color": "006b75",
+          "default": false
+        },
+        {
+          "id": 182807004,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-firefox",
+          "name": "browser-firefox",
+          "color": "d4c5f9",
+          "default": false
+        }
+      ],
+      "state": "open",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": {
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1",
+        "html_url": "https://github.com/webcompat/webcompat-tests/milestone/1",
+        "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1/labels",
+        "id": 2744172,
+        "number": 1,
+        "title": "needstriage",
+        "description": "Issues which needs to be triaged",
+        "creator": {
+          "login": "karlcow",
+          "id": 505230,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/505230?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/karlcow",
+          "html_url": "https://github.com/karlcow",
+          "followers_url": "https://api.github.com/users/karlcow/followers",
+          "following_url": "https://api.github.com/users/karlcow/following{/other_user}",
+          "gists_url": "https://api.github.com/users/karlcow/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/karlcow/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/karlcow/subscriptions",
+          "organizations_url": "https://api.github.com/users/karlcow/orgs",
+          "repos_url": "https://api.github.com/users/karlcow/repos",
+          "events_url": "https://api.github.com/users/karlcow/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/karlcow/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "open_issues": 70,
+        "closed_issues": 0,
+        "state": "open",
+        "created_at": "2017-09-05T03:39:06Z",
+        "updated_at": "2018-03-01T21:15:19Z",
+        "due_on": null,
+        "closed_at": null
+      },
+      "comments": 0,
+      "created_at": "2018-02-13T22:13:52Z",
+      "updated_at": "2018-02-20T09:50:55Z",
+      "closed_at": null,
+      "author_association": "MEMBER",
+      "body": "<!-- @browser: Firefox 60.0 -->\n<!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0 -->\n<!-- @reported_with: web -->\n\n**URL**: http://candyforthemasses.org\n\n**Browser / Version**: Firefox 60.0\n**Operating System**: Mac OS X 10.13\n**Tested Another Browser**: Yes\n\n**Problem type**: Desktop site instead of mobile site\n**Description**: nothing, just bored\n**Steps to Reproduce**:\n\n\n\n\n_From [webcompat.com](https://webcompat.com/) with ❤️_",
+      "score": 1.0
+    },
+    {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1367",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1367/labels{/name}",
+      "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1367/comments",
+      "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1367/events",
+      "html_url": "https://github.com/webcompat/webcompat-tests/issues/1367",
+      "id": 293216830,
+      "number": 1367,
+      "title": "candyforthemassesandlongerurlasweneedtotestsomething.org - desktop site instead of mobile site",
+      "user": {
+        "login": "webcompat-bot",
+        "id": 8862693,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/8862693?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/webcompat-bot",
+        "html_url": "https://github.com/webcompat-bot",
+        "followers_url": "https://api.github.com/users/webcompat-bot/followers",
+        "following_url": "https://api.github.com/users/webcompat-bot/following{/other_user}",
+        "gists_url": "https://api.github.com/users/webcompat-bot/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/webcompat-bot/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/webcompat-bot/subscriptions",
+        "organizations_url": "https://api.github.com/users/webcompat-bot/orgs",
+        "repos_url": "https://api.github.com/users/webcompat-bot/repos",
+        "events_url": "https://api.github.com/users/webcompat-bot/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/webcompat-bot/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 148714215,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-android",
+          "name": "browser-android",
+          "color": "f7c6c7",
+          "default": false
+        },
+        {
+          "id": 90454697,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-chrome",
+          "name": "browser-chrome",
+          "color": "006b75",
+          "default": false
+        },
+        {
+          "id": 764985357,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-firefou-abc",
+          "name": "browser-firefou-abc",
+          "color": "ededed",
+          "default": false
+        },
+        {
+          "id": 602787897,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-firefox-mobile-(tablet)",
+          "name": "browser-firefox-mobile-(tablet)",
+          "color": "ededed",
+          "default": false
+        },
+        {
+          "id": 86614755,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/closed-duplicate",
+          "name": "closed-duplicate",
+          "color": "cccccc",
+          "default": false
+        },
+        {
+          "id": 584072494,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/type-media",
+          "name": "type-media",
+          "color": "ededed",
+          "default": false
+        },
+        {
+          "id": 650809601,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/type-stylo",
+          "name": "type-stylo",
+          "color": "ededed",
+          "default": false
+        }
+      ],
+      "state": "open",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": {
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1",
+        "html_url": "https://github.com/webcompat/webcompat-tests/milestone/1",
+        "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1/labels",
+        "id": 2744172,
+        "number": 1,
+        "title": "needstriage",
+        "description": "Issues which needs to be triaged",
+        "creator": {
+          "login": "karlcow",
+          "id": 505230,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/505230?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/karlcow",
+          "html_url": "https://github.com/karlcow",
+          "followers_url": "https://api.github.com/users/karlcow/followers",
+          "following_url": "https://api.github.com/users/karlcow/following{/other_user}",
+          "gists_url": "https://api.github.com/users/karlcow/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/karlcow/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/karlcow/subscriptions",
+          "organizations_url": "https://api.github.com/users/karlcow/orgs",
+          "repos_url": "https://api.github.com/users/karlcow/repos",
+          "events_url": "https://api.github.com/users/karlcow/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/karlcow/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "open_issues": 70,
+        "closed_issues": 0,
+        "state": "open",
+        "created_at": "2017-09-05T03:39:06Z",
+        "updated_at": "2018-03-01T21:15:19Z",
+        "due_on": null,
+        "closed_at": null
+      },
+      "comments": 12,
+      "created_at": "2018-01-31T16:10:45Z",
+      "updated_at": "2018-02-19T10:02:51Z",
+      "closed_at": null,
+      "author_association": "MEMBER",
+      "body": "<!-- @browser: Firefox 60.0 -->\n<!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0 -->\n<!-- @reported_with: web -->\n\n**URL**: http://candyforthemasses.org\n\n**Browser / Version**: Firefox 60.0\n**Operating System**: Mac OS X 10.13\n**Tested Another Browser**: No\n\n**Problem type**: Desktop site instead of mobile site\n**Description**: There is no candy\n**Steps to Reproduce**:\n1\r\n2\r\n3\n\n\n\n_From [webcompat.com](https://webcompat.com/) with ❤️_",
+      "score": 1.0
+    },
+    {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1103",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1103/labels{/name}",
+      "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1103/comments",
+      "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/1103/events",
+      "html_url": "https://github.com/webcompat/webcompat-tests/issues/1103",
+      "id": 245752612,
+      "number": 1103,
+      "title": "example.com - unknown",
+      "user": {
+        "login": "brizental",
+        "id": 25176023,
+        "avatar_url": "https://avatars2.githubusercontent.com/u/25176023?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/brizental",
+        "html_url": "https://github.com/brizental",
+        "followers_url": "https://api.github.com/users/brizental/followers",
+        "following_url": "https://api.github.com/users/brizental/following{/other_user}",
+        "gists_url": "https://api.github.com/users/brizental/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/brizental/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/brizental/subscriptions",
+        "organizations_url": "https://api.github.com/users/brizental/orgs",
+        "repos_url": "https://api.github.com/users/brizental/repos",
+        "events_url": "https://api.github.com/users/brizental/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/brizental/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 148714215,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-android",
+          "name": "browser-android",
+          "color": "f7c6c7",
+          "default": false
+        },
+        {
+          "id": 602787897,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-firefox-mobile-(tablet)",
+          "name": "browser-firefox-mobile-(tablet)",
+          "color": "ededed",
+          "default": false
+        },
+        {
+          "id": 124747710,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/browser-ie",
+          "name": "browser-ie",
+          "color": "ededed",
+          "default": false
+        },
+        {
+          "id": 388130717,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/nsfw",
+          "name": "nsfw",
+          "color": "b60205",
+          "default": false
+        },
+        {
+          "id": 743991534,
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/status-needinfo",
+          "name": "status-needinfo",
+          "color": "bfd4f2",
+          "default": false
+        }
+      ],
+      "state": "open",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": {
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1",
+        "html_url": "https://github.com/webcompat/webcompat-tests/milestone/1",
+        "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/1/labels",
+        "id": 2744172,
+        "number": 1,
+        "title": "needstriage",
+        "description": "Issues which needs to be triaged",
+        "creator": {
+          "login": "karlcow",
+          "id": 505230,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/505230?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/karlcow",
+          "html_url": "https://github.com/karlcow",
+          "followers_url": "https://api.github.com/users/karlcow/followers",
+          "following_url": "https://api.github.com/users/karlcow/following{/other_user}",
+          "gists_url": "https://api.github.com/users/karlcow/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/karlcow/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/karlcow/subscriptions",
+          "organizations_url": "https://api.github.com/users/karlcow/orgs",
+          "repos_url": "https://api.github.com/users/karlcow/repos",
+          "events_url": "https://api.github.com/users/karlcow/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/karlcow/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "open_issues": 70,
+        "closed_issues": 0,
+        "state": "open",
+        "created_at": "2017-09-05T03:39:06Z",
+        "updated_at": "2018-03-01T21:15:19Z",
+        "due_on": null,
+        "closed_at": null
+      },
+      "comments": 0,
+      "created_at": "2017-07-26T15:01:51Z",
+      "updated_at": "2017-11-27T11:26:32Z",
+      "closed_at": null,
+      "author_association": "MEMBER",
+      "body": "<!-- @browser: BarFoo -->\n<!-- @ua_header: werkzeug/0.12.2 -->\n<!-- @reported_with: web -->\n\n**URL**: http://example.com\n\n**Browser / Version**: BarFoo\n**Operating System**: Foobar\n**Tested Another Browser**: Unknown\n\n**Problem type**: Unknown\n**Description**: foo\n**Steps to Reproduce**:\nNone\n\n\n\n_From [webcompat.com](https://webcompat.com/) with ❤️_",
+      "score": 1.0
+    }
+  ]
+}

--- a/tests/functional/_intern.js
+++ b/tests/functional/_intern.js
@@ -59,9 +59,7 @@ intern.configure({
   reporters: [args.reporters ? args.reporters : "pretty"],
 
   functionalSuites: [
-    args.functionalSuites
-      ? args.functionalSuites
-      : "./tests/functional/*.js"
+    args.functionalSuites ? args.functionalSuites : "./tests/functional/*.js"
   ]
 });
 

--- a/tests/functional/_intern.js
+++ b/tests/functional/_intern.js
@@ -59,7 +59,9 @@ intern.configure({
   reporters: [args.reporters ? args.reporters : "pretty"],
 
   functionalSuites: [
-    args.functionalSuites ? args.functionalSuites : "./tests/functional/*.js"
+    args.functionalSuites
+      ? args.functionalSuites
+      : "./tests/functional/*.js"
   ]
 });
 

--- a/tests/functional/search-auth.js
+++ b/tests/functional/search-auth.js
@@ -62,96 +62,15 @@ registerSuite("Search (auth)", {
         .end();
     },
 
-    "Results are loaded from the query params"() {
-      var params =
-        "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=vladvlad";
-      return FunctionalHelpers.openPage(
-        this,
-        url("/issues", params),
-        ".js-IssueList:nth-of-type(1)"
-      )
-        .findDisplayedByCssSelector(".js-IssueList:nth-of-type(1) a")
-        .getVisibleText()
-        .then(function(text) {
-          assert.include(
-            text,
-            "vladvlad",
-            "The search query results show up on the page."
-          );
-        })
-        .end()
-        .getCurrentUrl()
-        .then(function(currUrl) {
-          assert.include(
-            currUrl,
-            "q=vladvlad",
-            "Our params didn't go anywhere."
-          );
-        })
-        .end();
-    },
-
-    "Search works by icon click"() {
-      return FunctionalHelpers.openPage(
-        this,
-        url("/issues"),
-        ".js-IssueList:nth-of-type(10)"
-      )
-        .findByCssSelector(".js-SearchForm input")
-        .type("vladvlad")
-        .end()
-        .findByCssSelector(".js-SearchForm button")
-        .click()
-        .end()
-        .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
-        .getVisibleText()
-        .then(function(text) {
-          assert.include(
-            text,
-            "vladvlad",
-            "The search results show up on the page."
-          );
-        })
-        .end();
-    },
-
-    "Search works by Return key"() {
-      return FunctionalHelpers.openPage(
-        this,
-        url("/issues"),
-        ".js-SearchForm input"
-      )
-        .findDisplayedByCssSelector(".js-SearchForm input")
-        .type("vladvlad")
-        .type("\uE007")
-        .end()
-        .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
-        .getVisibleText()
-        .then(function(text) {
-          assert.include(
-            text,
-            "vladvlad",
-            "The search results show up on the page."
-          );
-        })
-        .end();
-    },
-
-    "Search from the homepage"() {
-      return (
-        FunctionalHelpers.openPage(this, url("/"), ".js-SearchBarOpen")
-          .get(url("/"))
-          .findByCssSelector(".js-SearchBarOpen")
-          .click()
-          .end()
-          // Wait for animation to complete.
-          .sleep(1000)
-          .findByCssSelector(".js-SearchBar input")
-          .click()
-          .type("vladvlad")
-          .type("\uE007")
-          .end()
-          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+      "Results are loaded from the query params"() {
+        var params =
+          "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=vladvlad";
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues", params),
+          ".js-IssueList:nth-of-type(1)"
+        )
+          .findDisplayedByCssSelector(".js-IssueList:nth-of-type(1) a")
           .getVisibleText()
           .then(function(text) {
             assert.include(
@@ -163,11 +82,92 @@ registerSuite("Search (auth)", {
           .end()
           .getCurrentUrl()
           .then(function(currUrl) {
-            assert.include(currUrl, "page=1", "Default params got merged.");
+            assert.include(
+              currUrl,
+              "q=vladvlad",
+              "Our params didn't go anywhere."
+            );
           })
+          .end();
+      },
+
+      "Search works by icon click"() {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues"),
+          ".js-IssueList:nth-of-type(10)"
+        )
+          .findByCssSelector(".js-SearchForm input")
+          .type("vladvlad")
           .end()
-      );
-    },
+          .findByCssSelector(".js-SearchForm button")
+          .click()
+          .end()
+          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+          .getVisibleText()
+          .then(function(text) {
+            assert.include(
+              text,
+              "vladvlad",
+              "The search results show up on the page."
+            );
+          })
+          .end();
+      },
+
+      "Search works by Return key"() {
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues"),
+          ".js-SearchForm input"
+        )
+          .findDisplayedByCssSelector(".js-SearchForm input")
+          .type("vladvlad")
+          .type("\uE007")
+          .end()
+          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+          .getVisibleText()
+          .then(function(text) {
+            assert.include(
+              text,
+              "vladvlad",
+              "The search results show up on the page."
+            );
+          })
+          .end();
+      },
+
+      "Search from the homepage"() {
+        return (
+          FunctionalHelpers.openPage(this, url("/"), ".js-SearchBarOpen")
+            .get(url("/"))
+            .findByCssSelector(".js-SearchBarOpen")
+            .click()
+            .end()
+            // Wait for animation to complete.
+            .sleep(1000)
+            .findByCssSelector(".js-SearchBar input")
+            .click()
+            .type("vladvlad")
+            .type("\uE007")
+            .end()
+            .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+            .getVisibleText()
+            .then(function(text) {
+              assert.include(
+                text,
+                "vladvlad",
+                "The search query results show up on the page."
+              );
+            })
+            .end()
+            .getCurrentUrl()
+            .then(function(currUrl) {
+              assert.include(currUrl, "page=1", "Default params got merged.");
+            })
+            .end()
+        );
+      },
 
     "Search with a dash works"() {
       // load up a garbage search, so we can more easily detect when
@@ -198,25 +198,69 @@ registerSuite("Search (auth)", {
         .end();
     },
 
-    "Search input is loaded from q param (with dashes)"() {
+    "Label have correct URL after search without results"() {
       // load up a garbage search, so we can more easily detect when
       // the search values we want are loaded.
-      var searchParam = "?q=one:two-three";
-      return FunctionalHelpers.openPage(
-        this,
-        url("/issues", searchParam),
-        ".js-no-results"
-      )
-        .findByCssSelector("#js-SearchForm-input")
-        .getProperty("value")
-        .then(function(text) {
-          assert.include(
-            text,
-            "one:two-three",
-            "The q param populated the search input."
-          );
-        })
-        .end();
-    }
+      return (
+        FunctionalHelpers.openPage(
+          this,
+          url(
+            "/issues",
+            "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc"
+          ),
+          ".grid"
+        )
+          .findByCssSelector("#js-SearchForm-input")
+          .clearValue()
+          .click()
+          .type("noExpectedResult123")
+          .submit()
+          .getProperty("value")
+          .then(function(text) {
+            assert.equal(
+              text,
+              "noExpectedResult123",
+              "The q param populated the search input."
+            );
+          })
+          .end()
+          .findByCssSelector("#x-search-bar")
+          .submit()
+          .end()
+          .sleep(2000)
+          .findDisplayedByCssSelector(".label-browser-android")
+          .click()
+          .end()
+          .getCurrentUrl()
+          .then(function(url){
+            assert.equal(
+              url,
+              "http://localhost:5000/issues?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=label%3Abrowser-android",
+              "Suggested labels are shown with correct URL."
+            )
+          })
+      );
+    },
+
+      "Search input is loaded from q param (with dashes)"() {
+        // load up a garbage search, so we can more easily detect when
+        // the search values we want are loaded.
+        var searchParam = "?q=one:two-three";
+        return FunctionalHelpers.openPage(
+          this,
+          url("/issues", searchParam),
+          ".js-no-results"
+        )
+          .findByCssSelector("#js-SearchForm-input")
+          .getProperty("value")
+          .then(function(text) {
+            assert.include(
+              text,
+              "one:two-three",
+              "The q param populated the search input."
+            );
+          })
+          .end();
+      }
   }
 });

--- a/tests/functional/search-auth.js
+++ b/tests/functional/search-auth.js
@@ -62,15 +62,96 @@ registerSuite("Search (auth)", {
         .end();
     },
 
-      "Results are loaded from the query params"() {
-        var params =
-          "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=vladvlad";
-        return FunctionalHelpers.openPage(
-          this,
-          url("/issues", params),
-          ".js-IssueList:nth-of-type(1)"
-        )
-          .findDisplayedByCssSelector(".js-IssueList:nth-of-type(1) a")
+    "Results are loaded from the query params"() {
+      var params =
+        "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=vladvlad";
+      return FunctionalHelpers.openPage(
+        this,
+        url("/issues", params),
+        ".js-IssueList:nth-of-type(1)"
+      )
+        .findDisplayedByCssSelector(".js-IssueList:nth-of-type(1) a")
+        .getVisibleText()
+        .then(function(text) {
+          assert.include(
+            text,
+            "vladvlad",
+            "The search query results show up on the page."
+          );
+        })
+        .end()
+        .getCurrentUrl()
+        .then(function(currUrl) {
+          assert.include(
+            currUrl,
+            "q=vladvlad",
+            "Our params didn't go anywhere."
+          );
+        })
+        .end();
+    },
+
+    "Search works by icon click"() {
+      return FunctionalHelpers.openPage(
+        this,
+        url("/issues"),
+        ".js-IssueList:nth-of-type(10)"
+      )
+        .findByCssSelector(".js-SearchForm input")
+        .type("vladvlad")
+        .end()
+        .findByCssSelector(".js-SearchForm button")
+        .click()
+        .end()
+        .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+        .getVisibleText()
+        .then(function(text) {
+          assert.include(
+            text,
+            "vladvlad",
+            "The search results show up on the page."
+          );
+        })
+        .end();
+    },
+
+    "Search works by Return key"() {
+      return FunctionalHelpers.openPage(
+        this,
+        url("/issues"),
+        ".js-SearchForm input"
+      )
+        .findDisplayedByCssSelector(".js-SearchForm input")
+        .type("vladvlad")
+        .type("\uE007")
+        .end()
+        .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
+        .getVisibleText()
+        .then(function(text) {
+          assert.include(
+            text,
+            "vladvlad",
+            "The search results show up on the page."
+          );
+        })
+        .end();
+    },
+
+    "Search from the homepage"() {
+      return (
+        FunctionalHelpers.openPage(this, url("/"), ".js-SearchBarOpen")
+          .get(url("/"))
+          .findByCssSelector(".js-SearchBarOpen")
+          .click()
+          .end()
+          // Wait for animation to complete.
+          .sleep(1000)
+          .findByCssSelector(".js-SearchBar input")
+          .click()
+          .type("vladvlad")
+          .type("\uE007")
+          .end()
+          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
           .getVisibleText()
           .then(function(text) {
             assert.include(
@@ -82,92 +163,11 @@ registerSuite("Search (auth)", {
           .end()
           .getCurrentUrl()
           .then(function(currUrl) {
-            assert.include(
-              currUrl,
-              "q=vladvlad",
-              "Our params didn't go anywhere."
-            );
+            assert.include(currUrl, "page=1", "Default params got merged.");
           })
-          .end();
-      },
-
-      "Search works by icon click"() {
-        return FunctionalHelpers.openPage(
-          this,
-          url("/issues"),
-          ".js-IssueList:nth-of-type(10)"
-        )
-          .findByCssSelector(".js-SearchForm input")
-          .type("vladvlad")
           .end()
-          .findByCssSelector(".js-SearchForm button")
-          .click()
-          .end()
-          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
-          .getVisibleText()
-          .then(function(text) {
-            assert.include(
-              text,
-              "vladvlad",
-              "The search results show up on the page."
-            );
-          })
-          .end();
-      },
-
-      "Search works by Return key"() {
-        return FunctionalHelpers.openPage(
-          this,
-          url("/issues"),
-          ".js-SearchForm input"
-        )
-          .findDisplayedByCssSelector(".js-SearchForm input")
-          .type("vladvlad")
-          .type("\uE007")
-          .end()
-          .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
-          .getVisibleText()
-          .then(function(text) {
-            assert.include(
-              text,
-              "vladvlad",
-              "The search results show up on the page."
-            );
-          })
-          .end();
-      },
-
-      "Search from the homepage"() {
-        return (
-          FunctionalHelpers.openPage(this, url("/"), ".js-SearchBarOpen")
-            .get(url("/"))
-            .findByCssSelector(".js-SearchBarOpen")
-            .click()
-            .end()
-            // Wait for animation to complete.
-            .sleep(1000)
-            .findByCssSelector(".js-SearchBar input")
-            .click()
-            .type("vladvlad")
-            .type("\uE007")
-            .end()
-            .findDisplayedByCssSelector(".js-IssueList:only-of-type a")
-            .getVisibleText()
-            .then(function(text) {
-              assert.include(
-                text,
-                "vladvlad",
-                "The search query results show up on the page."
-              );
-            })
-            .end()
-            .getCurrentUrl()
-            .then(function(currUrl) {
-              assert.include(currUrl, "page=1", "Default params got merged.");
-            })
-            .end()
-        );
-      },
+      );
+    },
 
     "Search with a dash works"() {
       // load up a garbage search, so we can more easily detect when
@@ -201,66 +201,64 @@ registerSuite("Search (auth)", {
     "Label have correct URL after search without results"() {
       // load up a garbage search, so we can more easily detect when
       // the search values we want are loaded.
-      return (
-        FunctionalHelpers.openPage(
-          this,
-          url(
-            "/issues",
-            "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc"
-          ),
-          ".grid"
-        )
-          .findByCssSelector("#js-SearchForm-input")
-          .clearValue()
-          .click()
-          .type("noExpectedResult123")
-          .submit()
-          .getProperty("value")
-          .then(function(text) {
-            assert.equal(
-              text,
-              "noExpectedResult123",
-              "The q param populated the search input."
-            );
-          })
-          .end()
-          .findByCssSelector("#x-search-bar")
-          .submit()
-          .end()
-          .sleep(2000)
-          .findDisplayedByCssSelector(".label-browser-android")
-          .click()
-          .end()
-          .getCurrentUrl()
-          .then(function(url){
-            assert.equal(
-              url,
-              "http://localhost:5000/issues?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=label%3Abrowser-android",
-              "Suggested labels are shown with correct URL."
-            )
-          })
-      );
+      return FunctionalHelpers.openPage(
+        this,
+        url(
+          "/issues",
+          "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc"
+        ),
+        ".grid"
+      )
+        .findByCssSelector("#js-SearchForm-input")
+        .clearValue()
+        .click()
+        .type("noExpectedResult123")
+        .submit()
+        .getProperty("value")
+        .then(function(text) {
+          assert.equal(
+            text,
+            "noExpectedResult123",
+            "The q param populated the search input."
+          );
+        })
+        .end()
+        .findByCssSelector("#x-search-bar")
+        .submit()
+        .end()
+        .sleep(2000)
+        .findDisplayedByCssSelector(".label-browser-android")
+        .click()
+        .end()
+        .getCurrentUrl()
+        .then(function(url) {
+          assert.equal(
+            url,
+            "http://localhost:5000/issues?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=label%3Abrowser-android",
+            "Suggested labels are shown with correct URL."
+          );
+        });
     },
 
-      "Search input is loaded from q param (with dashes)"() {
-        // load up a garbage search, so we can more easily detect when
-        // the search values we want are loaded.
-        var searchParam = "?q=one:two-three";
-        return FunctionalHelpers.openPage(
-          this,
-          url("/issues", searchParam),
-          ".js-no-results"
-        )
-          .findByCssSelector("#js-SearchForm-input")
-          .getProperty("value")
-          .then(function(text) {
-            assert.include(
-              text,
-              "one:two-three",
-              "The q param populated the search input."
-            );
-          })
-          .end();
-      }
+    "Search input is loaded from q param (with dashes)"() {
+      // load up a garbage search, so we can more easily detect when
+      // the search values we want are loaded.
+      var searchParam = "?q=one:two-three";
+      return FunctionalHelpers.openPage(
+        this,
+        url("/issues", searchParam),
+        ".js-no-results"
+      )
+        .findByCssSelector("#js-SearchForm-input")
+        .getProperty("value")
+        .then(function(text) {
+          assert.include(
+            text,
+            "one:two-three",
+            "The q param populated the search input."
+          );
+        })
+        .end();
+    }
   }
 });

--- a/tests/functional/search-auth.js
+++ b/tests/functional/search-auth.js
@@ -198,30 +198,11 @@ registerSuite("Search (auth)", {
         .end();
     },
 
-    "Label have correct URL after search without results"() {
-      // load up a garbage search, so we can more easily detect when
-      // the search values we want are loaded.
-      return FunctionalHelpers.openPage(
-        this,
-        url(
-          "/issues",
-          "?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc"
-        ),
-        ".grid"
-      )
+    "After search without results, suggested label appear and have a clickable URL."() {
+      return FunctionalHelpers.openPage(this, url("/issues"), ".grid")
         .findByCssSelector("#js-SearchForm-input")
-        .clearValue()
         .click()
         .type("noExpectedResult123")
-        .submit()
-        .getProperty("value")
-        .then(function(text) {
-          assert.equal(
-            text,
-            "noExpectedResult123",
-            "The q param populated the search input."
-          );
-        })
         .end()
         .findByCssSelector("#x-search-bar")
         .submit()
@@ -232,10 +213,11 @@ registerSuite("Search (auth)", {
         .end()
         .getCurrentUrl()
         .then(function(url) {
-          assert.equal(
-            url,
-            "http://localhost:5000/issues?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc&q=label%3Abrowser-android",
-            "Suggested labels are shown with correct URL."
+          assert(
+            url.includes(
+              "q=label%3Abrowser-android",
+              "Redirect from a suggested label goes to correct URL."
+            )
           );
         });
     },


### PR DESCRIPTION
@miketaylr I'm having issues with this test. Maybe you can help?

I've added a comment here: https://github.com/webcompat/webcompat.com/blob/issues/2171/tests/functional/search-auth.js#L230

The issue is that the 404 page is not loaded as the URL directs to `http://localhost:5000/api/issues?...` and not `http://localhost:5000/issues?...` as expected. So we don't have a redirect.

Please don't mind the URL params that are passed into the `openPage` function. Also the test itself contains a few things to try out.