### PR TITLE
Fixes #2193: Add support for --grep when running intern tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,4 @@ before_script:
 # now run the tests!
 script:
   - nosetests
-  - node ./tests/functional/_intern.js reporters="runner"
+  - npm run test:js -- --reporters="runner"

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -99,6 +99,14 @@ Note: the extra `--` is how you pass arguments to the npm script. Don't forget i
 npm run test:js -- --functionalSuites=tests/functional/foo.js
 ```
 
+To filter which tests *within* a single test suite you run, you can use the `--grep` argument:
+
+```bash
+npm run test:js -- --functionalSuites=tests/functional/foo.js --grep=tacos
+```
+
+This will run any test within the foo.js suite that has "tacos" in its name.
+
 Right now the tests are running in Firefox as a default. You can specify which browsers you want to test with using the `browsers` argument. Like this:
 
 ```bash

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -80,10 +80,6 @@ npm run start:test
 In a separate terminal window or tab, run the tests:
 
 ```bash
-node_modules/.bin/intern-runner config=tests/intern
-
-or
-
 npm run test:js
 ```
 
@@ -97,18 +93,16 @@ Shortly after running this command, you should see the browser open and various 
 
 To run a single test suite, where foo.js is the file found in the `tests/functional` directory:
 
+Note: the extra `--` is how you pass arguments to the npm script. Don't forget it!
+
 ```bash
-node_modules/.bin/intern-runner config=tests/intern functionalSuites=tests/functional/foo.js 
+npm run test:js -- --functionalSuites=tests/functional/foo.js
 ```
 
 Right now the tests are running in Firefox as a default. You can specify which browsers you want to test with using the `browsers` argument. Like this:
 
 ```bash
-npm run test:js browsers=chrome,firefox
-
-or
-
-node_modules/.bin/intern-runner config=tests/intern browsers=safari,firefox
+npm run test:js -- --browsers=chrome,firefox
 ```
 
 For a list of the recognized browser names, just refer to [Browser enum](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_Browser.html)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "cssrecipes-reset": "^0.5.0",
     "cssrecipes-utils": "^0.6.2",
     "suitcss-utils-align": "^1.0.0",
-    "suitcss-utils-display": "^1.0.2"
+    "suitcss-utils-display": "^1.0.2",
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
     "eslint": "~3.19.0",

--- a/tests/functional/_intern.js
+++ b/tests/functional/_intern.js
@@ -4,16 +4,8 @@
 
 "use strict";
 
+const args = require("yargs").argv;
 const intern = require("intern").default;
-
-const args = {};
-process.argv.forEach((val, index) => {
-  if (val.indexOf("=") !== -1) {
-    args[val.split("=")[0]] = val.split("=")[1];
-  } else {
-    args[index] = val;
-  }
-});
 
 const siteRoot = args.siteRoot ? args.siteRoot : "http://localhost:5000";
 

--- a/tests/functional/_intern.js
+++ b/tests/functional/_intern.js
@@ -29,7 +29,7 @@ browsers.forEach(function(b) {
   });
 });
 
-intern.configure({
+const config = {
   // Configuration object for webcompat
   wc: {
     pageLoadTimeout: args.wcPageLoadTimeout
@@ -61,7 +61,9 @@ intern.configure({
   functionalSuites: [
     args.functionalSuites ? args.functionalSuites : "./tests/functional/*.js"
   ]
-});
+};
+
+intern.configure(config);
 
 intern.run().catch(e => {
   // This might not throw, BUG filed: https://github.com/theintern/intern/issues/868

--- a/tests/functional/_intern.js
+++ b/tests/functional/_intern.js
@@ -55,6 +55,10 @@ const config = {
   ]
 };
 
+if (args.grep) {
+  config.grep = new RegExp(args.grep, "i");
+}
+
 intern.configure(config);
 
 intern.run().catch(e => {


### PR DESCRIPTION
Sending a PR against refactor because it will be nicer for those hacking on that branch (and that's where active development is happening right now).

usage:

`npm run test:js -- --functionalSuites=tests/functional/foo.js --grep=tacos`

r? @zoepage 