### PR TITLE
Refactor isReportableURL function

### DIFF
--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -268,14 +268,7 @@ function BugForm() {
   };
 
   this.isReportableURL = function(url) {
-    return (
-      url &&
-      !(_.startsWith(url, "about:") ||
-        _.startsWith(url, "chrome:") ||
-        _.startsWith(url, "file:") ||
-        _.startsWith(url, "resource:") ||
-        _.startsWith(url, "view-source:"))
-    );
+    return url && (_.startsWith(url, "http:") || _.startsWith(url, "https:"));
   };
 
   /* Check to see that the URL input element is not empty,


### PR DESCRIPTION
Issue #1508
In this PR I have: 

- Refactor the `isReportableURL` function in the `static/js/lib/bugform.js` file  by removing the checks to terms that should be avoided and replace by checks to see if we are seeing an `http` or` https` url.

