### PR TITLE
Fixes #2070 – Changed wompats link

### DIFF
--- a/webcompat/templates/home-page/how-it-works.html
+++ b/webcompat/templates/home-page/how-it-works.html
@@ -21,7 +21,7 @@
       <p>
         Who are the people behind the web compat project? <br /><br/>
 
-        Find out and <a href="./about" title="meet the wompats">meet the Wompats</a>.
+        Find out and <a href="./contributors" title="meet the wompats">meet the Wompats</a>.
       </p>
     </div>
     <aside class="grid-cell x2">


### PR DESCRIPTION
Changed wompats link to `contributors`.

r? @zoepage 