### PR TITLE
Fixes #2152. Fix logout message overlap.

### DIFF
--- a/webcompat/static/css/src/notification-bar.css
+++ b/webcompat/static/css/src/notification-bar.css
@@ -9,10 +9,6 @@
   line-height: 3.8;
 }
 
-.notication {
-  border-bottom: 5px solid;
-}
-
 .notification-information {
   background-color: var(--color-first-transparent);
   border-bottom-color: var(--color-first);

--- a/webcompat/static/css/src/notification-bar.css
+++ b/webcompat/static/css/src/notification-bar.css
@@ -10,8 +10,8 @@
 }
 
 .notification-information {
-  background-color: var(--color-first-transparent);
-  border-bottom-color: var(--color-first);
+  background-color: var(--color-first-contrast);
+  border-bottom: 5px solid var(--color-first);
 }
 
 .notification-alert {

--- a/webcompat/static/css/src/notification-bar.css
+++ b/webcompat/static/css/src/notification-bar.css
@@ -6,7 +6,7 @@
   right: 0;
   height: 58px;
   text-align: center;
-  line-height: 3.8;
+  line-height: 3;
 }
 
 .notification-information {

--- a/webcompat/static/css/src/variables.css
+++ b/webcompat/static/css/src/variables.css
@@ -18,6 +18,7 @@
   --color-bg-box: rgba(255, 255, 255, 1); /* #ffffff */
   --color-bg-comment-header: rgba(245, 245, 245, 1); /* #f5f5f5 */
   --color-first: rgba(255, 201, 0, 1); /* #ffc900 */
+  --color-first-contrast: rgba(255, 243, 201, .8);
   --color-first-transparent: rgba(255, 201, 1, .8); /* #ffc901 20% transparency */
   --color-first-light: rgba(255, 200, 3, .55); /* ffc803 45% transparency */
   --color-second: rgba(64, 64, 64, 1); /* #404040 */

--- a/webcompat/static/js/lib/flash-message.js
+++ b/webcompat/static/js/lib/flash-message.js
@@ -32,7 +32,7 @@ var FlashMessageView = Backbone.View.extend({
     var timeout = opts.timeout || 4000;
     var message = opts.message;
 
-    this.$el.addClass("notification");
+    this.$el.addClass("notification-information");
     this.render(message);
     setTimeout(_.bind(this.hide, this), timeout);
   },


### PR DESCRIPTION
r? @zoepage 

This is what it would look like with the default `notification-information` styles:
![screen shot 2018-03-16 at 2 18 31 pm](https://user-images.githubusercontent.com/67283/37540950-de630d40-2926-11e8-9ac2-3dcd28ff3b60.png)

So I tweaked it by adding a new class to have a bit more contast:

![screen shot 2018-03-16 at 2 21 35 pm](https://user-images.githubusercontent.com/67283/37540979-f05fbb60-2926-11e8-8b85-163951a0566d.png)

But I'm guessing there's probably a better color value I could use? *Very* open to suggestions here @zoepage. :)

