### PR TITLE
Fixes #2277 - Add missing border colors for status labels

### DIFF
--- a/webcompat/static/css/src/labels.css
+++ b/webcompat/static/css/src/labels.css
@@ -140,7 +140,7 @@
 }
 
 .label-box .label-editor-list [class *= "label-"] {
-  border-left-color: var(--color-fourth);
+  border-left-color: var(--label-closed);
 }
 
 .label-box .label-editor-list [class *= "label-type"] {
@@ -188,7 +188,7 @@
   border-left-color: var(--label-needs-contact);
 }
 
-.label-box .label-editor-list .label-ready {
+.label-box .label-editor-list .label-contactready {
   border-left-color: var(--label-outreach);
 }
 

--- a/webcompat/static/css/src/labels.css
+++ b/webcompat/static/css/src/labels.css
@@ -175,3 +175,27 @@
 .label-box .label-editor-list [class *= "label-status"] {
   border-left-color: var(--label-closed);
 }
+
+.label-box .label-editor-list .label-needstriage {
+  border-left-color: var(--label-needs-triage);
+}
+
+.label-box .label-editor-list .label-needsdiagnosis {
+  border-left-color: var(--label-needs-diagnosis);
+}
+
+.label-box .label-editor-list .label-needscontact {
+  border-left-color: var(--label-needs-contact);
+}
+
+.label-box .label-editor-list .label-ready {
+  border-left-color: var(--label-outreach);
+}
+
+.label-box .label-editor-list .label-sitewait {
+  border-left-color: var(--label-site-contacted);
+}
+
+.label-box .label-editor-list .label-closed {
+  border-left-color: var(--label-closed);
+}


### PR DESCRIPTION
There are more status labels than defined colors. So not sure, if this fits the needs.
Haven't spotted `border-color` definitions for status labels in the CSS, only `background-color` definitions, so I added them.

r? @zoepage 