### PR TITLE
Fixes #2274 - Automatic scrolling of label box when editing

### DIFF
--- a/webcompat/static/js/lib/labels.js
+++ b/webcompat/static/js/lib/labels.js
@@ -59,6 +59,7 @@ issues.LabelsView = issues.CategoryView.extend({
     _.each(toBeChecked, function(labelName) {
       $('[name="' + labelName + '"]').prop("checked", true);
     });
+    this.$el.closest(".label-box").scrollTop(this.$el.position().top);
   }
 });
 

--- a/webcompat/static/js/lib/milestones.js
+++ b/webcompat/static/js/lib/milestones.js
@@ -42,6 +42,7 @@ issues.MilestonesView = issues.CategoryView.extend({
       .after(this.milestoneEditor.render().el);
 
     $('[name="' + this.model.get("milestone") + '"]').prop("checked", true);
+    this.$el.closest(".label-box").scrollTop(this.$el.position().top);
   }
 });
 


### PR DESCRIPTION
This will automatically set the label-box scroll position, so the freshly opened list of labels or statuses is directly visible to the user.

r? @zoepage @miketaylr 