### PR TITLE
Issue #2334. Ensure that we consider browser-sent images as valid.

### DIFF
--- a/tests/functional/image-uploads-non-auth.js
+++ b/tests/functional/image-uploads-non-auth.js
@@ -145,6 +145,16 @@ registerSuite("Image Uploads (non-auth)", {
             assert.equal(isDisplayed, true, "Remove button is displayed");
           })
           .end()
+          .findByCssSelector(".js-image-upload")
+          .getAttribute("class")
+          .then(function(className) {
+            assert.notInclude(
+              "is-validated",
+              className,
+              "parent container got the right class after an image was postMessage'd"
+            );
+          })
+          .end()
       );
     },
 

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -135,6 +135,7 @@ function BugForm() {
         }, this)
       );
     } else {
+      this.makeValid("image");
       this.addPreviewBackground(dataURI);
     }
   }, this);


### PR DESCRIPTION
r? @zoepage 

`npm run test:js -- --grep="remove image upload button"`

![screen shot 2018-03-28 at 3 45 15 pm](https://user-images.githubusercontent.com/67283/38055340-0b6ccef8-329f-11e8-8a3e-18fb63b2e4b6.png)
