### PR TITLE
Fixes #2358 - Inline code multiline wrap on issue template

### DIFF
--- a/webcompat/static/css/src/issue.css
+++ b/webcompat/static/css/src/issue.css
@@ -2,6 +2,10 @@
   align-items: flex-start;
 }
 
+#issue :not(pre) > code[class *= "language-"] {
+  white-space: pre-wrap;
+}
+
 .issue-detail {
   padding-bottom: calc (var(--unit-space) * 2);
 }


### PR DESCRIPTION
I'm not really happy with that. It fixes only occurences of inline code on the issue detail page, but not in general.
On the other hand I don't want to touch the `webcompat/static/css/lib/prism-gh-theme.css` file.

Any other ideas or is this (temporarily?) ok?

r? @miketaylr 