### PR TITLE
Issue #2303. Add some styling to login + keyboard hints.

### DIFF
--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -20,22 +20,20 @@
             <section class="grid-cell issue-comment issue-new-comment x3">
               {% include "issue/issue-comment-submit.html" %}
             </section>
-          {% else %}
-          <div class="grid-nested x3">
-            <p class="x2">Please <a class="x2" href="{{ url_for('login') }}">login</a> to edit issues.</p>
-          </div>
           {% endif %}
-          <div class="grid-nested x3">
-            <p class="x2">
-              <a class="x2" href="https://github.com/{{ config['ISSUES_REPO_URI'] }}/{{ number }}">
-                <span class="wc-GithubLink-Icon"></span>View issue on Github</a>
-            </p>
-            <p class="x2">
-              <span class="desktop-only">Shortcut: Press <b>l</b> on your keyboard to open the label editor.</span> <br />
-              <span class="desktop-only">Shortcut: Press <b>g</b> on your keyboard to be taken to the GitHub view of this page.</span>
-            </p>
-          </div>
         </div>
+        <section class="grid-row grid-nested x2">
+          <div class="x2 grid-cell hint-text">
+          {% if not session.user_id and not session.avatar_url %}
+            <a class="x2" href="{{ url_for('login') }}">Please login to edit issues.</a>
+          {% endif %}
+            <p><a class="x2" href="https://github.com/{{ config['ISSUES_REPO_URI'] }}/{{ number }}">
+              View issue on Github
+            </a></p>
+            <span class="desktop-only">Shortcut: Press <b>l</b> on your keyboard to open the label editor.</span>
+            <span class="desktop-only">Shortcut: Press <b>g</b> on your keyboard to be taken to the GitHub view of this page.</span>
+          </div>
+        </section>
       </article>
       <aside class="grid-cell x1 label-box">
         {% include "issue/issue-aside.html" %}


### PR DESCRIPTION
Turns out we had some styles for `hint-text` that were unused.

r? @Regaddi 

logged out:
![screen shot 2018-04-04 at 6 08 08 pm](https://user-images.githubusercontent.com/67283/38339396-9b866d16-3833-11e8-91da-b1501cd838cc.png)

logged in:
![screen shot 2018-04-04 at 6 09 57 pm](https://user-images.githubusercontent.com/67283/38339410-a6664490-3833-11e8-9f21-1e1a44a0ab9f.png)


