### PR TITLE
Fixes #2430 - Make {LINE,LOG}_TEMPLATE unicode literals.

### DIFF
--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -29,8 +29,8 @@ HEADERS = {'Accept': 'application/vnd.github.v3+json',
            'Authorization': 'token {token}'.format(token=OAUTH_TOKEN),
            'User-Agent': 'webcompat/webcompat-bot'}
 # Templates for producing the changelog
-LINE_TEMPLATE = '* {title} [Pull #{number}]({url})\n'
-LOG_TEMPLATE = """
+LINE_TEMPLATE = u'* {title} [Pull #{number}]({url})\n'
+LOG_TEMPLATE = u"""
 
 ## X.X.X - {date}
 


### PR DESCRIPTION
```
🐓 python tools/changelog.py -t
Statuses Initialization…
Fetching milestones from Github…
Milestones saved in data/
Milestones in memory


## X.X.X - 2018-04-27

* mozilla.org – see bug description 😐 [Pull #1494](https://github.com/webcompat/webcompat-tests/issues/1494)
* candy.de - design is broken [Pull #1458](https://github.com/webcompat/webcompat-tests/issues/1458)
* gfjhgfjh - design is broken [Pull #1381](https://github.com/webcompat/webcompat-tests/issues/1381)
```