### PR TITLE
Fixes #2459 - Add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+# See https://prettier.io/docs/en/options.html for available options
+
+# We actually don’t need to configure anything in here, because we adapt the default settings of prettier.
+# But we need this file, because otherwise prettier will search up the file tree until to find a config file.
+# This will lead to problems if one has settings different from the default settings defined in ~/.prettierrc.
+# See https://github.com/webcompat/webcompat.com/issues/2459


### PR DESCRIPTION
Seems to be pretty useless because it‘s an empty file.
But without an `.prettierrc` file in the project prettier uses `~/.prettierrc` which will cause thousands of linting errors if one has settings different from the default settings.