### PR TITLE
Fix #2466: Fix broken links to contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,10 +8,10 @@ You are welcome to contribute to this project. Here are the guidelines we try to
 * [Triaging Issues](#triaging-issues)
 * [Finding an Issue to Work On](#finding-an-issue-to-work-on)
 * [Feature Requests](#feature-requests)
-* [Development Environment setup](docs/dev-env-setup.md)
-* [Pull Request + Code Style Guidelines](docs/pr-coding-guidelines.md)
-* [Tests](docs/tests.md)
-* [Production Server Setup](docs/prod-server.md)
+* [Development Environment setup](../docs/dev-env-setup.md)
+* [Pull Request + Code Style Guidelines](../docs/pr-coding-guidelines.md)
+* [Tests](../docs/tests.md)
+* [Production Server Setup](../docs/prod-server.md)
 * [Acknowledgements](#acknowledgements)
 
 Please note that everyone interacting in our codebases, issue trackers, and any other form of communication, including chat rooms and mailing lists, is expected to follow our [code of conduct](https://github.com/webcompat/webcompat.com/blob/master/CODE_OF_CONDUCT.md) so we can all enjoy the effort we put into this project.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [CHANGELOG](https://github.com/webcompat/webcompat.com/blob/master/CHANG
 
 ## Contributing
 
-Your contributions are appreciated which could be; contributing code, design and UX, documentation, feature requests, taking care of bugs or other kinds of issues. For more details, please check out [CONTRIBUTING.md]( https://github.com/webcompat/webcompat.com/blob/master/CONTRIBUTING.md) and for instructions on how to set up a [local build environment](https://github.com/webcompat/webcompat.com/blob/master/docs/dev-env-setup.md). Everyone interacting in our codebases, issue trackers, and any other form of communication, including chat rooms and mailing lists, is expected to follow our [code of conduct](https://github.com/webcompat/webcompat.com/blob/master/CODE_OF_CONDUCT.md) so we can all enjoy the effort we put into this project.
+Your contributions are appreciated which could be; contributing code, design and UX, documentation, feature requests, taking care of bugs or other kinds of issues. For more details, please check out [CONTRIBUTING.md]( https://github.com/webcompat/webcompat.com/blob/master/.github/CONTRIBUTING.md) and for instructions on how to set up a [local build environment](https://github.com/webcompat/webcompat.com/blob/master/docs/dev-env-setup.md). Everyone interacting in our codebases, issue trackers, and any other form of communication, including chat rooms and mailing lists, is expected to follow our [code of conduct](https://github.com/webcompat/webcompat.com/blob/master/CODE_OF_CONDUCT.md) so we can all enjoy the effort we put into this project.
 
 ### Assets & Design
 

--- a/run.py
+++ b/run.py
@@ -26,7 +26,7 @@ The config.py file seems to be missing.
 
 Please create a copy of config.py.example and customize it accordingly.
 For details, please see
-https://github.com/webcompat/webcompat.com/blob/master/CONTRIBUTING.md#configuring-the-server
+https://github.com/webcompat/webcompat.com/blob/master/.github/CONTRIBUTING.md#configuring-the-server
 ==============================================
 '''
 

--- a/webcompat/templates/contributors/build-tools.html
+++ b/webcompat/templates/contributors/build-tools.html
@@ -22,7 +22,7 @@
 
             <ol>
               <li>
-                The <a href="https://github.com/webcompat/webcompat.com" target="_blank">webcompat.com</a> website. It is a mix of Python and JavaScript, CSS, HTML using GitHub as the backend. Anyone with UX, design, coding, writing or other skills are always <a href="https://github.com/webcompat/webcompat.com/blob/master/CONTRIBUTING.md" target="_blank">welcome to contribute</a>.
+                The <a href="https://github.com/webcompat/webcompat.com" target="_blank">webcompat.com</a> website. It is a mix of Python and JavaScript, CSS, HTML using GitHub as the backend. Anyone with UX, design, coding, writing or other skills are always <a href="https://github.com/webcompat/webcompat.com/blob/master/.github/CONTRIBUTING.md" target="_blank">welcome to contribute</a>.
               </li>
               <li>
                 The <a href="https://github.com/webcompat/webcompat-reporter-extensions" target="_blank">webcompat reporter extensions</a> help to make reports directly accessible in browsers.


### PR DESCRIPTION
This PR fixes issue #2466

## Proposed PR background

Fixes the broken links introduced with moving the contribution guidelines to the `.github` directory.
See https://github.com/webcompat/webcompat.com/pull/2461/commits/1ecc0923e2efc0c8f9661cfd5f640ae2e52d8874

---

- [x] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
