### PR TITLE
Fixes #2464 - Allow notification-bar to expand in height, if necessary

### DIFF
--- a/webcompat/static/css/src/notification-bar.css
+++ b/webcompat/static/css/src/notification-bar.css
@@ -1,7 +1,7 @@
 .notification-bar {
-  height: 58px;
   left: 0;
   line-height: 3;
+  min-height: 58px;
   position: fixed;
   right: 0;
   text-align: center;


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue #2464 

## Proposed PR background

Please provide enough information so that others can review your pull request:

This change will allow the notification bar to expand in height, if the content requires more space.
This will most likely affect mobile users, when the notification bar contains a longer text.

---

- [x] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
