### PR TITLE
Fixes #1971 - Adds stricter parsing for browser-* and a fallback

### DIFF
--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -153,8 +153,13 @@ class TestWebhook(unittest.TestCase):
             ({'browser': 'Firefox (tablet)'}, 'browser-fixme'),
             ({'browser': 'Firefox 30.0'}, 'browser-firefox'),
             ({'browser': 'Firefox Mobile 30.0'}, 'browser-firefox-mobile'),
-            ({'browser': 'Firefox Mobile (Tablet) 88.0'},
-                'browser-firefox-mobile-tablet')
+            ({'browser': 'Firefox Mobile (Tablet) 88.0'}, 'browser-firefox-tablet'),  # noqa
+            ({'browser': 'Firefox Mobile Nightly 59.0a1 (2017-12-04)'}, 'browser-firefox-mobile'),  # noqa
+            ({'browser': 'Mozilla/5.0 (Android 8.0.0; Mobile; rv:58.0) Gecko/58.0 Firefox/58.0'}, 'browser-fixme'),  # noqa
+            ({'browser': 'Firefox Developer Edition 60.0b14 (64-bit)'}, 'browser-firefox'),  # noqa
+            ({'browser': 'Firefox Mobile Nightly 61.0 & Firefox PC Nightly'}, 'browser-firefox-mobile'),  # noqa
+            ({'browser': 'LOL Mobile 55.0'}, 'browser-fixme'),
+            ({}, 'browser-fixme'),
         ]
         for metadata_dict, expected in metadata_tests:
             actual = helpers.extract_browser_label(metadata_dict)
@@ -186,8 +191,8 @@ class TestWebhook(unittest.TestCase):
         """Extract list of labels from an issue body."""
         labels_tests = [
             (self.issue_body, ['browser-firefox', 'type-media', 'type-stylo']),
-            (self.issue_body2, ['type-foobar']),
-            (self.issue_body3, ['browser-firefox-mobile-tablet'])
+            (self.issue_body2, ['browser-fixme', 'type-foobar']),
+            (self.issue_body3, ['browser-firefox-tablet'])
         ]
         for issue_body, expected in labels_tests:
             actual = helpers.get_issue_labels(issue_body)

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -147,10 +147,10 @@ class TestWebhook(unittest.TestCase):
     def test_extract_browser_label(self):
         """Extract browser label name."""
         metadata_tests = [
-            ({'browser': 'Firefox'}, None),
-            ({'browser': 'Firefox Mobile'}, None),
-            ({'browser': 'Firefox99.0'}, None),
-            ({'browser': 'Firefox (tablet)'}, None),
+            ({'browser': 'Firefox'}, 'browser-fixme'),
+            ({'browser': 'Firefox Mobile'}, 'browser-fixme'),
+            ({'browser': 'Firefox99.0'}, 'browser-fixme'),
+            ({'browser': 'Firefox (tablet)'}, 'browser-fixme'),
             ({'browser': 'Firefox 30.0'}, 'browser-firefox'),
             ({'browser': 'Firefox Mobile 30.0'}, 'browser-firefox-mobile'),
             ({'browser': 'Firefox Mobile (Tablet) 88.0'},

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -17,6 +17,8 @@ from webcompat.form import domain_name
 from webcompat.helpers import extract_url
 from webcompat.helpers import proxy_request
 
+BROWSERS = ['blackberry', 'brave', 'chrome', 'edge', 'firefox', 'iceweasel', 'ie', 'lynx', 'myie', 'opera', 'puffin', 'qq', 'safari', 'samsung', 'seamonkey', 'uc', 'vivaldi']  # noqa
+
 
 def extract_metadata(body):
     """Parse all the hidden comments for issue metadata.
@@ -35,16 +37,32 @@ def extract_metadata(body):
 def extract_browser_label(metadata_dict):
     """Return the browser label from metadata_dict."""
     browser = metadata_dict.get('browser', None)
+    dash_browser = 'fixme'
     # Only proceed if browser looks like "FooBrowser 99.0"
     if browser and re.search(r'([^\d]+?)\s[\d\.]+', browser):
         browser = browser.lower()
-        browser = browser.rsplit(' ', 1)[0]
         browser = browser.encode('utf-8')
+        # Remove parenthesis from the name
         browser = browser.translate(None, '()')
-        dash_browser = '-'.join(browser.split())
-        return 'browser-{name}'.format(name=dash_browser)
-    else:
-        return 'browser-fixme'
+        # Before returning a label, we need to clean up a bit
+        label_data = browser.split(' ')
+        name = label_data[0]
+        remainder = label_data[1:]
+        # Let's focus on the known browsers.
+        if name in BROWSERS:
+            dash_browser = label_data[0]
+            # Let's find a type for the browser.
+            remainder = label_data[1:]
+            browser_type = None
+            if 'mobile' in remainder:
+                browser_type = 'mobile'
+            if 'tablet' in remainder:
+                browser_type = 'tablet'
+            if browser_type:
+                dash_browser = '{dash_browser}-{browser_type}'.format(
+                    dash_browser=dash_browser,
+                    browser_type=browser_type)
+    return 'browser-{name}'.format(name=dash_browser)
 
 
 def extract_extra_labels(metadata_dict):

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -44,7 +44,7 @@ def extract_browser_label(metadata_dict):
         dash_browser = '-'.join(browser.split())
         return 'browser-{name}'.format(name=dash_browser)
     else:
-        return None
+        return 'browser-fixme'
 
 
 def extract_extra_labels(metadata_dict):


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue #1971

## Proposed PR background

This does two things:
1. Adds a generic browser-fixme label for unknown pattern
2. Greatly simplify the list of accepted parameters for browsers names.

This is an intermediary steps toward the proposal of @denschub (which I agree with)

r? @miketaylr 