### PR TITLE
Fixes #2474 - Properly send along the submit_type to the server.

### DIFF
--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -90,7 +90,7 @@ class IssueForm(FlaskForm):
                       [Optional(),
                        FileAllowed(Upload.ALLOWED_FORMATS, image_message)])
     details = HiddenField()
-    submit_type = HiddenField(default="submitanon")
+    submit_type = HiddenField()
 
 
 def get_form(ua_header):

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -267,7 +267,7 @@ function BugForm() {
   };
 
   this.storeClickedButton = function(event) {
-    this.clickedButton = event.target.value;
+    this.clickedButton = event.target.name;
   };
 
   this.trimWyciwyg = function(url) {

--- a/webcompat/templates/home-page/form.html
+++ b/webcompat/templates/home-page/form.html
@@ -119,6 +119,7 @@
         class="button button-secondary js-Button"
         id="submitanon"
         type="submit"
+        name="github-auth-report"
       >
         Report Anonymously
       </button>
@@ -126,6 +127,7 @@
         class="button button-primary right js-Button"
         id="submitgithub"
         type="submit"
+        name="github-proxy-report"
       >
         {% if session.username %}Report as {{ session.username }}{% else %}Report via GitHub{% endif %}
       </button>


### PR DESCRIPTION
Thanks for finding this bug @karlcow. 

This underscores a critical weakness: we need functional tests for bug creation (ideally that don't create real bugs so we don't get labelled as spammers).

r? @karlcow 

Note: tags v11.0.0 and v11.0.1 aren't safe to deploy, but we'll cut v11.0.2 and deploy that once this is merged.