### PR TITLE
Fixes #2473. Markup fixes (SVG alternatives, invalid code, unnecessary `role="button"`, account dropdown trigger)

### DIFF
--- a/tests/unit/test_rendering.py
+++ b/tests/unit/test_rendering.py
@@ -82,30 +82,22 @@ class TestURIContent(unittest.TestCase):
         headers = {'HTTP_USER_AGENT': FIREFOX_UA}
         rv = self.app.get('/', environ_base=headers)
         expected = '<span class="link-text">Download Firefox Add-on</span>'
-        expected2 = '<use xlink:href="#svg-download2">Firefox addons</use>'
         self.assertTrue(expected in rv.data)
-        self.assertTrue(expected2 in rv.data)
         # testing for Firefox Androidpe
         headers = {'HTTP_USER_AGENT': FIREFOX_AND_UA}
         rv = self.app.get('/', environ_base=headers)
         expected = '<span class="link-text">Download Firefox Add-on</span>'
-        expected2 = '<use xlink:href="#svg-download2">Firefox for Android addons</use>'  # noqa
         self.assertTrue(expected in rv.data)
-        self.assertTrue(expected2 in rv.data)
         # testing for Chrome
         headers = {'HTTP_USER_AGENT': CHROME_UA}
         rv = self.app.get('/', environ_base=headers)
         expected = '<span class="link-text">Download Chrome Add-on</span>'
-        expected2 = '<use xlink:href="#svg-download2">Chrome webstore</use>'
         self.assertTrue(expected in rv.data)
-        self.assertTrue(expected2 in rv.data)
         # testing for Opera
         headers = {'HTTP_USER_AGENT': OPERA_UA}
         rv = self.app.get('/', environ_base=headers)
         expected = '<span class="link-text">Download Opera Add-on</span>'
-        expected2 = '<use xlink:href="#svg-download2">Opera Extension</use>'
         self.assertTrue(expected in rv.data)
-        self.assertTrue(expected2 in rv.data)
         # testing for unknown browser
         headers = {'HTTP_USER_AGENT': 'Punk Cat Space'}
         rv = self.app.get('/', environ_base=headers)

--- a/webcompat/static/js/lib/homepage.js
+++ b/webcompat/static/js/lib/homepage.js
@@ -52,7 +52,7 @@ function HomePage() {
     navDropDown.click(function() {
       var $this = $(this);
       $this.toggleClass("is-active");
-      $this.attr("aria-pressed", function() {
+      $this.find("button").attr("aria-expanded", function() {
         return $this.hasClass("is-active") ? "true" : "false";
       });
     });
@@ -61,6 +61,7 @@ function HomePage() {
     $(document).on("click", function(e) {
       if (!$(e.target).closest(navDropDown).length) {
         navDropDown.removeClass("is-active");
+        navDropDown.find("button").attr("aria-expanded", "false");
       }
     });
   };

--- a/webcompat/templates/dashboard/triage/filters.html
+++ b/webcompat/templates/dashboard/triage/filters.html
@@ -71,7 +71,7 @@
       </select>
     </div>
     <div class="wc-Filter">
-      <button type="submit" role="button">
+      <button type="submit">
         Filtered
       </button>
     </div>

--- a/webcompat/templates/home-page/hero.html
+++ b/webcompat/templates/home-page/hero.html
@@ -3,21 +3,17 @@
       <h1 class="hero-claim highlight js-hero-title">Bug reporting <br> for the web.</h1>
       <button id="js-ReportBug" type="button" class="button button-hero is-closed">
         Report bug
-      <svg class="icon-middle" role="presentation" aria-role="hide">
-        <title>circle-right</title>
-          <use class="button-icon-hero" xlink:href="#svg-circle-right">Report bug</use>
+      <svg class="icon-middle" role="presentation" aria-hidden="true">
+          <use class="button-icon-hero" xlink:href="#svg-circle-right" />
       </svg>
       </button>
     </article>
     <aside class="hero-illustration">
-      <svg class="hero-illustration-bulb" role="presentation" viewBox="0 0 160 447" aria-role="hide">
-        <title>bulb</title>
-        <use xlink:href="#svg-bulb">bulb</use>
+      <svg class="hero-illustration-bulb" role="presentation" viewBox="0 0 160 447" aria-hidden="true">
+        <use xlink:href="#svg-bulb" />
       </svg>
-
-      <svg class="hero-illustration-bug bug-animated" role="presentation" viewBox="0 0 47 65" aria-role="hide">
-        <title>bug</title>
-        <use xlink:href="#svg-bug-animated">bug</use>
+      <svg class="hero-illustration-bug bug-animated" role="presentation" viewBox="0 0 47 65" aria-hidden="true">
+        <use xlink:href="#svg-bug-animated" />
       </svg>
     </aside>
 </section>

--- a/webcompat/templates/issue/issue-labels.jst
+++ b/webcompat/templates/issue/issue-labels.jst
@@ -2,10 +2,9 @@
   <header class="label-box-editor-button">
     <h3 class="headline-3">Labels</h3>
     <% if ($("body").data("username")) { %>
-    <button class="nav-button nav-link icon right js-CategoryEditorLauncher js-LabelEditorLauncher">
-      <svg class="nav-text icon nav-icon" viewBox="0 0 30 30" role="presentation">
-          <title>Edit labels</title>
-          <use xlink:href="#svg-sliders">Edit labels</use>
+    <button class="nav-button nav-link icon right js-CategoryEditorLauncher js-LabelEditorLauncher" aria-label="Edit labels">
+      <svg class="nav-text icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+          <use xlink:href="#svg-sliders" />
       </svg>
     </button>
     <% } %>

--- a/webcompat/templates/issue/issue-milestones.jst
+++ b/webcompat/templates/issue/issue-milestones.jst
@@ -3,10 +3,9 @@
     <h3 class="headline-3">Status</h3>
     <% if ($("body").data("username")) { %>
     <span class="js-Issue-categoryEditor">
-      <button class="nav-button nav-link icon right js-CategoryEditorLauncher js-MilestoneEditorLauncher">
-        <svg class="nav-text icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <title>Edit Statuses</title>
-            <use xlink:href="#svg-sliders">Edit Statuses</use>
+      <button class="nav-button nav-link icon right js-CategoryEditorLauncher js-MilestoneEditorLauncher" aria-label="Edit Statuses">
+        <svg class="nav-text icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-sliders" />
         </svg>
       </button>
     </span>

--- a/webcompat/templates/issue/upload-image.jst
+++ b/webcompat/templates/issue/upload-image.jst
@@ -7,15 +7,15 @@
            type="file"
     />
     <div class="label-icon label-upload js-label-upload">
-      <svg class="icon icon-big" role="presentation" title="Upload Screenshot">
-        <use class="icon-upload" xlink:href="#svg-plus">Upload Screenshot</use>
+      <svg class="icon icon-big" role="presentation" aria-hidden="true">
+        <use class="icon-upload" xlink:href="#svg-plus" />
       </svg>
       <small class="label-icon-message">Upload screenshot</small>
     </div>
 
     <div class="label-icon label-remove is-hidden js-remove-upload">
-      <svg class="icon icon-big" role="presentation" title="Remove Screenshot">
-        <use class="icon-remove" xlink:href="#svg-x">Remove Screenshot</use>
+      <svg class="icon icon-big" role="presentation" aria-hidden="true">
+        <use class="icon-remove" xlink:href="#svg-x" />
       </svg>
       <small class="label-icon-message">Remove screenshot</small>
     </div>

--- a/webcompat/templates/list-issue/dropdown.jst
+++ b/webcompat/templates/list-issue/dropdown.jst
@@ -1,9 +1,8 @@
 <script type="text/template">
   <button type="button" class="button js-Dropdown-toggle">
      <span class="js-Dropdown-label"><%= dropdownTitle %></span>
-
-     <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-        <use xlink:href="#svg-chevron-right">dropdown</use>
+     <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+        <use xlink:href="#svg-chevron-right" />
     </svg>
   </button>
   <ul class="dropdown js-Dropdown-options" aria-hidden="false">

--- a/webcompat/templates/list-issue/issuelist-search.jst
+++ b/webcompat/templates/list-issue/issuelist-search.jst
@@ -1,9 +1,9 @@
 <script type="text/template">
   <form id="x-search-bar" method="get" action="/issues">
     <input id="js-SearchForm-input" class="form-field text-field" name="q" placeholder="Search issues by keyword"/>
-    <button role="button" class="nav-button nav-link js-SearchForm-button" type="submit" title="Search for an item.">
-      <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-        <use xlink:href="#svg-search2">Search</use>
+    <button class="nav-button nav-link js-SearchForm-button" type="submit" title="Search for an item." aria-label="Search">
+      <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+        <use xlink:href="#svg-search2" />
       </svg>
     </button>
     </form>

--- a/webcompat/templates/nav/addon-links.html
+++ b/webcompat/templates/nav/addon-links.html
@@ -2,10 +2,9 @@
     {%- if browser == 'firefox' %}
     <li class="nav-item">
         <a class="nav-link js-addon-link" href="https://addons.mozilla.org/en-US/firefox/addon/webcompatcom-reporter/"
-           title="Navigate to firefox addon store">
-            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                <title>Firefox addons</title>
-                <use xlink:href="#svg-download2">Firefox addons</use>
+           title="Navigate to Firefox Add-on store">
+            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                <use xlink:href="#svg-download2" />
             </svg>
             <span class="link-text">Download Firefox Add-on</span>
         </a>
@@ -13,10 +12,9 @@
     {%- elif browser == 'firefox mobile' -%}
     <li class="nav-item">
         <a class="nav-link js-addon-link" href="https://addons.mozilla.org/en-US/android/addon/webcompatcom-mobile-reporter/"
-           title="Navigate to firefox addon store">
-            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                <title>Firefox for Android addons</title>
-                <use xlink:href="#svg-download2">Firefox for Android addons</use>
+           title="Navigate to Firefox Add-on store">
+            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                <use xlink:href="#svg-download2" />
             </svg>
             <span class="link-text">Download Firefox Add-on</span>
         </a>
@@ -24,10 +22,9 @@
     {%- elif browser == 'chrome' -%}
     <li class="nav-item">
         <a class="nav-link js-addon-link" href="https://chrome.google.com/webstore/detail/webcompatcom-reporter/ffnnhckjcpbbjlmgfjigknkoffakclol"
-           title="Navigate to chrome webstore">
-            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                <title>Chrome webstore</title>
-                <use xlink:href="#svg-download2">Chrome webstore</use>
+           title="Navigate to Chrome webstore">
+            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                <use xlink:href="#svg-download2" />
             </svg>
             <span class="link-text">Download Chrome Add-on</span>
         </a>
@@ -35,17 +32,16 @@
     {%- elif browser == 'opera' -%}
     <li class="nav-item">
         <a class="nav-linknnjs-addon-link" href="https://addons.opera.com/en/extensions/details/webcompatcom-reporter/?display=en"
-           title="Navigate to opera addons">
+           title="Navigate to Opera Add-ons">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                <title>Opera Extension</title>
-                <use xlink:href="#svg-download2">Opera Extension</use>
+                <use xlink:href="#svg-download2" />
             </svg>
             <span class="link-text">Download Opera Add-on</span>
         </a>
     </li>
     {%- else -%}
     <li class="nav-item">
-        <a class="nav-link" href="https://github.com/webcompat/webcompat.com/issues?state=open" title="Navigate to github issues">
+        <a class="nav-link" href="https://github.com/webcompat/webcompat.com/issues?state=open" title="Navigate to GitHub issues">
             <span class="link-text">Give Feedback</span>
         </a>
     </li>

--- a/webcompat/templates/nav/nav.html
+++ b/webcompat/templates/nav/nav.html
@@ -3,18 +3,16 @@
         <ul class="nav-left">
             <li class="nav-item">
                 <a href="/" title="Navigate to main page." class="js-Navbar-link nav-link">
-                    <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                        <title>Home</title>
-                        <use xlink:href="#svg-home">home</use>
+                    <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                        <use xlink:href="#svg-home" />
                     </svg>
                     <span class="link-text">Home</span>
                 </a>
             </li>
             <li class="nav-item">
                 <a href="/issues/new" title="Report a bug" class="js-Navbar-link nav-link">
-                    <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                        <title>bug</title>
-                        <use xlink:href="#svg-zap">bug</use>
+                    <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                        <use xlink:href="#svg-zap" />
                     </svg>
                     <span class="link-text">Report a bug</span>
                 </a>

--- a/webcompat/templates/nav/shared-nav-links.html
+++ b/webcompat/templates/nav/shared-nav-links.html
@@ -1,15 +1,15 @@
 <li class="nav-item">
     <a class="nav-link" href="/contributors" title="Contribute to our project.">
-        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <use xlink:href="#svg-users">Contribute</use>
+        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-users" />
         </svg>
         <span class="link-text">Contribute</span>
     </a>
 </li>
 <li class="nav-item">
     <a class="nav-link js-issues-link" href="{{ url_for('show_issues') }}?page=1&per_page=50&state=open&stage=all&sort=created&direction=desc" title="Take a look at all filed issues.">
-        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <use xlink:href="#svg-hash">All issues</use>
+        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-hash" />
         </svg>
         <span class="link-text">All issues</span>
     </a>
@@ -17,18 +17,18 @@
 {% if not session.user_id %}
 <li class="nav-item">
     <a href="{{ url_for('login') }}" class="js-login-link nav-link" title="Log in with your Github account.">
-        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <use xlink:href="#svg-log-in">Log in</use>
+        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-log-in" />
         </svg>
         <span class="link-text">Login</span>
     </a>
 </li>
 {% else %}
 <li class="nav-item login js-login-link js-DropdownHeader">
-    <button class="nav-button nav-link" aria-pressed="false">
+    <button class="nav-button nav-link" aria-pressed="false" aria-label="My account">
         <img class="login-avatar-img" src="{{ session.avatar_url }}" alt="User Avatar">
-        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <use xlink:href="#svg-chevron-right">dropdown</use>
+        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-chevron-right" />
         </svg>
     </button>
     <div class="nav-dropdown-wrapper">

--- a/webcompat/templates/nav/shared-nav-links.html
+++ b/webcompat/templates/nav/shared-nav-links.html
@@ -25,7 +25,7 @@
 </li>
 {% else %}
 <li class="nav-item login js-login-link js-DropdownHeader">
-    <button class="nav-button nav-link" aria-pressed="false" aria-label="My account">
+    <button class="nav-button nav-link" aria-expanded="false" aria-label="My account">
         <img class="login-avatar-img" src="{{ session.avatar_url }}" alt="User Avatar">
         <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
             <use xlink:href="#svg-chevron-right" />

--- a/webcompat/templates/nav/topbar.html
+++ b/webcompat/templates/nav/topbar.html
@@ -5,9 +5,8 @@
             <ul class="nav-left">
                 <li class="nav-item">
                     <a class="nav-link js-Navbar-link" href="/" title="Navigate to main page.">
-                        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                            <title>Home</title>
-                            <use xlink:href="#svg-home">home</use>
+                        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                            <use xlink:href="#svg-home" />
                         </svg>
                         <span class="link-text">Home</span>
                     </a>
@@ -20,8 +19,8 @@
             <ul class="nav-right">
                 <li class="nav-item">
                     <button class="nav-button nav-link js-SearchBarOpen" title="Search for an item.">
-                        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-                            <use xlink:href="#svg-search2">Search</use>
+                        <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+                            <use xlink:href="#svg-search2" />
                         </svg>
                         <span class="link-text">Search</span>
                     </button>
@@ -33,10 +32,9 @@
 
     <form id="search-bar" class="grid" method="get" action="/issues">
         <input class="form-field text-field" name="q" placeholder="Search issues by keyword" required />
-        <button class="nav-button js-SearchBarClose" aria-hidden="true" type="button">
-          <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-            <title>Close search</title>
-            <use xlink:href="#svg-x">Close search</use>
+        <button class="nav-button js-SearchBarClose" type="button" aria-label="Close search">
+          <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+            <use xlink:href="#svg-x" />
         </svg>
         </button>
     </form>

--- a/webcompat/templates/shared/footer.html
+++ b/webcompat/templates/shared/footer.html
@@ -74,17 +74,15 @@
       <ul class="grid-cell x1 footer-sub-icons">
         <li class="footer-icon icon-twitter">
           <a class="footer-item-link" aria-label="open Twitter in a new tab" href="https://twitter.com/webcompat/with_replies" target="_blank">
-              <svg class="icon" role="presentation" aria-role="hide" viewBox="0 0 30 30">
-                  <title>Twitter</title>
-                  <use xlink:href="#svg-twitter">Twitter</use>
+              <svg class="icon" role="presentation" viewBox="0 0 30 30 aria-hidden="true"">
+                  <use xlink:href="#svg-twitter" />
               </svg>
           </a>
         </li>
         <li class="footer-icon icon-twitter">
           <a class="footer-item-link" aria-label="open Github in a new tab" href=" https://github.com/webcompat/webcompat.com/" target="_blank">
-              <svg class="icon" role="presentation" aria-role="hide" viewBox="0 0 30 30">
-                  <title>github</title>
-                  <use xlink:href="#svg-github2">Github</use>
+              <svg class="icon" role="presentation" viewBox="0 0 30 30" aria-hidden="true">
+                  <use xlink:href="#svg-github2" />
               </svg>
           </a>
         </li>

--- a/webcompat/templates/web_modules/pagination.html
+++ b/webcompat/templates/web_modules/pagination.html
@@ -7,6 +7,6 @@
 <button class="pagination-next js-Pagination-next">
 	next
 	<svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
-    <use xlink:href="#svg-chevrons-right" />
+        <use xlink:href="#svg-chevrons-right" />
     </svg>
 </button>

--- a/webcompat/templates/web_modules/pagination.html
+++ b/webcompat/templates/web_modules/pagination.html
@@ -1,14 +1,12 @@
-<button class="pagination-previous js-Pagination-previous">
-	<svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-    <title>chevron for prev</title>
-    <use xlink:href="#svg-chevrons-right">chevron for prev</use>
-</svg>
+<button class="pagination-previous js-Pagination-previous" aria-label="Previous">
+	<svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+        <use xlink:href="#svg-chevrons-right" />
+    </svg>
 	previous
 </button>
 <button class="pagination-next js-Pagination-next">
 	next
-	<svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
-    <title>chevron for next</title>
-    <use xlink:href="#svg-chevrons-right">chevron for next</use>
-</svg>
+	<svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
+    <use xlink:href="#svg-chevrons-right" />
+    </svg>
 </button>


### PR DESCRIPTION
Issue #2483  - fixes incorrect/unnecessary SVG alternative text,  removes invalid `aria-role="hide"`, removes unnecessary `role="button"` on `<button>` elements, fixes up the currently broken aria on the account dropdown trigger

r? @miketaylr
---

- [x ] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
