### PR TITLE
Fixes #2453 - Changes regex to fix progressive label filtering

### DIFF
--- a/tests/functional/labels-auth.js
+++ b/tests/functional/labels-auth.js
@@ -109,6 +109,35 @@ registerSuite("Labels (auth)", {
           assert.notInclude("is-active", className);
         })
         .end();
+    },
+
+    "Label editor filters label list based on entered text": function() {
+      var count = 0;
+      return FunctionalHelpers.openPage(
+        this,
+        url("/issues/100"),
+        ".js-LabelEditorLauncher",
+        true /* longerTimeout */
+      )
+        .findByCssSelector(".js-LabelEditorLauncher")
+        .click()
+        .end()
+        .findByCssSelector(".js-label-search")
+        .type("tacos")
+        .end()
+        .sleep(1000)
+        .findAllByXpath(
+          '//label[contains (@class, "label-editor-list-item") and not(@style="display: none;")]'
+        )
+        .then(function(elements) {
+          count = elements.length;
+          assert.deepEqual(
+            1,
+            count,
+            "Entering label name in search box filters to matching label"
+          );
+        })
+        .end();
     }
   }
 });

--- a/webcompat/static/js/lib/editor.js
+++ b/webcompat/static/js/lib/editor.js
@@ -105,7 +105,7 @@ issues.CategoryEditorView = Backbone.View.extend({
     }, 100);
 
     var escape = function(s) {
-      return s.replace(/[-/\\^$*+?:.()|[\]{}]/g, "\\$&");
+      return s.replace(/[-&:/.\s()]/g, "\\$&");
     };
     var re = new RegExp("^" + escape(e.target.value), "i");
     var toHide = _.filter(this.model.toArray(), function(label) {


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue `#2453`

## Proposed PR background

Progressive label filtering was broken, seemingly because of something wonky in the regex. I simplified the regex used in `editor.js` to escape special characters in label titles. I only included currently used special characters, so if future label titles involve anything other than `/`, `.`, `(`, `)`, `/s`, `-`, `&`, and `:`, this will need to be updated.

---

- [✔︎] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
