### PR TITLE
Fixes #2515 - Make tmp path if it doesn't already exist.

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -7,6 +7,7 @@
 """This module handles application configuration and secrets."""
 
 from collections import namedtuple
+import errno
 import json
 import os
 import sys
@@ -136,6 +137,11 @@ CSP_LOG = True
 # 2015-09-14 20:50:19,185 INFO: Thing_To_Log [in /codepath/views.py:127]
 
 # set the tempdir to somewhere predictable, no matter the platform
+try:
+    os.makedirs(os.path.join(os.getcwd(), 'tmp'))
+except OSError as exception:
+    if exception.errno != errno.EEXIST:
+        raise
 tempfile.tempdir = os.path.join(os.getcwd(), 'tmp')
 print('Writing logs to: {}'.format(tempfile.gettempdir()))
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -138,11 +138,12 @@ CSP_LOG = True
 
 # set the tempdir to somewhere predictable, no matter the platform
 try:
-    os.makedirs(os.path.join(os.getcwd(), 'tmp'))
+    tmp_path = os.path.join(os.getcwd(), 'tmp')
+    os.makedirs(tmp_path)
 except OSError as exception:
     if exception.errno != errno.EEXIST:
         raise
-tempfile.tempdir = os.path.join(os.getcwd(), 'tmp')
+tempfile.tempdir = tmp_path
 print('Writing logs to: {}'.format(tempfile.gettempdir()))
 
 LOG_FILE = os.path.join(tempfile.gettempdir(), 'webcompat.log')


### PR DESCRIPTION
This PR fixes issue #2515.

If the /tmp/ path didn't exist (because a user or automation hadnt yet built the project), it would throw. This fixes that.

r? @karlcow 