### PR TITLE
Fixes #2511 - Triage dashboard 'needsinfo' label category doesn't include 'needsinfo-xxx' labels

### DIFF
--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -68,7 +68,9 @@ class TestDashboard(unittest.TestCase):
         """Check if a list of labels contains the 'status-needsinfo'."""
         labels = ['browser-firefox', 'browser-chrome', 'status-needsinfo']
         self.assertTrue(has_needsinfo(labels))
-        labels = ['browser-safari', 'status-needsinfo', 'browser-firefox-mobile', 'status-needsinfo-karcow', 'priority-critical', 'status-needsinfo-and-guacamole']
+        labels = ['browser-safari', 'status-needsinfo',
+                  'browser-firefox-mobile', 'status-needsinfo-karcow',
+                  'priority-critical', 'status-needsinfo-and-guacamole']
         self.assertTrue(has_needsinfo(labels))
         labels = ['needsinfo', 'browser-firefox']
         self.assertFalse(has_needsinfo(labels))

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -68,6 +68,8 @@ class TestDashboard(unittest.TestCase):
         """Check if a list of labels contains the 'status-needsinfo'."""
         labels = ['browser-firefox', 'browser-chrome', 'status-needsinfo']
         self.assertTrue(has_needsinfo(labels))
+        labels = ['browser-safari', 'status-needsinfo', 'browser-firefox-mobile', 'status-needsinfo-karcow', 'priority-critical', 'status-needsinfo-and-guacamole']
+        self.assertTrue(has_needsinfo(labels))
         labels = ['needsinfo', 'browser-firefox']
         self.assertFalse(has_needsinfo(labels))
         self.assertFalse(has_needsinfo([]))

--- a/webcompat/dashboard.py
+++ b/webcompat/dashboard.py
@@ -42,15 +42,16 @@ def filter_needstriage(milestone_list):
                                     for issue in needstriage_list
                                     if issue['older'] is True])
     dashboard_stats['needsinfo'] = len([issue['needsinfo']
-                                       for issue in needstriage_list
-                                       if issue['needsinfo'] is True])
+                                        for issue in needstriage_list
+                                        if issue['needsinfo'] is True])
     return needstriage_list, dashboard_stats
 
 
 def has_needsinfo(labels):
     """Assess if the issue has a needsinfo label."""
     print(labels)
-    needsinfo = (label for label in labels if label.startswith('status-needsinfo'))
+    needsinfo = (label for label in labels if label.startswith(
+        'status-needsinfo'))
     if next(needsinfo, False):
         return True
     return False

--- a/webcompat/dashboard.py
+++ b/webcompat/dashboard.py
@@ -49,10 +49,11 @@ def filter_needstriage(milestone_list):
 
 def has_needsinfo(labels):
     """Assess if the issue has a needsinfo label."""
-    needsinfo = False
-    if 'status-needsinfo' in labels:
-        needsinfo = True
-    return needsinfo
+    print(labels)
+    needsinfo = (label for label in labels if label.startswith('status-needsinfo'))
+    if next(needsinfo, False):
+        return True
+    return False
 
 
 def browser_labels(labels):

--- a/webcompat/dashboard.py
+++ b/webcompat/dashboard.py
@@ -49,9 +49,8 @@ def filter_needstriage(milestone_list):
 
 def has_needsinfo(labels):
     """Assess if the issue has a needsinfo label."""
-    print(labels)
-    needsinfo = (label for label in labels if label.startswith(
-        'status-needsinfo'))
+    needsinfo = (label for label in labels
+                 if label.startswith('status-needsinfo'))
     if next(needsinfo, False):
         return True
     return False


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue `#2511`

## Proposed PR background

<p>We're now filtering on anything that starts with `status-needsinfo`, so this should  cover future pingees as well.</p>
---

- [✅] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
