### PR TITLE
Fixes #2535 - Use latest Firefox on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 language: python
 
 addons:
-  firefox: "58.0"
+  firefox: latest
   chrome: stable
 
 python:


### PR DESCRIPTION
This PR fixes issue #2535.

## Proposed PR background

This change makes Travis use the latest stable Firefox, rather than a hard coded 58.

It's possible this causes failures, depending on the speed of geckodriver breaking changes or updates.