### PR TITLE
Fixes #2537 - Add browser-focus-geckoview to EXTRA_LABELS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -172,6 +172,7 @@ for cat_label in cat_labels:
 # labels that we allow to be added via a `label` GET param, when
 # creating an issue.
 EXTRA_LABELS = [
+    'browser-focus-geckoview',
     'type-media',
     'type-stylo',
     'type-tracking-protection-basic',

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -145,6 +145,20 @@ class TestForm(unittest.TestCase):
         expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-stylo, type-webrender-enabled -->\n'  # nopep8
         self.assertEqual(actual, expected)
 
+    def test_get_metadata_browser_as_extra(self):
+        """Test that we can handle a browser-foo inside of EXTRA_LABELS."""
+        form_object = MultiDict([
+            ('reported_with', u'desktop-reporter'),
+            ('url', u'http://localhost:5000/issues/new'),
+            ('extra_labels', [u'type-stylo', u'browser-focus-geckoview']),
+            ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
+            ('browser', u'Firefox 59.0')])
+        metadata_keys = ['browser', 'ua_header', 'reported_with',
+                         'extra_labels']
+        actual = form.get_metadata(metadata_keys, form_object)
+        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-stylo, browser-focus-geckoview -->\n'  # nopep8
+        self.assertEqual(actual, expected)
+
     def test_normalize_metadata(self):
         """Avoid some type of strings."""
         cases = [('blue sky -->', 'blue sky'),

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -159,6 +159,10 @@ class TestWebhook(unittest.TestCase):
             ({'browser': 'Firefox Developer Edition 60.0b14 (64-bit)'}, 'browser-firefox'),  # noqa
             ({'browser': 'Firefox Mobile Nightly 61.0 & Firefox PC Nightly'}, 'browser-firefox-mobile'),  # noqa
             ({'browser': 'LOL Mobile 55.0'}, 'browser-fixme'),
+            ({'browser': 'LOL Mobile 55.0',
+             'extra_labels': 'browser-focus-geckoview'}, 'browser-fixme'),
+             ({'browser': 'Firefox 30.0',
+             'extra_labels': 'browser-focus-geckoview'}, 'browser-firefox'),
             ({}, 'browser-fixme'),
         ]
         for metadata_dict, expected in metadata_tests:
@@ -169,6 +173,8 @@ class TestWebhook(unittest.TestCase):
         """Extract 'extra' label."""
         metadata_tests = [
             ({'extra_labels': 'type-media'}, ['type-media']),
+            ({'extra_labels': 'browser-focus-geckoview'},
+             ['browser-focus-geckoview']),
             ({'extra_labels': 'cool, dude'}, ['cool', 'dude']),
             ({'extra_labels': u'weather-☁'}, ['weather-\xe2\x98\x81']),
             ({'burgers': 'french fries'}, None),


### PR DESCRIPTION
This will likely change in the near future, after the work for https://github.com/webcompat/webcompat.com/issues/2372 and related issues is complete.

We will need to coordinate a PR against Focus when that happens.
This PR fixes issue #2537

## Proposed PR background

This PR adds a label to the extra labels allowlist so we can distinguish between firefox focus (webview) and firefox focus (geckoview), if and only if the report comes in via their report site issue menu. For other web-reported bugs, we won't know.