### PR TITLE
Fixes #2552 - Adds additional csp directives

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -509,6 +509,9 @@ def add_csp(response):
         "manifest-src 'self'; " +
         "script-src 'self' https://www.google-analytics.com https://api.github.com; " +  # nopep8
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+        "base-uri 'self'; " +
+        "frame-ancestors 'self'; " +
+        "form-action 'self'; " +
         "report-uri /csp-report"
     )
 


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue `#2552`

## Proposed PR background

This pull request restricts `frame-ancestors`, `base-uri`, and `form-action` in the content security policy to `self` for a small enhancement to security.

---

- [ ✅] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
