### PR TITLE
Fixes #2555 - Add type-google to the EXTRA_LABELS list

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -173,6 +173,7 @@ for cat_label in cat_labels:
 # creating an issue.
 EXTRA_LABELS = [
     'browser-focus-geckoview',
+    'type-google',
     'type-media',
     'type-stylo',
     'type-tracking-protection-basic',


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue `#2555`

## Proposed PR background

The label already exists:
https://github.com/webcompat/web-bugs/labels/type-google

This is to make this URL work:
https://webcompat.com/issues/new?label=type-google

It will be used for Google teams to report browser compat/interop issues which the Chrome team can then track and follow up on.

---

- [x] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
