### PR TITLE
Fixes #2560 - Add browser-firefox-reality to EXTRA_LABELS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -175,6 +175,7 @@ for cat_label in cat_labels:
 # creating an issue.
 EXTRA_LABELS = [
     'browser-focus-geckoview',
+    'browser-firefox-reality',
     'type-google',
     'type-media',
     'type-stylo',


### PR DESCRIPTION
This way we can identify them from in-product reports (before UA strings are finalized... and device detection libs updated, etc.).