### PR TITLE
Fixes #1942 - Modifies the Image saving parameters for better quality

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -7,7 +7,7 @@ GitHub-Flask==3.1.5
 mock==2.0.0
 nose==1.3.7
 pep8==1.7.0
-Pillow==4.0.0
+Pillow==5.2.0
 requests==2.13.0
 ua-parser==0.8
 WTForms==2.1

--- a/webcompat/api/uploads.py
+++ b/webcompat/api/uploads.py
@@ -119,7 +119,7 @@ class Upload(object):
         # unpacking save_parameters
         self.image_object.save(file_dest, **save_parameters)
         # Creating the thumbnail
-        size = (700, 700)
+        size = (1024, 1024)
         self.image_object.thumbnail(size, Image.BILINEAR)
         self.image_object.save(thumb_dest, **save_parameters)
 

--- a/webcompat/api/uploads.py
+++ b/webcompat/api/uploads.py
@@ -120,7 +120,7 @@ class Upload(object):
         self.image_object.save(file_dest, **save_parameters)
         # Creating the thumbnail
         size = (1024, 1024)
-        self.image_object.thumbnail(size, Image.BILINEAR)
+        self.image_object.thumbnail(size, Image.HAMMING)
         self.image_object.save(thumb_dest, **save_parameters)
 
 

--- a/webcompat/api/uploads.py
+++ b/webcompat/api/uploads.py
@@ -104,6 +104,9 @@ class Upload(object):
         dest_dir = os.path.dirname(file_dest)
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
+        # Alpha channels are not supported in JPEG
+        if (self.image_object.format == 'PNG'):
+            self.image_object = self.image_object.convert('RGB')
         # Optimize further the image compression for these formats
         if self.image_object.format in ['JPEG', 'JPG', 'JPE', 'PNG']:
             save_parameters['optimize'] = True


### PR DESCRIPTION
This PR fixes issue #1942

## Proposed PR background

Some  thumbnail images were blurry. 
This is an attempt at improving the quality a little bit by adjusting size and filter.
This also upgrades the library version of Pillow.

