### PR TITLE
Fixes #2567 - Starts the server for functional tests after nosetests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ install:
   - firefox --version
   # lint python
   - pep8 --ignore=E402 webcompat/ tests/ config/secrets.py.example
-  - python run.py -t &
 
 before_script:
   - sleep 5
@@ -58,5 +57,6 @@ before_script:
 # now run the tests!
 script:
   - nosetests
+  - python run.py -t &
   - sleep 5
   - npm run test:js -- --reporters="runner" --firefoxBinary=`which firefox`

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,14 @@ install:
   - which firefox
   - java -version
   - firefox --version
-  # lint python
-  - pep8 --ignore=E402 webcompat/ tests/ config/secrets.py.example
 
 before_script:
   - sleep 5
   # lint JS in default eslint task
   - npm run lint
   - npm run build
+  # lint python
+  - pep8 --ignore=E402 webcompat/ tests/ config/secrets.py.example
 
 # now run the tests!
 script:


### PR DESCRIPTION

This PR fixes issue  #2567 

## Proposed PR background

This intends to fix the fact python run.py starts a server before running nosetests.
Unit testing is independent of any tests running and that would delay the execution time and even could fail when milestones have difficult time to be initialized.

