### PR TITLE
Fixes #2547 - Fix typo in addons link of template for opera

### DIFF
--- a/webcompat/templates/nav/addon-links.html
+++ b/webcompat/templates/nav/addon-links.html
@@ -31,7 +31,7 @@
     </li>
     {%- elif browser == 'opera' -%}
     <li class="nav-item">
-        <a class="nav-linknnjs-addon-link" href="https://addons.opera.com/en/extensions/details/webcompatcom-reporter/?display=en"
+        <a class="nav-link js-addon-link" href="https://addons.opera.com/en/extensions/details/webcompatcom-reporter/?display=en"
            title="Navigate to Opera Add-ons">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
                 <use xlink:href="#svg-download2" />


### PR DESCRIPTION
This PR fixes issue #2547.

The [Typo](https://github.com/webcompat/webcompat.com/blob/958bac4e5b8565a769ad5539f10bd1139b8b5467/webcompat/templates/nav/addon-links.html#L34) has been fixed & changed line is [this](https://github.com/suhailsinghbains/webcompat.com/blob/issues/2547/1/webcompat/templates/nav/addon-links.html#L34).

r? @laghee 

 [Yes ] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
