### PR TITLE
Fixes #2051: Remove type-stylo from EXTRA_LABELS allow-list

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -178,7 +178,6 @@ EXTRA_LABELS = [
     'browser-firefox-reality',
     'type-google',
     'type-media',
-    'type-stylo',
     'type-tracking-protection-basic',
     'type-tracking-protection-strict',
     'type-webrender-enabled',

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -136,7 +136,7 @@ class TestForm(unittest.TestCase):
         form_object = MultiDict([
             ('reported_with', u'desktop-reporter'),
             ('url', u'http://localhost:5000/issues/new'),
-            ('extra_labels', [u'type-stylo', u'type-webrender-enabled']),
+            ('extra_labels', u'type-webrender-enabled'),
             ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
             ('browser', u'Firefox 59.0')])
         metadata_keys = ['browser', 'ua_header', 'reported_with',

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -142,7 +142,7 @@ class TestForm(unittest.TestCase):
         metadata_keys = ['browser', 'ua_header', 'reported_with',
                          'extra_labels']
         actual = form.get_metadata(metadata_keys, form_object)
-        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-stylo, type-webrender-enabled -->\n'  # nopep8
+        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-webrender-enabled -->\n'  # nopep8
         self.assertEqual(actual, expected)
 
     def test_get_metadata_browser_as_extra(self):
@@ -150,13 +150,13 @@ class TestForm(unittest.TestCase):
         form_object = MultiDict([
             ('reported_with', u'desktop-reporter'),
             ('url', u'http://localhost:5000/issues/new'),
-            ('extra_labels', [u'type-stylo', u'browser-focus-geckoview']),
+            ('extra_labels', u'browser-focus-geckoview'),
             ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
             ('browser', u'Firefox 59.0')])
         metadata_keys = ['browser', 'ua_header', 'reported_with',
                          'extra_labels']
         actual = form.get_metadata(metadata_keys, form_object)
-        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: type-stylo, browser-focus-geckoview -->\n'  # nopep8
+        expected = u'<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: browser-focus-geckoview -->\n'  # nopep8
         self.assertEqual(actual, expected)
 
     def test_normalize_metadata(self):

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -136,7 +136,7 @@ class TestForm(unittest.TestCase):
         form_object = MultiDict([
             ('reported_with', u'desktop-reporter'),
             ('url', u'http://localhost:5000/issues/new'),
-            ('extra_labels', u'type-webrender-enabled'),
+            ('extra_labels', [u'type-webrender-enabled']),
             ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
             ('browser', u'Firefox 59.0')])
         metadata_keys = ['browser', 'ua_header', 'reported_with',
@@ -150,7 +150,7 @@ class TestForm(unittest.TestCase):
         form_object = MultiDict([
             ('reported_with', u'desktop-reporter'),
             ('url', u'http://localhost:5000/issues/new'),
-            ('extra_labels', u'browser-focus-geckoview'),
+            ('extra_labels', [u'browser-focus-geckoview']),
             ('ua_header', u'Mozilla/5.0...Firefox 59.0'),
             ('browser', u'Firefox 59.0')])
         metadata_keys = ['browser', 'ua_header', 'reported_with',


### PR DESCRIPTION
Fixes #2051 

I removed type-stylo from config/__init__.py
I removed type-stylo from tests/unit/test_form.py
 [Yes ] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
