### PR TITLE
Fixes #1955 - Adds missing tests to webhooks

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -52,3 +52,6 @@ class TestConfig(unittest.TestCase):
         milestones_json = json_data('milestones_content_plus.json')
         actual = update_status_config(milestones_json)
         self.assertEqual(actual, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -86,3 +86,6 @@ class TestDashboard(unittest.TestCase):
         """Check we receive the right list of browsers."""
         labels = ['status-foo', 'blah', 'browser-', 'browser-firefox']
         self.assertListEqual(['firefox'], browser_labels(labels))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -244,3 +244,6 @@ class TestForm(unittest.TestCase):
         """Assert domains validity in issue reporting."""
         self.assertTrue(helpers.is_blacklisted_domain('coco.fr'))
         self.assertFalse(helpers.is_blacklisted_domain('w3.org'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -260,15 +260,33 @@ class TestWebhook(unittest.TestCase):
     def test_signature_check(self):
         """Test the signature check function for WebHooks."""
         payload = 'A body'
-        secret_key = 'SECRET'
-        post_signature = 'sha1=3ed5d2f74f4555cef6d72c7679370a4bebf86628'
+        key = 'SECRET'
+        post_signature = 'sha1=abacb5cff87d9e0122683d0d1d18a150809ac700'
         self.assertTrue(helpers.signature_check(key, post_signature, payload))
-        post_signature = '3ed5d2f74f4555cef6d72c7679370a4bebf86628'
+        post_signature = 'abacb5cff87d9e0122683d0d1d18a150809ac700'
         self.assertFalse(helpers.signature_check(key, post_signature, payload))
         post_signature = 'sha1='
         self.assertFalse(helpers.signature_check(key, post_signature, payload))
         post_signature = 'sha1=wrong'
         self.assertFalse(helpers.signature_check(key, post_signature, payload))
+
+    def test_new_opened_issue(self):
+        """Test the core actions on new opened issues for WebHooks."""
+        # A 200 response
+        json_event, signature = event_data('new_event_valid.json')
+        payload = json.loads(json_event)
+        with patch('webcompat.webhooks.helpers.proxy_request') as proxy:
+            proxy.return_value.status_code = 200
+            response = helpers.new_opened_issue(payload)
+            self.assertEqual(response.status_code, 200)
+            # A 401 response
+            proxy.return_value.status_code = 401
+            proxy.return_value.content = '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}'  # noqa
+            with patch.dict('webcompat.webhooks.helpers.app.config',
+                            {'OAUTH_TOKEN': ''}):
+                response = helpers.new_opened_issue(payload)
+                self.assertEqual(response.status_code, 401)
+                self.assertTrue('Bad credentials' in response.content)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -257,6 +257,18 @@ class TestWebhook(unittest.TestCase):
         actual = helpers.get_issue_info(payload)
         self.assertDictEqual(expected, actual)
 
+    def test_signature_check(self):
+        """Test the signature check function for WebHooks."""
+        payload = 'A body'
+        secret_key = 'SECRET'
+        post_signature = 'sha1=3ed5d2f74f4555cef6d72c7679370a4bebf86628'
+        self.assertTrue(helpers.signature_check(key, post_signature, payload))
+        post_signature = '3ed5d2f74f4555cef6d72c7679370a4bebf86628'
+        self.assertFalse(helpers.signature_check(key, post_signature, payload))
+        post_signature = 'sha1='
+        self.assertFalse(helpers.signature_check(key, post_signature, payload))
+        post_signature = 'sha1=wrong'
+        self.assertFalse(helpers.signature_check(key, post_signature, payload))
 
 if __name__ == '__main__':
     unittest.main()

--- a/webcompat/__init__.py
+++ b/webcompat/__init__.py
@@ -33,9 +33,8 @@ import webcompat.views  # nopep8
 from api.endpoints import api
 from api.uploads import uploads
 from error_handlers import error_handlers
-from webhooks import webhooks
 
-for blueprint in [api, error_handlers, uploads, webhooks]:
+for blueprint in [api, error_handlers, uploads]:
     app.register_blueprint(blueprint)
 
 

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -4,15 +4,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Flask Blueprint for our "webhooks" module.webhooks.
+"""WebHooks module
 
-See https://developer.github.com/webhooks/ for what is possible.
+See https://developer.github.com/ for what is possible.
 """
 
 import json
 import logging
 
-from flask import Blueprint
 from flask import request
 
 from helpers import get_issue_info
@@ -21,10 +20,8 @@ from helpers import new_opened_issue
 
 from webcompat import app
 
-webhooks = Blueprint('webhooks', __name__, url_prefix='/webhooks')
 
-
-@webhooks.route('/labeler', methods=['POST'])
+@app.route('/webhooks/labeler', methods=['POST'])
 def hooklistener():
     """Listen for the "issues" webhook event.
 


### PR DESCRIPTION
This PR fixes issue #1955

## Proposed PR background

This does a couple of things.

1. It removes the blueprint for webhooks. It was not that useful in this context (one route, no templates) and it made the testing a lot harder.
2. It removes the update_issue which was kind of duplicating what new_opened_issue was doing.
3. There's a room for improving by creating a function to extract the useful information in new_opened_issue.
4. It adds the missing tests for webhooks module.

@miketaylr r?