### PR TITLE
Fixes #2024 - Adds the ability to receive POST data with a JSON Payload

### DIFF
--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -83,41 +83,41 @@ class TestForm(unittest.TestCase):
 
     def test_metadata_wrapping(self):
         """Check that metadata is processed and wrapped."""
-        TEST_DICT = {'cool': 'dude', 'wow': 'ok'}
-        EXPECTED_SINGLE = '<!-- @cool: dude -->\n'
-        EXPECTED_SINGLE_COMMA = '<!-- @cool: dude, wow -->\n'
-        EXPECTED_MULTIPLE = '<!-- @cool: dude -->\n<!-- @wow: ok -->\n'
+        test_dict = {'cool': 'dude', 'wow': 'ok'}
+        expected_single = '<!-- @cool: dude -->\n'
+        expected_single_comma = '<!-- @cool: dude, wow -->\n'
+        expected_multiple = '<!-- @cool: dude -->\n<!-- @wow: ok -->\n'
 
         r = form.wrap_metadata(('cool', 'dude'))
-        self.assertEqual(r, EXPECTED_SINGLE)
+        self.assertEqual(r, expected_single)
 
         r = form.wrap_metadata(('cool', 'dude, wow'))
-        self.assertEqual(r, EXPECTED_SINGLE_COMMA)
+        self.assertEqual(r, expected_single_comma)
 
-        r = form.get_metadata(('cool', 'wow'), TEST_DICT)
-        self.assertEqual(r, EXPECTED_MULTIPLE)
+        r = form.get_metadata(('cool', 'wow'), test_dict)
+        self.assertEqual(r, expected_multiple)
 
     def test_radio_button_label(self):
         """Check that appropriate radio button label is returned."""
-        TEST_LABELS_LIST = [
+        test_labels_list = [
             (u'detection_bug', u'Desktop site instead of mobile site'),
             (u'unknown_bug', u'Something else')
         ]
 
-        r = form.get_radio_button_label('unknown_bug', TEST_LABELS_LIST)
+        r = form.get_radio_button_label('unknown_bug', test_labels_list)
         self.assertEqual(r, u'Something else')
 
-        r = form.get_radio_button_label(u'detection_bug', TEST_LABELS_LIST)
+        r = form.get_radio_button_label(u'detection_bug', test_labels_list)
         self.assertEqual(r, u'Desktop site instead of mobile site')
 
-        r = form.get_radio_button_label(None, TEST_LABELS_LIST)
+        r = form.get_radio_button_label(None, test_labels_list)
         self.assertEqual(r, u'Unknown')
 
-        r = form.get_radio_button_label('failme', TEST_LABELS_LIST)
+        r = form.get_radio_button_label('failme', test_labels_list)
         self.assertEqual(r, u'Unknown')
 
     def test_get_form(self):
-        """Checks we return the right form with the appropriate data."""
+        """Check we return the right form with the appropriate data."""
         with webcompat.app.test_request_context('/issues/new'):
             form_data = {'user_agent': FIREFOX_UA,
                          'url': 'http://example.net/'}

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -118,8 +118,10 @@ class TestForm(unittest.TestCase):
 
     def test_get_form(self):
         """Checks we return the right form with the appropriate data."""
-        with webcompat.app.test_request_context('/'):
-            actual = form.get_form(FIREFOX_UA)
+        with webcompat.app.test_request_context('/issues/new'):
+            form_data = {'user_agent': FIREFOX_UA,
+                         'url': 'http://example.net/'}
+            actual = form.get_form(form_data)
             expected_browser = 'Firefox 48.0'
             expected_os = 'Mac OS X 10.11'
             self.assertIsInstance(actual, form.IssueForm)

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -247,5 +247,22 @@ class TestForm(unittest.TestCase):
         self.assertTrue(helpers.is_blacklisted_domain('coco.fr'))
         self.assertFalse(helpers.is_blacklisted_domain('w3.org'))
 
+    def test_report_issue_anonymous_fails_with_wrong_credentials(self):
+        """Report issue should not be working if wrong credentials."""
+        with webcompat.app.app_context():
+            rv = self.app.post(
+                '/issues/new',
+                content_type='multipart/form-data',
+                data=dict(
+                    browser='Firefox Mobile 45.0',
+                    description='testing 2971',
+                    os='macos',
+                    problem_category='yada',
+                    submit_type='punkcat-submit',
+                    url='http://testing.example.org',
+                    username='yeeha'))
+            self.assertEqual(rv.status_code, 400)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -6,14 +6,9 @@
 
 """Tests for helper methods in webcompat/helpers.py."""
 
-import os.path
-import sys
 import unittest
 
 import flask
-
-# Add webcompat module to import path
-sys.path.append(os.path.realpath(os.pardir))
 
 import webcompat
 from webcompat.helpers import form_type
@@ -268,24 +263,24 @@ class TestHelpers(unittest.TestCase):
                      'url': u'http://example.net/',
                      }
         with webcompat.app.test_request_context(
-            '/issues/new?url=http://example.net/&src=web&label=type-stylo',
-            method='GET',
-            headers={'User-agent': 'Burger'}):
+                '/issues/new?url=http://example.net/&src=web&label=type-stylo',
+                method='GET',
+                headers={'User-agent': 'Burger'}):
             self.assertEqual(prepare_form(flask.request), form_data)
         # Testing that we keep even when some parameters are not defined.
         with webcompat.app.test_request_context(
-            '/issues/new?src=web&label=type-stylo',
-            method='GET',
-            headers={'User-agent': 'Burger'}):
+                '/issues/new?src=web&label=type-stylo',
+                method='GET',
+                headers={'User-agent': 'Burger'}):
             # URL is not defined
             form_data['url'] = None
             self.assertEqual(prepare_form(flask.request), form_data)
         # Testing with non-valid extra-labels. For now we keep them.
         # They are filtered by form.py
         with webcompat.app.test_request_context(
-            '/issues/new?src=web&label=type-punkcat&label=type-webvr',
-            method='GET',
-            headers={'User-agent': 'Burger'}):
+                '/issues/new?src=web&label=type-punkcat&label=type-webvr',
+                method='GET',
+                headers={'User-agent': 'Burger'}):
             form_data['url'] = None
             form_data['extra_labels'] = [u'type-punkcat', u'type-webvr']
             self.assertEqual(prepare_form(flask.request), form_data)
@@ -298,11 +293,11 @@ class TestHelpers(unittest.TestCase):
                      'url': u'http://json.example.net/',
                      }
         with webcompat.app.test_request_context(
-            '/issues/new?url=http://example.net/&src=web&label=type-stylo',
-            headers={'User-agent': 'Burger',
-                     'Content-Type': 'application/json'},
-            json=json_data,
-            method='POST'):
+                '/issues/new?url=http://example.net/&src=web&label=type-stylo',
+                headers={'User-agent': 'Burger',
+                         'Content-Type': 'application/json'},
+                json=json_data,
+                method='POST'):
             self.assertEqual(prepare_form(flask.request), json_data)
 
 if __name__ == '__main__':

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-'''Tests for helper methods in webcompat/helpers.py.'''
+"""Tests for helper methods in webcompat/helpers.py."""
 
 import os.path
 import sys
@@ -15,8 +15,8 @@ sys.path.append(os.path.realpath(os.pardir))
 
 import webcompat
 from webcompat.helpers import format_link_header
-from webcompat.helpers import get_browser_name
 from webcompat.helpers import get_browser
+from webcompat.helpers import get_browser_name
 from webcompat.helpers import get_name
 from webcompat.helpers import get_os
 from webcompat.helpers import get_str_value
@@ -57,7 +57,7 @@ class TestHelpers(unittest.TestCase):
         pass
 
     def test_rewrite_link(self):
-        '''Test we're correctly rewriting the passed in link.'''
+        """Test we're correctly rewriting the passed in link."""
         self.assertEqual(rewrite_links(GITHUB_ISSUES_LINK_HEADER),
                          REWRITTEN_ISSUES_LINK_HEADER)
         self.assertEqual(rewrite_links(GITHUB_SEARCH_LINK_HEADER),
@@ -66,17 +66,18 @@ class TestHelpers(unittest.TestCase):
                          REWRITTEN_COMMENTS_LINK_HEADER)
 
     def test_sanitize_link(self):
-        '''Test that we're removing access_token parameters.'''
+        """Test that we're removing access_token parameters."""
         self.assertNotIn('access_token=', sanitize_link(ACCESS_TOKEN_LINK))
 
     def test_rewrite_and_sanitize_link(self):
+        """Rewrite and Sanitize Links test."""
         self.assertNotIn('access_token=',
                          rewrite_and_sanitize_link(ACCESS_TOKEN_LINK))
         self.assertEqual(rewrite_and_sanitize_link(ACCESS_TOKEN_LINK),
                          REWRITTEN_ISSUES_LINK_HEADER)
 
     def test_normalize_api_params_converts_correctly(self):
-        '''Test that API params are correctly converted to Search API.'''
+        """Test that API params are correctly converted to Search API."""
         self.assertEqual(normalize_api_params({'direction': u'desc'}),
                          {'order': u'desc'})
         self.assertNotIn('direction',
@@ -110,7 +111,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(normalize_api_params(multi_before), multi_after)
 
     def test_normalize_api_params_ignores_unknown_params(self):
-        '''normalize_api_params shouldn't transform unknown params.'''
+        """normalize_api_params shouldn't transform unknown params."""
         self.assertEqual({'foo': u'bar'},
                          normalize_api_params({'foo': u'bar'}))
         self.assertEqual({'order': u'desc', 'foo': u'bar'},
@@ -118,19 +119,19 @@ class TestHelpers(unittest.TestCase):
                                               'direction': u'desc'}))
 
     def test_parse_http_link_headers(self):
-        '''Test HTTP Links parsing for GitHub only.'''
+        """Test HTTP Links parsing for GitHub only."""
         link_header = GITHUB_ISSUES_LINK_HEADER
         parsed_headers = PARSED_LINKED_HEADERS
         self.assertEqual(parse_link_header(link_header), parsed_headers)
 
     def test_format_http_link_headers(self):
-        '''Test HTTP Links formating.'''
+        """Test HTTP Links formating."""
         parsed_headers = PARSED_LINKED_HEADERS
         link_header = GITHUB_ISSUES_LINK_HEADER
         self.assertEqual(format_link_header(parsed_headers), link_header)
 
     def test_get_browser_name(self):
-        '''Test browser name parsing via get_browser_name helper method.'''
+        """Test browser name parsing via get_browser_name helper method."""
         self.assertEqual(get_browser_name(FIREFOX_UA), 'firefox')
         self.assertEqual(get_browser_name(FIREFOX_MOBILE_UA), 'firefox mobile')
         self.assertEqual(get_browser_name(FIREFOX_MOBILE_UA_OLD),
@@ -153,7 +154,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(get_browser_name(None), 'unknown')
 
     def test_get_browser(self):
-        '''Test browser parsing via get_browser helper method.'''
+        """Test browser parsing via get_browser helper method."""
         self.assertEqual(get_browser(FIREFOX_UA), 'Firefox 48.0')
         self.assertEqual(get_browser(FIREFOX_MOBILE_UA), 'Firefox Mobile 40.0')
         self.assertEqual(get_browser_name(FIREFOX_MOBILE_UA_OLD),
@@ -176,7 +177,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(get_browser(None), 'Unknown')
 
     def test_get_os(self):
-        '''Test OS parsing via get_os helper method.'''
+        """Test OS parsing via get_os helper method."""
         self.assertEqual(get_os(FIREFOX_UA), 'Mac OS X 10.11')
         self.assertEqual(get_os(FIREFOX_MOBILE_UA), 'Android 6.0.1')
         self.assertEqual(get_os(FIREFOX_MOBILE_UA_OLD), 'Android')
@@ -197,8 +198,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(get_os(None), 'Unknown')
 
     def test_get_str_value(self):
-        """Test getting an expected string, including Python to js-style
-        boolean.
+        """Get an expected string, including Python to js-style boolean.
 
         Note: key (output) and value (input) are in an unexpected order,
         just to keep the data structure valid.
@@ -210,9 +210,10 @@ class TestHelpers(unittest.TestCase):
                 self.assertEqual(get_str_value(browser_input), output)
 
     def test_get_version_string(self):
-        '''Test version string composition from Dict
-        via get_version_string helper method.
-        '''
+        """Test version string composition.
+
+        From Dict via get_version_string helper method.
+        """
         tests = [
             [{'major': '10', 'minor': '4', 'patch': '3'}, '10.4.3'],
             [{'major': '10', 'minor': '4', 'patch': None}, '10.4'],
@@ -227,7 +228,7 @@ class TestHelpers(unittest.TestCase):
             self.assertEqual(get_version_string(test[0]), test[1])
 
     def test_get_name(self):
-        '''Test name extraction from Dict via get_name helper method.'''
+        """Test name extraction from Dict via get_name helper method."""
         self.assertEqual(get_name({'family': 'Chrome'}), 'Chrome')
         self.assertEqual(get_name({'family': 'Mac OS X'}), 'Mac OS X')
         self.assertEqual(get_name({'family': 'Other'}), 'Unknown')

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -267,7 +267,8 @@ class TestHelpers(unittest.TestCase):
                 method='GET',
                 headers={'User-agent': 'Burger'}):
             self.assertEqual(prepare_form(flask.request), form_data)
-        # Testing that we keep even when some parameters are not defined.
+        # Testing that we keep processing
+        # even when some parameters are not defined.
         with webcompat.app.test_request_context(
                 '/issues/new?src=web&label=type-stylo',
                 method='GET',

--- a/tests/unit/test_rendering.py
+++ b/tests/unit/test_rendering.py
@@ -104,6 +104,14 @@ class TestURIContent(unittest.TestCase):
         expected = '<span class="link-text">Give Feedback</span>'
         self.assertTrue(expected in rv.data)
 
+    def test_form_rendering(self):
+        """Double Check that the form is properly populated."""
+        url = '/issues/new?url=http://example.com/&label=type-stylo'
+        headers = {'HTTP_USER_AGENT': FIREFOX_UA}
+        rv = self.app.get(url, environ_base=headers)
+        self.assertTrue('Firefox 61.0' in rv.data)
+        self.assertTrue('Mac OS X 10.13' in rv.data)
+        self.assertTrue('http://example.com/' in rv.data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_uploads.py
+++ b/tests/unit/test_uploads.py
@@ -8,11 +8,11 @@
 
 import json
 import os.path
+from StringIO import StringIO
 import sys
 import unittest
 
 from flask import Request
-from StringIO import StringIO
 from werkzeug import FileStorage
 from werkzeug.datastructures import MultiDict
 
@@ -47,7 +47,8 @@ def check_rv_format(self, resp):
 
 
 class TestingFileStorage(FileStorage):
-    """
+    """Test-only File Storage class.
+
     This is a helper for testing upload behavior in your application. You
     can manually create it, and its save method is overloaded to set `saved`
     to the name of the file it was saved to. All of these parameters are
@@ -76,7 +77,8 @@ class TestingFileStorage(FileStorage):
         self.saved = None
 
     def save(self, dst, buffer_size=16384):
-        """
+        """File save feature.
+
         This marks the file as saved by setting the `saved` attribute to the
         name of the file it was saved to.
 
@@ -90,7 +92,10 @@ class TestingFileStorage(FileStorage):
 
 
 class TestUploads(unittest.TestCase):
-    '''Modified from http://prschmid.blogspot.com/2013/05/unit-testing-flask-file-uploads-without.html  # nopep8'''
+    '''Test-only Uploads Class.
+
+    Modified from http://prschmid.blogspot.com/2013/05/unit-testing-flask-file-uploads-without.html  # nopep8
+    '''
 
     def setUp(self):
         app.config['TESTING'] = True
@@ -124,8 +129,11 @@ class TestUploads(unittest.TestCase):
             # we can ensure that the filename that we are "uploading"
             # is the same as the one being used by the application
             class TestingRequest(Request):
-                """A testing request to use that will return a
-                TestingFileStorage to test the uploading."""
+                """Test-only Request Class.
+
+                A testing request to use that will return a TestingFileStorage
+                to test the uploading.
+                """
                 @property
                 def files(self):
                     d = MultiDict()
@@ -156,8 +164,9 @@ class TestUploads(unittest.TestCase):
                 (PILE_OF_POO, 415)):
 
             class TestingRequest(Request):
-                """A testing request to use that allows us to manipulate
-                request.form to send screenshot data.
+                """A testing-only request class.
+
+                It allows to manipulate request.form to send screenshot data.
                 """
                 @property
                 def form(self):

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -66,6 +66,7 @@ class TestURLs(unittest.TestCase):
         mock_proxy.return_value = POST_RESPONSE
         rv = self.app.post(
             '/issues/new',
+            content_type='multipart/form-data',
             environ_base=headers,
             data=dict(
                 browser='Firefox Mobile 45.0',
@@ -89,6 +90,7 @@ class TestURLs(unittest.TestCase):
         rv = self.app.post(
             '/issues/new',
             environ_base=headers,
+            content_type='multipart/form-data',
             data=dict(
                 browser='Firefox Mobile 45.0', ))
         self.assertEqual(rv.status_code, 400)
@@ -203,7 +205,9 @@ class TestURLs(unittest.TestCase):
 
     def test_missing_parameters_for_new_issue(self):
         """Sends 400 to POST on /issues/new with missing parameters."""
-        rv = self.app.post('/issues/new', data=dict(url='foo'))
+        rv = self.app.post('/issues/new',
+                           content_type='multipart/form-data',
+                           data=dict(url='foo'))
         self.assertEqual(rv.status_code, 400)
 
     def test_new_issue_should_not_crash(self):
@@ -214,7 +218,9 @@ class TestURLs(unittest.TestCase):
                 'url': u'http://example.com',
                 'os': u'Foobar',
                 'browser': u'BarFoo'}
-        rv = self.app.post('/issues/new', data=data)
+        rv = self.app.post('/issues/new',
+                           content_type='multipart/form-data',
+                           data=data)
         self.assertEqual(rv.status_code, 400)
 
     def test_dashboard_triage(self):

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -6,17 +6,11 @@
 
 """Tests for our URL endpoints."""
 
-import json
 import os.path
 import sys
 import unittest
 
-from mock import MagicMock
 from mock import patch
-from requests import Response
-
-
-from webcompat.views import report_issue
 
 # Add webcompat module to import path
 sys.path.append(os.path.realpath(os.pardir))
@@ -84,15 +78,20 @@ class TestURLs(unittest.TestCase):
 
     @patch('webcompat.issues.proxy_request')
     def test_fail_post_new_issue(self, mock_proxy):
-        """Test that post is not working on /issues/new."""
-        mock_proxy = MagicMock(spec=Response)
-        mock_proxy = json.dumps(POST_RESPONSE)
+        """Test that post is not working on /issues/new.
+
+        It will fail with a 400 because the URL is missing."""
         rv = self.app.post(
             '/issues/new',
             environ_base=headers,
             content_type='multipart/form-data',
             data=dict(
-                browser='Firefox Mobile 45.0', ))
+                browser='Firefox Mobile 45.0',
+                description='http POST will fail.',
+                os='macOS',
+                problem_category='what',
+                submit_type='github-proxy-report',
+                username='PunkCat',))
         self.assertEqual(rv.status_code, 400)
 
     def test_about(self):

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -21,6 +21,7 @@ from helpers import get_str_value
 from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField
 from flask_wtf import FlaskForm
+from wtforms import FieldList
 from wtforms import HiddenField
 from wtforms import RadioField
 from wtforms import StringField
@@ -90,15 +91,25 @@ class IssueForm(FlaskForm):
                       [Optional(),
                        FileAllowed(Upload.ALLOWED_FORMATS, image_message)])
     details = HiddenField()
+    reported_with = HiddenField()
+    ua_header = HiddenField()
     submit_type = HiddenField()
 
 
-def get_form(ua_header):
-    """Return an instance of flask_wtf.FlaskForm with browser and os info."""
+def get_form(form_data):
+    """Return an instance of flask_wtf.FlaskForm.
+
+    It receives a dictionary of everything which needs to be fed to the form.
+    """
     bug_form = IssueForm()
-    # add browser and version to bug_form object data
+    ua_header = form_data['user_agent']
+    # Populate the form
     bug_form.browser.data = get_browser(ua_header)
+    bug_form.extra_labels = form_data.get('extra_labels', None)
     bug_form.os.data = get_os(ua_header)
+    bug_form.reported_with.data = form_data.get('src', 'web')
+    bug_form.ua_header.data = ua_header
+    bug_form.url.data = form_data.get('url', None)
     return bug_form
 
 

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -14,14 +14,9 @@ import json
 import random
 import urlparse
 
-from helpers import get_browser
-from helpers import get_os
-from helpers import get_str_value
-
+from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField
-from flask_wtf import FlaskForm
-from wtforms import FieldList
 from wtforms import HiddenField
 from wtforms import RadioField
 from wtforms import StringField
@@ -30,8 +25,11 @@ from wtforms.validators import InputRequired
 from wtforms.validators import Length
 from wtforms.validators import Optional
 
-from webcompat.api.uploads import Upload
 from webcompat import app
+from webcompat.api.uploads import Upload
+from webcompat.helpers import get_browser
+from webcompat.helpers import get_os
+from webcompat.helpers import get_str_value
 
 AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
@@ -114,8 +112,11 @@ def get_form(form_data):
 
 
 def get_details(details_string):
-    """Return details content as a formatted string, if it was JSON. Otherwise,
-    just return the string as-is."""
+    """Return details content.
+
+    * If JSON as a formatted string
+    * Otherwise as a string as-is.
+    """
     content = details_string
     rv = ''
 

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -15,7 +15,6 @@ import hashlib
 import json
 import os
 import re
-import requests
 import urlparse
 
 from flask import abort
@@ -23,6 +22,7 @@ from flask import g
 from flask import make_response
 from flask import request
 from flask import session
+import requests
 from ua_parser import user_agent_parser
 
 from webcompat import api
@@ -586,6 +586,7 @@ def is_blacklisted_domain(domain):
     spamlist = ['qiangpiaoruanjian', 'cityweb.de', 'coco.fr']
     return domain in spamlist
 
+
 def form_type(form_request):
     """Check the type of form request for /issues/new.
 
@@ -603,6 +604,7 @@ def form_type(form_request):
         return 'create'
     else:
         return None
+
 
 def prepare_form(form_request):
     """Extract all known information from the form request.

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -585,3 +585,21 @@ def is_blacklisted_domain(domain):
     # see https://github.com/webcompat/webcompat.com/issues/1627
     spamlist = ['qiangpiaoruanjian', 'cityweb.de', 'coco.fr']
     return domain in spamlist
+
+def form_type(form_request):
+    """Check the type of form request for /issues/new.
+
+    It can return either:
+    * 'prefill'
+    * 'create'
+    """
+    method = form_request.method
+    content_type = form_request.content_type
+    if method == 'GET':
+        return 'prefill'
+    elif method == 'POST' and content_type == 'application/json':
+        return 'prefill'
+    elif method == 'POST' and content_type.startswith('multipart/form-data'):
+        return 'create'
+    else:
+        return None

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -603,3 +603,24 @@ def form_type(form_request):
         return 'create'
     else:
         return None
+
+def prepare_form(form_request):
+    """Extract all known information from the form request.
+
+    This is called by /issues/new to prepare needed by the form
+    before being posted on GitHub.
+    For HTTP POST:
+    The JSON content will override any existing URL parameters.
+    The URL parameters will be kept if non-existent in the JSON.
+    """
+    form_data = {}
+    form_data['user_agent'] = request.headers.get('User-Agent')
+    form_data['src'] = request.args.get('src')
+    form_data['extra_labels'] = request.args.getlist('label')
+    form_data['url'] = request.args.get('url')
+    # we rely here on the fact we receive the right POST
+    # because we tested it with form_type(request)
+    if form_request.method == 'POST':
+        json_data = form_request.get_json()
+        form_data.update(json_data)
+    return form_data

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -11,6 +11,8 @@ It handles authenticated users and webcompat-bot (proxy) case.
 
 import json
 
+from flask import abort
+
 from webcompat import github
 from webcompat.form import build_formdata
 from webcompat.helpers import proxy_request
@@ -21,13 +23,16 @@ def report_issue(form, proxy=False):
     """Report an issue, as a logged in user or anonymously."""
     # /repos/:owner/:repo/issues
     path = 'repos/{0}'.format(REPO_URI)
-    if proxy:
+    submit_type = form.get('submit_type')
+    if proxy and submit_type == 'github-proxy-report':
         # Return a Response object.
         response = proxy_request('post',
                                  path,
                                  data=json.dumps(build_formdata(form)))
         json_response = response.json()
-    else:
+    elif (not proxy) and submit_type == 'github-auth-report':
         # Return JSON data as a dict
         json_response = github.post(path, build_formdata(form))
+    else:
+        abort(400)
     return json_response

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -4,8 +4,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-'''Module that handles submission of issues via the GitHub API, both for an
-authed user and the proxy case.'''
+"""Module that handles submission of issues via the GitHub API.
+
+It handles authenticated users and webcompat-bot (proxy) case.
+"""
 
 import json
 
@@ -16,7 +18,7 @@ from webcompat.helpers import REPO_URI
 
 
 def report_issue(form, proxy=False):
-    '''Report an issue, as a logged in user or anonymously.'''
+    """Report an issue, as a logged in user or anonymously."""
     # /repos/:owner/:repo/issues
     path = 'repos/{0}'.format(REPO_URI)
     if proxy:

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -169,10 +169,32 @@ def show_issues():
 
 @app.route('/issues/new', methods=['GET', 'POST'])
 def create_issue():
-    """Create a new issue.
+    """Create a new issue or prefill a form for submission.
 
-    GET will return an HTML response for reporting issues.
-    POST will create a new issue.
+    * HTTP GET with (optional) parameters
+      * create a form with prefiled data.
+      * parameters:
+        * url: URL of the Web site
+        * src: source of the request (web, addon, etc.)
+        * label: controled list of labels
+    * HTTP POST with a JSON payload
+      * create a form with prefiled data
+      * content-type is application/json
+      * json may include:
+        * title
+        * User agent string
+        * OS identification
+        * labels list
+        * type of bugs
+        * short summary
+        * full description
+        * tested in another browser
+        * body
+    * HTTP POST with an attached form
+      * submit a form to GitHub to create a new issue
+      * form submit type:
+        * authenticated: Github authentification
+        * anonymous: handled by webcompat-bot
 
     Any deceptive requests will be ended as a 400.
     See https://tools.ietf.org/html/rfc7231#section-6.5.1

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -174,13 +174,13 @@ def create_issue():
     """Create a new issue or prefill a form for submission.
 
     * HTTP GET with (optional) parameters
-      * create a form with prefiled data.
+      * create a form with prefilled data.
       * parameters:
         * url: URL of the Web site
         * src: source of the request (web, addon, etc.)
         * label: controled list of labels
     * HTTP POST with a JSON payload
-      * create a form with prefiled data
+      * create a form with prefilled data
       * content-type is application/json
       * json may include:
         * title
@@ -246,7 +246,7 @@ def create_issue():
             session['show_thanks'] = True
             return redirect(
                 url_for('show_issue', number=json_response.get('number')))
-        # Authentified reporting
+        # Authenticated reporting
         if form.get('submit_type') == AUTH_REPORT:
             if g.user:  # If you're already authed, submit the bug.
                 json_response = report_issue(form)

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -212,7 +212,7 @@ def create_issue():
     if request_type == 'prefill':
         form_data = prepare_form(request)
         bug_form = get_form(form_data)
-        session['form_data'] = form_data
+        session['extra_labels'] = form_data['extra_labels']
         return render_template('new-issue.html', form=bug_form)
     # Issue Creation section
     elif request_type == 'create':
@@ -222,9 +222,9 @@ def create_issue():
             abort(400)
         # Adding parameters to the form
         form = request.form.copy()
-        form_data = session.pop('form_data', None)
-        if form_data:
-            form['extra_labels'] = form_data.get('extra_labels', None)
+        extra_labels = session.pop('extra_labels', None)
+        if extra_labels:
+            form['extra_labels'] = extra_labels
         # Logging the ip and url for investigation
         log.info('{ip} {url}'.format(
             ip=request.remote_addr,

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -242,7 +242,7 @@ def create_issue():
             abort(400)
         # Anonymous reporting
         if form.get('submit_type') == PROXY_REPORT:
-            json_response = report_issue(form)
+            json_response = report_issue(form, proxy=True)
             session['show_thanks'] = True
             return redirect(
                 url_for('show_issue', number=json_response.get('number')))


### PR DESCRIPTION
This PR fixes issue #2024

## Proposed PR background

This should be able to receive POST data with a JSON body for pre-populating the form.

* Works as before and accept URL parameters both from GET and POST
* Adds a POST JSON data for the form
* Submit the data as before with multiform/part

Possible Follow up issues to fill. 
* Be stricter in what is possible to do in the POST data (JSON validation)
* Be stricter on the form validation.

The next step will be to push this to staging so we can test it deeply and thoroughly.


```
→ nosetests 
..................................................................................................
----------------------------------------------------------------------
Ran 98 tests in 1.133s

OK
```

r? @miketaylr 