### PR TITLE
Fixes #2607 - Fixes typo in secrets.py.example

### DIFF
--- a/config/secrets.py.example
+++ b/config/secrets.py.example
@@ -37,7 +37,7 @@ if env.LOCALHOST:
 else:
     BACKUP_DEFAULT_DEST = ''
 
-# Production GiHub Issues repo URI. Can be ignored for local testing.
+# Production GitHub Issues repo URI. Can be ignored for local testing.
 if env.PRODUCTION:
     ISSUES_REPO_URI = ''
 # Staging and Local instances use the same test repo


### PR DESCRIPTION
Fixes #2607 
There was a typo in Github spelling. This PR is to fixed the same . If i need to create a issue for the same please let me know 