### PR TITLE
Issue #2576 - fixed white gap visible in homepage

### DIFF
--- a/webcompat/static/css/src/hero.css
+++ b/webcompat/static/css/src/hero.css
@@ -50,7 +50,7 @@
   }
 
   .hero-section {
-    margin: -32px auto 0;
+    margin: -34px auto 0;
     padding: 6em var(--unit-gap) 5.25em;
     position: relative;
     width: 100%;

--- a/webcompat/static/css/src/nav.css
+++ b/webcompat/static/css/src/nav.css
@@ -138,10 +138,6 @@
   padding-right: 0;
 }
 
-.nav-left {
-  margin-top: 3px;
-}
-
 .nav-dropdown-wrapper {
   display: none;
 }


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue #2576

## Proposed PR background

There is a `margin-top` on the link to the addon. Without this link there is a gap betwee the Fixed `Header` and the `Hero` section. So removing the margin  (on the link) and increase the `marginTop` on the `hero` fixed the issue. 

---

- [x] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
