### PR TITLE
Issue #2320 - Adds wc-Comment-content-nsfw to new CSS

### DIFF
--- a/tests/functional/issues-non-auth.js
+++ b/tests/functional/issues-non-auth.js
@@ -82,7 +82,7 @@ registerSuite("Issues", {
         )
         .getAttribute("class")
         .then(function(className) {
-          assert.include(className, "wc-Comment-content-nsfw");
+          assert.include(className, "issue-details-nsfw");
         })
         .end();
     },
@@ -94,24 +94,24 @@ registerSuite("Issues", {
         )
         .getAttribute("class")
         .then(function(className) {
-          assert.include(className, "wc-Comment-content-nsfw");
-          assert.notInclude(className, "wc-Comment-content-nsfw--display");
+          assert.include(className, "issue-details-nsfw");
+          assert.notInclude(className, "issue-details-nsfw--display");
         })
         .click()
         .end()
         .findByCssSelector(".js-Issue-commentList .js-Comment-content p")
         .getAttribute("class")
         .then(function(className) {
-          assert.include(className, "wc-Comment-content-nsfw");
-          assert.include(className, "wc-Comment-content-nsfw--display");
+          assert.include(className, "issue-details-nsfw");
+          assert.include(className, "issue-details-nsfw--display");
         })
         .click()
         .end()
         .findByCssSelector(".js-Issue-commentList .js-Comment-content p")
         .getAttribute("class")
         .then(function(className) {
-          assert.include(className, "wc-Comment-content-nsfw");
-          assert.notInclude(className, "wc-Comment-content-nsfw--display");
+          assert.include(className, "issue-details-nsfw");
+          assert.notInclude(className, "issue-details-nsfw--display");
         })
         .end();
     },

--- a/webcompat/static/css/src/issue.css
+++ b/webcompat/static/css/src/issue.css
@@ -127,3 +127,35 @@
 .issue-details {
   word-break: break-all;
 }
+
+.wc-Comment-content-nsfw {
+  position: relative;
+}
+
+.wc-Comment-content-nsfw::after {
+  background: var(--base-colorDark);
+  color: var(--base-background);
+  content: "Click to show image";
+  cursor: pointer;
+  display: block;
+  left: 50%;
+  padding: 1em;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 50%;
+}
+
+.wc-Comment-content-nsfw img {
+  filter: blur(50px);
+}
+
+.wc-Comment-content-nsfw--display img {
+  filter: blur(0);
+}
+
+.wc-Comment-content-nsfw--display::after {
+  display: none;
+}
+

--- a/webcompat/static/css/src/issue.css
+++ b/webcompat/static/css/src/issue.css
@@ -128,11 +128,11 @@
   word-break: break-all;
 }
 
-.wc-Comment-content-nsfw {
+.issue-details-nsfw {
   position: relative;
 }
 
-.wc-Comment-content-nsfw::after {
+.issue-details-nsfw::after {
   background: var(--base-colorDark);
   color: var(--base-background);
   content: "Click to show image";
@@ -147,15 +147,15 @@
   width: 50%;
 }
 
-.wc-Comment-content-nsfw img {
+.issue-details-nsfw img {
   filter: blur(50px);
 }
 
-.wc-Comment-content-nsfw--display img {
+.issue-details-nsfw--display img {
   filter: blur(0);
 }
 
-.wc-Comment-content-nsfw--display::after {
+.issue-details-nsfw--display::after {
   display: none;
 }
 

--- a/webcompat/static/css/src/variables.css
+++ b/webcompat/static/css/src/variables.css
@@ -1,4 +1,6 @@
 :root {
+  --base-background: #fff;
+  --base-colorDark: #ffc900; /* Dark Yellow */
   --grid-outermargin-s: 9px;
   --grid-outermargin-m: 19px;
   --unit-gap: 45px;

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -173,7 +173,7 @@ issues.BodyView = Backbone.View.extend({
       issueDesc
         .find("img")
         .closest("p")
-        .addClass("wc-Comment-content-nsfw");
+        .addClass("issue-details-nsfw");
     }
 
     return this;
@@ -331,7 +331,7 @@ issues.MainView = Backbone.View.extend(
     el: $(".js-Issue"),
     events: {
       "click .js-Issue-comment-button": "addNewComment",
-      "click .wc-Comment-content-nsfw": "toggleNSFW"
+      "click .issue-details-nsfw": "toggleNSFW"
     },
     keyboardEvents: {
       g: "githubWarp"
@@ -512,7 +512,7 @@ issues.MainView = Backbone.View.extend(
         _.each(commentElm.find("img"), function(elm) {
           $(elm)
             .closest("p")
-            .addClass("wc-Comment-content-nsfw");
+            .addClass("issue-details-nsfw");
         });
       }
     },
@@ -550,7 +550,7 @@ issues.MainView = Backbone.View.extend(
           : e.target.nodeName === "P" && e.target.firstElementChild;
       $(target)
         .parent()
-        .toggleClass("wc-Comment-content-nsfw--display");
+        .toggleClass("issue-details-nsfw--display");
     },
     render: function() {
       this.$el.removeClass("is-hidden");


### PR DESCRIPTION
This PR fixes issue #2320

It's necessary to add a `nsfw` label to the github repository in order for these changes to work.

r? @magsout 

---

- [x] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
