### PR TITLE
Fixes #2650 - Modified domain received by `is_blacklisted_domain`

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -584,7 +584,9 @@ def is_blacklisted_domain(domain):
     # see https://github.com/webcompat/webcompat.com/issues/1141
     # see https://github.com/webcompat/webcompat.com/issues/1237
     # see https://github.com/webcompat/webcompat.com/issues/1627
-    spamlist = ['qiangpiaoruanjian', 'cityweb.de', 'coco.fr']
+    spamlist = ['www.qiangpiaoruanjian.cn',
+                'mailmanager.cityweb.de',
+                'coco.fr']
     return domain in spamlist
 
 

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -6,6 +6,7 @@
 """Module for the main routes of webcompat.com."""
 import logging
 import os
+import urlparse
 
 from flask import abort
 from flask import flash
@@ -230,7 +231,7 @@ def create_issue():
             ip=request.remote_addr,
             url=form['url'].encode('utf-8')))
         # Checking blacklisted domains
-        if is_blacklisted_domain(form['url']):
+        if is_blacklisted_domain(urlparse.urlsplit(form['url']).hostname):
             msg = app.config['IS_BLACKLISTED_DOMAIN'].format(form['url'])
             flash(msg, 'notimeout')
             return redirect(url_for('index'))


### PR DESCRIPTION
I have changed the `views.py` to send domain instead of full URL using `URLParse` as suggested [here](https://github.com/webcompat/webcompat.com/issues/2650#issuecomment-429582078).

For checking if it is actually a URL i.e validating a URL before finding it is blacklisted, I want to add a function of URL Validation which will check for [terminating punctations](https://docs.google.com/document/d/1h9yPmUScIGt9gEquLjgf739GfEy8QJ6WG_hsc-OTkBU/edit#) (See also #2662 )

```
<Anushi1998> I want suggestions regarding #2662(https://github.com/webcompat/webcompat.com/issues/2662)
<Anushi1998> I was thinking to add more specific URL validation checks (than just http: or https:)
<Anushi1998> For this I tried finding such python module that is based on whatwg guidelines but my apologies I couldn't find (well I also don't think they exist :P)
<Anushi1998> So I am thinking to write such a function to check that (something like this https://github.com/kvesteri/validators/blob/master/validators/url.py modified for our purpose)
```

r? @karlcow 