### PR TITLE
Fixes #2670 - Makes sure we are passing a JSON object for processing details.

### DIFF
--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -198,7 +198,7 @@ class TestForm(unittest.TestCase):
     def test_get_details(self):
         """Assert we handle valid dict and other values."""
         actual_string_arg = form.get_details('cool')
-        expected_string_arg = 'cool'
+        expected_string_arg = '<li>cool</li>'
         self.assertEqual(actual_string_arg, expected_string_arg)
         actual_dict_arg = form.get_details({'a': 'b', 'c': False})
         expected_dict_arg = '<li>a: b</li><li>c: false</li>'
@@ -206,12 +206,18 @@ class TestForm(unittest.TestCase):
 
     def test_build_details(self):
         """Expected HTML is returned for a json object or a string."""
+        # Test for receiving JSON object as a string
         actual_json_arg = form.build_details(json.dumps(
             {'a': 'b', 'c': False}))
         expected_json_arg = '<details>\n<summary>Browser Configuration</summary>\n<ul>\n  <li>a: b</li><li>c: false</li>\n</ul>\n\n</details>'  # nopep8
         self.assertEqual(actual_json_arg, expected_json_arg)
-        actual_string_arg = form.build_details('cool')
-        expected_string_arg = '<details>\n<summary>Browser Configuration</summary>\n<ul>\n  cool\n</ul>\n\n</details>'  # nopep8
+        # Test for receiving a JSON value which is not an object
+        actual_json_arg = form.build_details('null')
+        expected_json_arg = '<details>\n<summary>Browser Configuration</summary>\n<ul>\n  <li>None</li>\n</ul>\n\n</details>'  # nopep8
+        self.assertEqual(actual_json_arg, expected_json_arg)
+        # Test for receiving a string
+        actual_string_arg = form.build_details(u'cool')
+        expected_string_arg = '<details>\n<summary>Browser Configuration</summary>\n<ul>\n  <li>cool</li>\n</ul>\n\n</details>'  # nopep8
         self.assertEqual(actual_string_arg, expected_string_arg)
 
     def test_build_details_with_console_logs(self):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -48,11 +48,15 @@ CHROME_TABLET_UA = 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B
 
 
 class TestHelpers(unittest.TestCase):
+    """Class for testing helpers."""
+
     def setUp(self):
+        """Set up the tests."""
         webcompat.app.config['TESTING'] = True
         self.app = webcompat.app.test_client()
 
     def tearDown(self):
+        """Tear down the tests."""
         pass
 
     def test_rewrite_link(self):
@@ -110,7 +114,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(normalize_api_params(multi_before), multi_after)
 
     def test_normalize_api_params_ignores_unknown_params(self):
-        """normalize_api_params shouldn't transform unknown params."""
+        """Ignore unknown parameters in normalize_api_params."""
         self.assertEqual({'foo': u'bar'},
                          normalize_api_params({'foo': u'bar'}))
         self.assertEqual({'order': u'desc', 'foo': u'bar'},

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -6,6 +6,7 @@
 
 """Tests for helper methods in webcompat/helpers.py."""
 
+import json
 import unittest
 
 import flask
@@ -19,6 +20,7 @@ from webcompat.helpers import get_name
 from webcompat.helpers import get_os
 from webcompat.helpers import get_str_value
 from webcompat.helpers import get_version_string
+from webcompat.helpers import is_json_object
 from webcompat.helpers import normalize_api_params
 from webcompat.helpers import parse_link_header
 from webcompat.helpers import prepare_form
@@ -304,6 +306,15 @@ class TestHelpers(unittest.TestCase):
                 json=json_data,
                 method='POST'):
             self.assertEqual(prepare_form(flask.request), json_data)
+
+    def test_json_object(self):
+        """Check if we return the right type of each JSON."""
+        # A simple JSON object
+        self.assertTrue(is_json_object(json.loads('{"a": "b"}')))
+        # A more complex JSON object
+        self.assertTrue(is_json_object(json.loads('{"bar":["baz", null, 1.0, 2]}')))  # noqa
+        # A JSON value, which is not an object
+        self.assertFalse(is_json_object(json.loads('null')))
 
 if __name__ == '__main__':
     unittest.main()

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -129,7 +129,7 @@ def get_details(details):
         rv = ''.join(['<li>{k}: {v}</li>'.format(k=k, v=get_str_value(v))
                       for k, v in details.items()])
     except AttributeError:
-        return content
+        return '<li>{content}</li>'.format(content=content)
     return rv
 
 

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -30,6 +30,7 @@ from webcompat.api.uploads import Upload
 from webcompat.helpers import get_browser
 from webcompat.helpers import get_os
 from webcompat.helpers import get_str_value
+from webcompat.helpers import is_json_object
 
 AUTH_REPORT = 'github-auth-report'
 PROXY_REPORT = 'github-proxy-report'
@@ -153,17 +154,15 @@ def build_details(details):
     If we get JSON, we try to pull out the console logs before building the
     rest of the details.
     """
-
     console_logs = None
-    content = details
     try:
         content = json.loads(details)
-        console_logs = content.pop('consoleLog', None)
+        if is_json_object(content):
+            console_logs = content.pop('consoleLog', None)
     except ValueError:
         # if we got a ValueError, details was a string, so just pass it
         # into get_details below
-        pass
-
+        content = details
     return """<details>
 <summary>Browser Configuration</summary>
 <ul>

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -627,3 +627,8 @@ def prepare_form(form_request):
         json_data = form_request.get_json()
         form_data.update(json_data)
     return form_data
+
+
+def is_json_object(json_data):
+    """Check if the JSON data are an object."""
+    return isinstance(json_data, dict)

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -75,6 +75,7 @@ def md5_checksum(file_path):
 
 
 def get_str_value(val):
+    """Map values from JSON to python."""
     details_map = {False: 'false', True: 'true', None: 'null'}
     if isinstance(val, (bool, type(None))):
         return details_map[val]
@@ -269,7 +270,7 @@ def normalize_api_params(params):
 
 
 def rewrite_links(link_header):
-    """Rewrites Link header Github API endpoints to our own.
+    """Rewrite Link header Github API endpoints to our own.
 
     <https://api.github.com/repositories/17839063/iss...&page=2>; rel="next",
     <https://api.github.com/repositories/17839063/iss...&page=4>; rel="last"


### PR DESCRIPTION
This PR fixes issue #2670

## Proposed PR background

This fixes a couple of issues, but mainly it makes sure that if details is not a JSON object we catch it and return a string. For this it adds a new method in helpers to check if the JSON is an object.
It also fixes a couple of minor syntactic issues.

