### PR TITLE
Fixes #2571 - Adds a dashboard route with the list of current dashboards

### DIFF
--- a/tests/unit/test_rendering.py
+++ b/tests/unit/test_rendering.py
@@ -55,6 +55,7 @@ class TestURIContent(unittest.TestCase):
             ('issues/new', 'New Issue'),
             ('/privacy', 'Privacy Policy'),
             ('/dashboard/triage', 'Triage Dashboard'),
+            ('/dashboard', 'Webcompat Dashboards'),
             ('/404', default_title)
         ]
         with webcompat.app.app_context():

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -80,7 +80,8 @@ class TestURLs(unittest.TestCase):
     def test_fail_post_new_issue(self, mock_proxy):
         """Test that post is not working on /issues/new.
 
-        It will fail with a 400 because the URL is missing."""
+        It will fail with a 400 because the URL is missing.
+        """
         rv = self.app.post(
             '/issues/new',
             environ_base=headers,
@@ -203,7 +204,7 @@ class TestURLs(unittest.TestCase):
         self.assertEqual(rv.status_code, 410)
 
     def test_missing_parameters_for_new_issue(self):
-        """Sends 400 to POST on /issues/new with missing parameters."""
+        """Send 400 to POST on /issues/new with missing parameters."""
         rv = self.app.post('/issues/new',
                            content_type='multipart/form-data',
                            data=dict(url='foo'))
@@ -230,19 +231,17 @@ class TestURLs(unittest.TestCase):
         self.assertTrue('text/html' in rv.content_type)
 
     def test_dashboard_route(self):
-        """Request to /dashboard should be 404.
+        """Request to /dashboard should exist.
 
-        For now, the dashboard route has no purpose.
+        * 200 on /dashboard
+        * 404 on /dashboard/
         """
         rv = self.app.get('/dashboard/')
-        content_test = 'Lost in Punk Cat Space (404)' in rv.data
         self.assertEqual(rv.status_code, 404)
         self.assertTrue('text/html' in rv.content_type)
-        self.assertTrue(content_test)
         rv = self.app.get('/dashboard')
-        content_test = 'Lost in Punk Cat Space (404)' in rv.data
-        self.assertEqual(rv.status_code, 404)
-        self.assertTrue('text/html' in rv.content_type)
+        content_test = 'Dashboards' in rv.data
+        self.assertEqual(rv.status_code, 200)
         self.assertTrue(content_test)
 
     def test_webhooks_route(self):

--- a/webcompat/templates/dashboard/footer.html
+++ b/webcompat/templates/dashboard/footer.html
@@ -4,10 +4,13 @@
     background-color: #ffc900;
     padding: 1em;
   }
+  .wc-Footer a {
+    text-decoration: none;
+  }
 </style>
 
 <footer class="wc-Footer">
   <div>
-    webcompat.com // Triage Dashboard
+    <a href="/">webcompat.com</a>
   </div>
 </footer>

--- a/webcompat/templates/dashboard/home.html
+++ b/webcompat/templates/dashboard/home.html
@@ -1,0 +1,26 @@
+{% extends "dashboard/layout.html" %}
+{% block title %}Webcompat Dashboards{% endblock %}
+{% block body %}
+  <style>
+  .wc-UIMain {display:flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background-color: #fff;
+    padding: 1.2em;}
+
+  @media all and (min-width: 33em) {
+    .wc-UIMain {
+      padding-left: 50px;
+      padding-right: 50px;
+    }
+  }
+  </style>
+  {% include "dashboard/home/top-bar.html" %}
+  <main class="wc-UIMain" role="main">
+    <ul>
+      <li><a href="http://adamstevenson.ca/mozilla/reports/">General Report</a></li>
+      <li><a href="/dashboard/triage">Triage</a></li>
+      <li><a href="https://webcompat.github.io/webcompat-metrics-client/">Diagnosis</a></li>
+    </ul>
+  </main>
+{% endblock %}

--- a/webcompat/templates/dashboard/home/top-bar.html
+++ b/webcompat/templates/dashboard/home/top-bar.html
@@ -1,0 +1,25 @@
+<style>
+  .wc-Header {
+    font-size: 1rem;
+    background-color: #ffc900;
+    padding: 1em;
+  }
+
+  .wc-Header > h1 {
+    font-size: 1.3em;
+    margin: 0;
+  }
+
+  .wc-Header a {
+    text-decoration: none;
+    color: rgb(64, 64, 64);
+  }
+
+  .wc-Header a:hover {
+    color: rgb(255, 255, 255);
+  }
+</style>
+
+<header class="wc-Header" role="banner">
+  <h1><a href="/">Webcompat.com</a> // Dashboards</h1>
+</header>

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -439,6 +439,14 @@ def cssfixme():
     return (msg, 410, {'content-type': 'text/plain; charset=utf-8'})
 
 
+@app.route('/dashboard')
+def dashboard():
+    """Route for dashboards index."""
+    if g.user:
+        get_user_info()
+    return render_template('dashboard/home.html')
+
+
 @app.route('/dashboard/triage')
 def dashboard_triage():
     """Route to handle dashboard triage."""


### PR DESCRIPTION
This PR fixes issue #2571

## Proposed PR background

As requested by @softvision-sergiulogigan this is a page which collects a list of different dashboard pages, now that we have a couple of them. This might need to be adjusted in the future. 

