### PR TITLE
Fixes #2689 - Update minimum node version to 10.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/webcompat/webcompat.com.git"
   },
   "engines": {
-    "node": ">= 4.x"
+    "node": ">= 10.13.0"
   },
   "dependencies": {
     "amd-to-commonjs-codemod": "^1.2.0",


### PR DESCRIPTION
Fixes #2689 - Update minimum node version to 10.13.0 because lint-staged requires `Node >= 8.6`

r? @miketaylr 