### PR TITLE
Issue #2698 - Go back to ^3.6.2 for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "husky": "^1.1.0",
     "intern": "^4.2.0",
     "leadfoot": "1.7.6",
-    "lint-staged": "^7.3.0",
+    "lint-staged": "^3.6.2",
     "load-grunt-tasks": "^4.0.0",
     "postcss": "^7.0.5",
     "postcss-browser-reporter": "^0.5.0",


### PR DESCRIPTION
That way committing will work without too much effort.

See #2698 for making it work on v8.

r? @karlcow 