### PR TITLE
Fixes #2698. Upgrade lint-staged to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "grunt-contrib-uglify": "^4.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-postcss": "^0.9.0",
-    "husky": "^1.1.0",
+    "husky": "^1.1.3",
     "intern": "^4.2.0",
     "leadfoot": "1.7.6",
-    "lint-staged": "^7.3.0",
+    "lint-staged": "^8.0.4",
     "load-grunt-tasks": "^4.0.0",
     "postcss": "^7.0.5",
     "postcss-browser-reporter": "^0.5.0",
@@ -65,11 +65,11 @@
     "build:svg:svg-sprite": "svg-sprite-generate -d ./webcompat/static/img/svg/tmp -o ./webcompat/static/img/svg/sprite.svg",
     "jst": "grunt jst",
     "lint": "npm run lint:js && npm run lint:css",
-    "lint:js": "eslint ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
-    "lint:css": "stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css'",
+    "lint:js": "npx eslint ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
+    "lint:css": "npx stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css'",
     "lint:fix": "npm run lint:fix:js && npm run lint:fix:css",
-    "lint:fix:js": "eslint --fix ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
-    "lint:fix:css": "stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css' --fix",
+    "lint:fix:js": "npx eslint --fix ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
+    "lint:fix:css": "npx stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css' --fix",
     "imagemin": "grunt imagemin",
     "prestart": "npm run build",
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
@@ -83,9 +83,20 @@
     "test:js": "node ./tests/functional/_intern.js",
     "test:python": "nosetests"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
-    "*.js": "lint:js",
-    "*.css": "lint:css"
+    "*.js": [
+      "npx eslint ./Gruntfile.js ./tests ./grunt-tasks ./webcompat/static/js/lib",
+      "git add"
+    ],
+    "*.css": [
+      "npx stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css'",
+      "git add"
+    ]
   },
   "license": "MPL-2.0"
 }


### PR DESCRIPTION
r? @magsout 

lint-staged can't reference npm scripts anymore, so it's a bit repetitive. 🤷‍♂️ 