### PR TITLE
Fixes #2738 - Adds a new mode to fetch fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "prestart": "npm run build",
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
     "start:test": "npm run build && source env/bin/activate || . env/bin/activate && python run.py -t",
+    "start:test:update-mock-outs": "npm run build && source env/bin/activate || . env/bin/activate && python run.py -tu",
     "virtualenv": "pip2 install virtualenv && virtualenv -p python2.7 env && source env/bin/activate || . env/bin/activate && npm run pip",
     "pip": "pip2 install -r config/requirements.txt",
     "config": "cp config/secrets.py.example config/secrets.py",

--- a/run.py
+++ b/run.py
@@ -102,6 +102,8 @@ if __name__ == '__main__':
                         help='Run server in "test mode".')
     parser.add_argument('-l', '--listen', default='localhost',
                         help='Interface to listen on.')
+    parser.add_argument('-u', '--updatemockouts', action='store_true',
+                        help='Update test\'s mock outs.')
     args = parser.parse_args()
 
     if check_pip_deps():
@@ -118,5 +120,9 @@ if __name__ == '__main__':
             app.config['SESSION_COOKIE_HTTPONLY'] = False
             app.config['SESSION_COOKIE_SAMESITE'] = None
             app.config['TESTING'] = True
+            app.config['UPDATE_MOCK_OUTS'] = False
             print("Starting server in ~*TEST MODE*~")
+            if args.updatemockouts:
+                app.config['UPDATE_MOCK_OUTS'] = True
+                print('Remember: you have to access each one of the issues you want to fetch.')
             app.run(host=args.listen)


### PR DESCRIPTION
To begin the mode that will download the new mock outs simply type:

`start:test:update-mock-outs` 

on your terminal. This mode will both fetch the new fixture files and enter into test mode.

r? @karlcow 