### PR TITLE
Fixes #2748. Pull GA params from POST data and send them inline

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -508,7 +508,7 @@ def add_csp(response):
         "font-src 'self' https://fonts.gstatic.com; " +
         get_img_src_policy() +
         "manifest-src 'self'; " +
-        "script-src 'self' https://www.google-analytics.com https://api.github.com 'nonce-{nonce}';".format(nonce=request.nonce) +  # nopep8
+        "script-src 'self' https://www.google-analytics.com https://api.github.com 'nonce-{nonce}'; ".format(nonce=request.nonce) +  # nopep8
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "base-uri 'self'; " +
         "frame-ancestors 'self'; " +

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -508,7 +508,7 @@ def add_csp(response):
         "font-src 'self' https://fonts.gstatic.com; " +
         get_img_src_policy() +
         "manifest-src 'self'; " +
-        "script-src 'self' https://www.google-analytics.com https://api.github.com; " +  # nopep8
+        "script-src 'self' https://www.google-analytics.com https://api.github.com 'nonce-{nonce}';".format(nonce=request.nonce) +  # nopep8
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "base-uri 'self'; " +
         "frame-ancestors 'self'; " +

--- a/webcompat/templates/new-issue.html
+++ b/webcompat/templates/new-issue.html
@@ -8,3 +8,13 @@
   </section>
 </main>
 {% endblock %}
+{%- block extrascripts -%}
+{% if source and campaign %}
+<script nonce={{nonce}}>
+if (typeof ga == "function") {
+  ga('set', 'campaignName', '{{campaign}}');
+  ga('set', 'campaignSource', '{{source}}');
+}
+</script>
+{% endif %}
+{%- endblock %}

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -196,6 +196,7 @@ def create_issue():
         * full description
         * tested in another browser
         * body
+        * utm_ params for Google Analytics
     * HTTP POST with an attached form
       * submit a form to GitHub to create a new issue
       * form submit type:
@@ -222,7 +223,10 @@ def create_issue():
             return render_template('thanks.html')
         bug_form = get_form(form_data)
         session['extra_labels'] = form_data['extra_labels']
-        return render_template('new-issue.html', form=bug_form)
+        source = form_data.pop('utm_source', None)
+        campaign = form_data.pop('utm_campaign', None)
+        return render_template('new-issue.html', form=bug_form, source=source,
+                               campaign=campaign, nonce=request.nonce)
     # Issue Creation section
     elif request_type == 'create':
         # Check if there is a form

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -4,9 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Module for the main routes of webcompat.com."""
+from hashlib import sha1
 import logging
 import os
 import urlparse
+from uuid import uuid4
 
 from flask import abort
 from flask import flash
@@ -55,6 +57,7 @@ def before_request():
         g.user = User.query.get(session['user_id'])
     g.referer = get_referer(request) or url_for('index')
     g.request_headers = request.headers
+    request.nonce = sha1(uuid4().hex).hexdigest()
 
 
 @app.after_request


### PR DESCRIPTION
This PR gives us the ability to use CSP nonce attributes in inline JS, and parses out the GA params from https://bugzilla.mozilla.org/show_bug.cgi?id=1514861.

Thinking about how on earth to test this...