### PR TITLE
Fixes #2747 - Updates Staging to use http2

### DIFF
--- a/docs/prod-server.md
+++ b/docs/prod-server.md
@@ -117,3 +117,35 @@ logto = $FOO/staging-uwsgi.log
 buffer-size = 8192
 
 ```
+
+## Staging Server Setup
+
+```nginx
+##
+# Gzip Settings
+##
+
+gzip on;
+gzip_disable "msie6";
+
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_buffers 16 8k;
+gzip_http_version 1.0;
+
+# Turn on gzip for all content types that should benefit from it.
+gzip_types application/ecmascript;
+gzip_types application/javascript;
+gzip_types application/json;
+gzip_types application/pdf;
+gzip_types application/postscript;
+gzip_types application/x-javascript;
+gzip_types image/svg+xml;
+gzip_types text/css;
+gzip_types text/csv;
+# "gzip_types text/html" is assumed.
+gzip_types text/javascript;
+gzip_types text/plain;
+gzip_types text/xml;
+```

--- a/docs/prod-server.md
+++ b/docs/prod-server.md
@@ -120,6 +120,56 @@ buffer-size = 8192
 
 ## Staging Server Setup
 
+nginx configuration file:
+
+```nginx
+# staging.webcompat.com
+#
+server {
+        server_name staging.webcompat.com;
+        root /home/webcompat/staging.webcompat.com;
+        error_log /home/webcompat/logs/staging-nginx-error.log;
+        client_max_body_size 4M;
+
+        listen [::]:443 ssl ipv6only=on http2; # managed by Certbot
+        listen 443 ssl http2; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/staging.webcompat.com/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/staging.webcompat.com/privkey.pem; # managed by Certbot
+        include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+        ssl_session_cache shared:SSL:50m;
+
+        keepalive_timeout 70;
+
+        location ^~ /uploads/ {
+                root /srv/uploads/staging.webcompat.com/;
+                try_files $uri /dev/null =404;
+        }
+
+        location / {
+                try_files /home/webcompat/staging.webcompat.com/webcompat/static/$uri @staging;
+                expires 1M;
+                add_header Cache-Control "public";
+        }
+
+
+        location @staging {
+                uwsgi_pass unix:///tmp/uwsgi-staging.sock;
+                uwsgi_buffer_size 512k;
+                uwsgi_buffers 8 512k;
+                include uwsgi_params;
+        }
+
+        location ~ /.well-known {
+                allow all;
+        }
+}
+
+```
+
+That have the following handlers:
+
 ```nginx
 ##
 # Gzip Settings


### PR DESCRIPTION
This configuration is working. The only thing it does is making the files available to be fetched as http2.

I've already updated to the Staging server.
But we still need to update Production.