### PR TITLE
Fixes #2726 - Handle pagination when fetching labels from GitHub

### DIFF
--- a/tests/unit/test_tools_labels.py
+++ b/tests/unit/test_tools_labels.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Tests for the label functions."""
+
+import unittest
+
+from tools.labels import get_issue_labels
+from tools.labels import USER_LABELS_URI
+
+LABELS_URI = USER_LABELS_URI
+
+
+class TestLabels(unittest.TestCase):
+    """Test for label operations."""
+
+    def setUp(self):
+        """Set up the tests."""
+        pass
+
+    def tearDown(self):
+        """Tear down the tests."""
+        pass
+
+    def test_get_issue_labels(self):
+        """Fetch all labels from GitHub."""
+        actual = get_issue_labels(LABELS_URI)
+        self.assertEqual(len(actual), 32)
+
+    def test_create_label(self):
+        """Create a label in the user repo."""
+        pass
+
+    def test_delete_label(self):
+        """Delete a label in the user repo."""
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_tools_labels.py
+++ b/tests/unit/test_tools_labels.py
@@ -11,8 +11,6 @@ import unittest
 from tools.labels import get_issue_labels
 from tools.labels import USER_LABELS_URI
 
-LABELS_URI = USER_LABELS_URI
-
 
 class TestLabels(unittest.TestCase):
     """Test for label operations."""
@@ -27,7 +25,7 @@ class TestLabels(unittest.TestCase):
 
     def test_get_issue_labels(self):
         """Fetch all labels from GitHub."""
-        actual = get_issue_labels(LABELS_URI)
+        actual = get_issue_labels(USER_LABELS_URI)
         self.assertEqual(len(actual), 32)
 
     def test_create_label(self):

--- a/tools/labels.py
+++ b/tools/labels.py
@@ -11,7 +11,7 @@ from webcompat import app
 
 API_URI = 'https://api.github.com/repos/'
 ISSUES_URI = app.config['ISSUES_REPO_URI'].rpartition('/issues')[0]
-USER_LABELS_URI = API_URI + ISSUES_URI + "/labels"
+USER_LABELS_URI = API_URI + ISSUES_URI + '/labels'
 WEBCOMPAT_LABELS_URI = API_URI + 'webcompat/webcompat-tests/labels'
 AUTH_HEADERS = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN']),
                 'User-Agent': 'webcompat/webcompat-bot'}
@@ -19,9 +19,22 @@ AUTH_HEADERS = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN']),
 
 def get_issue_labels(labels_uri):
     '''Get the issue labels from the given repo.'''
-    response = requests.get(labels_uri)
+    payload = {'page': '1', 'per_page': '100'}
+    response = requests.get(labels_uri, params=payload)
     if not response.status_code == 200:
         response.raise_for_status()
+    if bool(response.links):
+        print('Links has stuff in it...')
+        content = response.content
+        print(content)
+        labels_pagecount = int(response.links['last']['url'][-1:])
+        print('labels_pagecount= ' + str(labels_pagecount))
+        for page in range(2, labels_pagecount + 1):
+            print('looping pages... Page ' + str(page))
+            payload['page'] = page
+            r = requests.get(labels_uri, params=payload)
+            content += r.content
+            print(content)
     return response.json()
 
 

--- a/webcompat/static/js/lib/editor.js
+++ b/webcompat/static/js/lib/editor.js
@@ -4,12 +4,12 @@
 var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 /* Child classes need to define the following methods/properties:
-    * closeEditor
-    * openEditor
-    * fetchItems (to get data from model)
-    * template
-    * subTemplate
-*/
+ * closeEditor
+ * openEditor
+ * fetchItems (to get data from model)
+ * template
+ * subTemplate
+ */
 issues.CategoryView = Backbone.View.extend({
   _isLoggedIn: $("body").data("username"),
   editorButton: null,
@@ -26,10 +26,10 @@ issues.CategoryView = Backbone.View.extend({
 });
 
 /* Child classes need to define the following methods/properties, or this will explode:
-    * closeEditor
-    * template
-    * updateView
-*/
+ * closeEditor
+ * template
+ * updateView
+ */
 issues.CategoryEditorView = Backbone.View.extend({
   isOpen: false,
   className: "label-editor js-CategoryEditor",


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue #2726 

## Proposed PR background

Since we are not currently fetching all the existing labels with our GitHub repo call when constructing the label editor on an issue page, filtering behavior and selection is wonky. I added a pagination function to `get_issue_labels` and a test to make sure it works correctly. (I included stubs to expand into eventual testing of the other label functions as well.)

---

- [✅] I have read the [Pull Request + Code Style Guidelines](https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md) thoroughly.
