### PR TITLE
Fixes #2793 - Comments are sent as markdown to Github

### DIFF
--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -530,6 +530,7 @@ issues.MainView = Backbone.View.extend(
           commentLinkId: null
         });
         this.addComment(newComment);
+        newComment.attributes.body = textarea.val();
         // Now empty out the textarea.
         textarea.val("");
         // Push to GitHub


### PR DESCRIPTION
Locally they're rendered correctly in the website in the moment that they're posted:
<img width="718" alt="screen shot 2019-02-13 at 16 35 17" src="https://user-images.githubusercontent.com/17600982/52735240-4af69600-2fae-11e9-99e6-8a3a5199d238.png">

Checking the code that is sent to Github:
<img width="780" alt="screen shot 2019-02-13 at 16 35 04" src="https://user-images.githubusercontent.com/17600982/52735243-4d58f000-2fae-11e9-8a86-c72d2b81b2de.png">
it's markdown!

r? @karlcow 