### PR TITLE
Fixes #2819 - Add browser-fenix to EXTRA_LABELS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -183,6 +183,7 @@ for cat_label in cat_labels:
 # labels that we allow to be added via a `label` GET param, when
 # creating an issue.
 EXTRA_LABELS = [
+    'browser-fenix',
     'browser-focus-geckoview',
     'browser-firefox-reality',
     'type-google',


### PR DESCRIPTION
Right now Fenix issues are being flagged as regular Firefox for Android issues, and it turns out they're already sending this extra param. So let's use it.

r? @karlcow 