### PR TITLE
Fixes #2750 - Improves text rendering

### DIFF
--- a/webcompat/static/css/webcompat.dev.css
+++ b/webcompat/static/css/webcompat.dev.css
@@ -98,3 +98,31 @@
   max-height: 75vh;
   max-width: 100%;
 }
+
+@font-face {
+  font-display: optional;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 300;
+  src: local("Source Sans Pro Light"), local("SourceSansPro-Light"), url("https://fonts.gstatic.com/s/sourcesanspro/v11/6xKydSBYKcSV-LCoeQqfX1RYOo3ik4zwlxdu3cOWxw.woff2") format("woff2");
+}
+
+@font-face {
+  font-display: optional;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 400;
+  src: local("Source Sans Pro Regular"), local("SourceSansPro-Regular"), url("https://fonts.gstatic.com/s/sourcesanspro/v11/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7lujVj9w.woff2") format("woff2");
+}
+
+@font-face {
+  font-display: optional;
+  font-family: "Open Sans", sans-serif;
+  font-weight: 400;
+  src: local("Open Sans"), url("https://fonts.gstatic.com/s/opensans/v15/mem8YaGs126MiZpBA-UFWJ0bf8pkAp6a.woff2") format("woff2");
+}
+
+@font-face {
+  font-display: optional;
+  font-family: "Open Sans", sans-serif;
+  font-weight: 600;
+  src: local("Open Sans"), url("https://fonts.gstatic.com/s/opensans/v15/mem5YaGs126MiZpBA-UNirkOXOhpKKSTj5PW.woff2") format("woff2");
+}

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -8,7 +8,7 @@
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-32x32.png') }}" sizes="32x32">
 
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Sans+Pro:300,400|PT+Mono" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Sans+Pro:300,400" rel="stylesheet">
   <link href="{{ url_for('static', filename='css/dist/webcompat.min.css') }}" type="text/css" rel="stylesheet">
 </head>
 <body id="body-webcompat" data-username="{{ session.username }}">
@@ -45,4 +45,5 @@
 {% endfor %}
 {% block extrascripts %}{% endblock %}
 </body>
+</html>
 </html>

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -46,4 +46,3 @@
 {% block extrascripts %}{% endblock %}
 </body>
 </html>
-</html>


### PR DESCRIPTION
This PR follows the previous discussion we had here: https://github.com/webcompat/webcompat.com/pull/2808
I decided to create a new version so we still keep a log from the discussion we had about trying to use the `fontfaceobserver`.

There are two changes in this PR.
1. I removed the PT+Mono webfont because Mike and I agreed it wasn't worth it to make a request for that font. @karlcow what do you think?
2. Added some configuration to our fonts using `@font-face`. The reason why I added it can be found in this https://github.com/webcompat/webcompat.com/issues/2750#issuecomment-464926948 but summarizing I think the `font-display: optional` option can have a huge impact for users in slow internet connections showing text for them much earlier + this is super easy to implement.

@miketaylr these are the changes I proposed here https://github.com/webcompat/webcompat.com/pull/2808#issuecomment-473409855.