### PR TITLE
Fixes #2762 - Removes the autolinking on adding contact

### DIFF
--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -380,7 +380,8 @@ def build_formdata(form_object):
     contact = contact.strip()
     contact = contact.replace('@', '')
     if contact:
-        body += u'\n\nReported by @{contact}'.format(contact=contact)
+        body += u'\n\nSubmitted in the name of `@{contact}`'.format(
+            contact=contact)
     # Append "from webcompat.com" message to bottom (for GitHub issue viewers)
     body += u'\n\n{0}'.format(GITHUB_HELP)
     rv = {'title': summary, 'body': body}


### PR DESCRIPTION
This PR fixes issue #2762 and #2791

## Proposed PR background

The intent here is to avoid the auto-notification for people having their names added into the issue being reported.
It also slighly modifies the text to make it clear that it's not necessary reported by this person. 