### PR TITLE
Fixes #1838 - Separates the python dependencies into prod and dev

### DIFF
--- a/config/requirements-dev.txt
+++ b/config/requirements-dev.txt
@@ -1,0 +1,5 @@
+# This is for dev purpose
+-r requirements.txt
+mock==2.0.0
+nose==1.3.7
+pycodestyle==2.5.0

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -5,9 +5,6 @@ Flask-Limiter==1.0.1
 Flask-SQLAlchemy==2.3.2
 Flask-WTF==0.14.2
 GitHub-Flask==3.2.0
-mock==2.0.0
-nose==1.3.7
-pep8==1.7.1
 Pillow==5.4.1
 requests==2.21.0
 ua-parser==0.8

--- a/docs/dev-env-setup.md
+++ b/docs/dev-env-setup.md
@@ -137,8 +137,8 @@ source env/bin/activate
 #  Windows: http://pillow.readthedocs.org/en/3.0.x/installation.html#windows-installation
 #  Linux: http://pillow.readthedocs.org/en/3.0.x/installation.html#linux-installation
 # install rest of dependencies
-pip2 install -r config/requirements.txt
-# In Ubuntu: if ImportError: No module named flask.ext.github occurs, it means the dependencies in requirements.txt are installed in /usr/lib instead of <project_repository>/env/python<version>/site-packages.
+pip2 install -r config/requirements-dev.txt
+# In Ubuntu: if ImportError: No module named flask.ext.github occurs, it means the dependencies in requirements-dev.txt are installed in /usr/lib instead of <project_repository>/env/python<version>/site-packages.
 # In this case, use virtual environment's pip from <project_repository>/env/lib/pip folder of the project repository instead of the global pip.
 ```
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "start": "source env/bin/activate || . env/bin/activate && python run.py",
     "start:test": "npm run build && source env/bin/activate || . env/bin/activate && python run.py -t",
     "virtualenv": "pip2 install virtualenv && virtualenv -p python2.7 env && source env/bin/activate || . env/bin/activate && npm run pip",
-    "pip": "pip2 install -r config/requirements.txt",
+    "pip": "pip2 install -r config/requirements-dev.txt",
     "config": "cp config/secrets.py.example config/secrets.py",
     "project-update": "pip2 install --upgrade pip && npm update",
     "precommit": "lint-staged",

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ IMPORT_ERROR = '''
 ==============================================
 It seems like you don't have all dependencies.
 Please re-run:
-    pip install -r config/requirements.txt
+    pip install -r config/requirements-dev.txt
 ==============================================
 '''
 


### PR DESCRIPTION

This PR fixes issue #1838

## Proposed PR background

This is the first step of properly separating the production and the development environment. Once this is done, we can think of ways to modify the fabfile so it deploys only the prod environment. 

r? @miketaylr 