### PR TITLE
Fixes #2728 - Ignores browser label when extra labels already provides it

### DIFF
--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -70,6 +70,19 @@ class TestWebhook(unittest.TestCase):
         <!-- @browser: Firefox Mobile (Tablet) 40.0 -->
         """
 
+        self.issue_body5 = """
+        <!-- @browser: Android 8.1.0 -->
+        <!-- @ua_header: Mozilla/5.0 (Android 8.1.0; Mobile VR; rv:65.0) Gecko/65.0 Firefox/65.0 -->
+        <!-- @reported_with: browser-fxr -->
+        <!-- @extra_labels: browser-firefox-reality, type-media -->
+
+        **URL**: https://vrporn.com/closing-shift-shaft/
+
+        **Browser / Version**: Android 8.1.0
+        **Operating System**: Android 8.1.0
+        **Tested Another Browser**: Yes
+        """  # noqa
+
     def tearDown(self):
         """Tear down tests."""
         pass
@@ -198,7 +211,8 @@ class TestWebhook(unittest.TestCase):
         labels_tests = [
             (self.issue_body, ['browser-firefox', 'type-media', 'type-stylo']),
             (self.issue_body2, ['browser-fixme', 'type-foobar']),
-            (self.issue_body3, ['browser-firefox-tablet'])
+            (self.issue_body3, ['browser-firefox-tablet']),
+            (self.issue_body5, ['browser-firefox-reality', 'type-media']),
         ]
         for issue_body, expected in labels_tests:
             actual = helpers.get_issue_labels(issue_body)

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -154,14 +154,17 @@ def get_issue_info(payload):
 
 def get_issue_labels(issue_body):
     """Extract the list of labels from an issue body to be sent to GitHub."""
-    metadata_dict = extract_metadata(issue_body)
-    browser_label = extract_browser_label(metadata_dict)
-    extra_labels = extract_extra_labels(metadata_dict)
-    priority_label = extract_priority_label(issue_body)
     labelslist = []
-    labelslist.extend([browser_label, priority_label])
+    metadata_dict = extract_metadata(issue_body)
+    extra_labels = extract_extra_labels(metadata_dict)
+    browser_label = extract_browser_label(metadata_dict)
     if extra_labels:
+        # if extra_labels contains a browser tag, we do not need to extract it
+        if any(label.startswith('browser') for label in extra_labels):
+            browser_label = None
         labelslist.extend(extra_labels)
+    priority_label = extract_priority_label(issue_body)
+    labelslist.extend([browser_label, priority_label])
     labelslist = [label for label in labelslist if label is not None]
     return labelslist
 


### PR DESCRIPTION
<!--IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
This PR fixes issue #2728

## Proposed PR background

Basically it was identified that when a specific client was sending one authorized extra-labels, the system would report twice the browser-* label. Coming from extra-labels and from the browser identification itself.

hence we decided to ignore the browser label when it existed already in extra labels.
r? @miketaylr 