### PR TITLE
Fixes #2944, #2947 - Read experiment variation values from envvars

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,10 +1,23 @@
 # AB testing
 ## Configuration
-You can enable/disable AB testing support by configuring the `config.AB_EXPERIMENT` dictionary.
-This will configure flask to set cookies to responses. For example:
+You can enable/disable AB testing support by configuring the following environment variables:
+
+`FORM_V1_VARIATION`: expects a string of the format '{int} {int}'
+`FORM_V2_VARIATION`: expects a string of the format '{int} {int}'
+`EXP_MAX_AGE`: expects a number which defines when the experiment cookie expires
+
+These are read by the `config.AB_EXPERIMENT` dictionary in `./config/__init__.py` and converted to a tuple.
+This will configure flask to set cookies to responses. For example, setting the variables to the following:
 
 ```
+export FORM_V1_VARIATION = "0 20"
+export FORM_V2_VARIATION = "20 100"
+export EXP_MAX_AGE = 604800
+```
 
+This will result in the `AB_EXPERIMENTS` dictionary with the following values:
+
+```
 AB_EXPERIMENTS = {
     'exp-1': {
         'variations': {

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,6 +11,7 @@ import os
 import unittest
 
 from config import update_status_config
+from config import get_variation
 from webcompat import webcompat
 
 
@@ -52,6 +53,20 @@ class TestConfig(unittest.TestCase):
         milestones_json = json_data('milestones_content_plus.json')
         actual = update_status_config(milestones_json)
         self.assertEqual(actual, expected)
+
+    def test_get_variation(self):
+        """
+        Check the conversion from string to tuples of two int.
+        """
+        defs = {'a': (1, 2)}
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': '1 2'}, defs))
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': None}, defs))
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': ''}, defs))
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': 2}, defs))
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': '1 2 3'}, defs))
+        self.assertTupleEqual((1, 2), get_variation('a', {'a': '1 '}, defs))
+        self.assertTupleEqual((1, 2),
+                              get_variation('a', {'a': '  1 2 '}, defs))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This feels maybe slightly hacky -- we can't safely store a tuple in an environment variable, so it build one up from something like `0 20`. Open to other ideas.

And add tests.

r? @johngian @karlcow 