### PR TITLE
Fixes #2940 - Add a label to v2 form issues

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -189,6 +189,7 @@ EXTRA_LABELS = [
     'browser-fenix',
     'browser-focus-geckoview',
     'browser-firefox-reality',
+    'form-v2-experiment',
     'type-fastclick',
     'type-google',
     'type-marfeel',

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -263,6 +263,8 @@ def create_issue():
 
         if ab_active('exp') == 'form-v2':
             bug_form = get_form(form_data, form=FormWizard)
+            # TODO: remove this when the experiment has ended
+            form_data['extra_labels'].append('form-v2-experiment')
         else:
             bug_form = get_form(form_data)
 


### PR DESCRIPTION
It's hard-coded, but shortlived. We can also use `label` param if we want to, but this way seems easiest. 

r? @karlcow 

https://github.com/webcompat/webcompat-tests/issues/1953 is a sample issue (filed from chrome!!111), which has the label added, as well as the `<!-- @extra_labels: form-v2-experiment -->` comment. 