### PR TITLE
Issue #2958 - Fix `ab_active` to populate cookies on first request

### DIFF
--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -670,7 +670,7 @@ def ab_active(exp_id):
     if ab_exempt():
         return False
 
-    return request.cookies.get(exp_id) or False
+    return g.current_experiments.get(exp_id) or False
 
 
 def ab_exempt():
@@ -693,7 +693,7 @@ def ab_current_experiments():
 
     for exp_id in app.config['AB_EXPERIMENTS']:
 
-        active_var = ab_active(exp_id)
+        active_var = request.cookies.get(exp_id) or False
 
         if active_var:
             curr_exp[exp_id] = active_var
@@ -717,7 +717,7 @@ def ab_init(response):
         return response
 
     for exp_id, var in g.current_experiments.items():
-        if not ab_active(exp_id):
+        if not request.cookies.get(exp_id) or False:
             max_age = app.config['AB_EXPERIMENTS'][exp_id]['max-age']
             response.set_cookie(exp_id, var, max_age=max_age)
 


### PR DESCRIPTION


<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #2958 

## Proposed PR background

There was an issue on the way that we check if an experiment is active. `ab_active` helper instead of checking the ``g.current_experiments`` dict that we populate before each request, was checking the actual cookies. That means that on the first request `ab_active` was failing to give the proper result because cookies where not populated.

Changes introduced in the commit:

* Fix `ab_active` behaviour
* Change tests to work for the new behaviour
* Minor cleanup/docstring changes on tests

I tested in 2 temp firefox containers and it looks like experiment cookies are loaded on first request.
