### PR TITLE
Fixes #2955 - Move the no-top-padding class to the codebase of the ex…

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -18,10 +18,6 @@
   --presumed-step-height-updown: -230px;
 }
 
-#body-webcompat.no-top-padding {
-  padding-top: 0;
-}
-
 #js-ReportForm {
   overflow: hidden;
   padding: 40px 10px 0;
@@ -49,15 +45,17 @@
 
 .issue-form {
   background: transparent;
+  margin-top: 35px;
 }
 
 #wizard-container {
   background-color: var(--base-colorDark);
   display: flex;
   justify-content: space-evenly;
+  margin-top: -35px;
   padding: 1rem 0;
-  position: sticky;
-  top: 39px;
+  position: fixed;
+  top: 75px;
   transform: none;
   transition: top 400ms ease;
   width: 100%;
@@ -65,7 +63,7 @@
 }
 
 #wizard-container.is-offscreen {
-  top: 0;
+  top: 35px;
 }
 
 #wizard-container .grid {

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -13,9 +13,7 @@
   {% block extracss %}{% endblock %}
 
 </head>
-<body id="body-webcompat"
-  class="{%- if request.url_rule.endpoint == 'create_issue' and ab_active('exp') == 'form-v2' %}no-top-padding{% endif %}"
-  data-username="{{ session.username }}">
+<body id="body-webcompat" data-username="{{ session.username }}">
 {% include "shared/svg-icons.html" %}
 {% block body %}{% endblock %}
 {% include "shared/footer.html" %}


### PR DESCRIPTION
This PR fixes issue #2955 and @johngian feedback here: [#2942 (comment)](https://github.com/webcompat/webcompat.com/pull/2942#discussion_r332177495)
The issue consisted of moving the 'no-top-padding' class to the codebase of the experiment.

To solve this issue, I removed the `no-top-padding` class from the shared HTML template and adjusted the styles contained in the experiment to achieve the same UI result.