### PR TITLE
Fixes #2975 -  "Briefly describe the issue" fix & validation

### DIFF
--- a/webcompat/static/js/lib/bugform-validation.js
+++ b/webcompat/static/js/lib/bugform-validation.js
@@ -24,6 +24,10 @@ function Validation() {
       var val = descField.val();
       return $.trim(val) !== "";
     },
+    isIssueValid: function(issueField) {
+      var val = issueField.val();
+      return $.trim(val) !== "";
+    },
     isUrlValid: function(urlField) {
       var val = urlField.val();
       return $.trim(val) !== "" && isReportableURL(val);

--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -568,7 +568,7 @@ BugForm.prototype.checkBrowserInputValidity = function(silent) {
 /* Check to see that the issue description input is not empty. */
 BugForm.prototype.checkProblemSubtypeValidity = function(silent) {
   var func = this.determineValidityFunction(
-    this.validation.isProblemSubtypeValid,
+    this.validation.isIssueValid,
     this.problemSubtype,
     silent
   );


### PR DESCRIPTION
This PR fixes issue #2975

## Proposed PR background

I added validation for the field. When this field is empty, the "Continue" button is disabled. When you enter something, the field is validated, the check symbol appears and the button is activated to proceed to the next step.