### PR TITLE
Fixes #2976 - Prevent user from leaving blank Browser and Device fields

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -394,11 +394,25 @@
   text-align: left;
 }
 
-.form-message-error {
+.form-message-error,
+.device-browser-error {
   color: var(--wizard-step-error);
   font-size: 16px;
   font-weight: 200;
   text-align: left;
+}
+
+.device-browser-error {
+  display: none;
+  font-size: 15px;
+}
+
+.is-error .device-browser-error {
+  display: block;
+}
+
+.step5 .with-validation-icons {
+  align-self: flex-start;
 }
 
 .input-control a {
@@ -954,6 +968,10 @@
   #js-ReportForm .form-label {
     margin-bottom: 5px;
     width: auto;
+  }
+
+  #js-ReportForm .is-error .form-label {
+    margin-bottom: 0;
   }
 
   .custom-browser .form-element:nth-child(odd) {

--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -42,7 +42,9 @@ BugForm.prototype.onDOMReadyInit = function() {
   this.step2Trigger = $(".next-step.step-2");
   this.step3Trigger = $("#problem_category input");
   this.step3Btn = $(".next-step.step-3");
+  this.step4Btn = $(".next-step.step-4");
   this.step4Trigger = $(".subproblem input[type='radio']");
+  this.step5Btn = $(".next-step.issue-btn.step-5");
   this.step6Btn = $("button.next-step.step-6");
   this.step8Btn = $("button.next-step.step-8");
   this.step10Btn = $("button.next-step.step-10");
@@ -66,6 +68,7 @@ BugForm.prototype.onDOMReadyInit = function() {
   this.problemStep = 2;
   this.subproblemStep = 3;
   this.browserDetectionStep = 4;
+  this.customBrowserStep = 5;
   this.browserSelectionStepNo = 7;
   this.descriptionStep = 8;
   this.stepNotDefined = -1;
@@ -184,13 +187,13 @@ BugForm.prototype.onDOMReadyInit = function() {
       el: $("#browser"),
       valid: true,
       helpText: null,
-      errFunction: "optionalField"
+      errFunction: "requiredField"
     },
     os: {
       el: $("#os"),
       valid: true,
       helpText: null,
-      errFunction: "optionalField"
+      errFunction: "requiredField"
     },
     browser_test_type: {
       el: $("[name=browser_test]"),
@@ -207,7 +210,9 @@ BugForm.prototype.onDOMReadyInit = function() {
   };
 
   this.browserField = this.inputs.browser.el;
+  this.browserVal = this.inputs.browser.el.val();
   this.osField = this.inputs.os.el;
+  this.osVal = this.inputs.os.el.val();
   this.problemType = this.inputs.problem_category.el;
   this.problemSubtype = this.inputs.other_problem.el;
   this.otherBrowser = this.inputs.browser_test_type.el;
@@ -273,6 +278,7 @@ BugForm.prototype.init = function() {
   this.nextStepBtn.on("click", this.nextStep.bind(this));
   this.step3Trigger.on("change", this.nextStep.bind(this));
   this.step3Radio.on("change", this.nextStep.bind(this));
+  this.step4Btn.on("click", this.resetDefaultDevice.bind(this));
   this.step6Radio.on("change", this.nextStep.bind(this));
   this.anonUsernameTrigger.on("click", this.revealUsernameField.bind(this));
 
@@ -584,6 +590,7 @@ BugForm.prototype.checkOptionalNonEmpty = function(field) {
   );
   var inputId = field.prop("id");
   this[func](inputId);
+  this.setNextBtnStatus(this.customBrowserStep);
 };
 
 /* Check to see if the GitHub username has the right syntax.*/
@@ -739,6 +746,15 @@ BugForm.prototype.setNextBtnStatus = function(step) {
         this.step3Btn.removeClass("disabled");
       } else {
         this.step3Btn.addClass("disabled");
+      }
+      break;
+    case this.customBrowserStep:
+      var customBrowserVal = $.trim(this.inputs["browser"].el[0].value);
+      var osVal = $.trim(this.inputs["os"].el[0].value);
+      if (customBrowserVal.length > 0 && osVal.length > 0) {
+        this.step5Btn.removeClass("disabled");
+      } else {
+        this.step5Btn.addClass("disabled");
       }
       break;
     case this.browserSelectionStepNo:
@@ -1251,6 +1267,13 @@ BugForm.prototype.revealUsernameField = function(e) {
 
 BugForm.prototype.resetProblemType = function() {
   this.resetRadio(this.step3Trigger);
+};
+
+BugForm.prototype.resetDefaultDevice = function() {
+  this.browserField.val(this.browserVal);
+  this.browserField.trigger("blur");
+  this.osField.val(this.osVal);
+  this.osField.trigger("blur");
 };
 
 BugForm.prototype.resetBrowserSelection = function() {

--- a/webcompat/templates/home-page/issue-wizard-form.html
+++ b/webcompat/templates/home-page/issue-wizard-form.html
@@ -165,10 +165,12 @@
           <div class="row mobile-col">
             <div class="form-element js-Form-group low with-validation-icons half">
               {{ form.browser.label(class_='form-label') }}
+              <small class="device-browser-error">Browser required</small>
               {{ form.browser(class_='form-field text-field') }}
             </div>
             <div class="form-element js-Form-group low with-validation-icons half">
               {{ form.device.label(class_='form-label') }}
+              <small class="device-browser-error">Device required</small>
               {{ form.os(class_='form-field text-field') }}
             </div>
           </div>


### PR DESCRIPTION
This PR fixes issue #2976

## Proposed PR background

The Browser and Device fields are required now, and the user cannot continue unless the fields are filled in.

If for some reason the user decides to delete the data from these fields, then changes his/her mind and hits "Yes" (as an answer to the question above), the user will proceed to the next step confirming the data.

At the same time, the data from these 2 input fields gets reset to the initial values in case the user changes his mind again, and wants to proceed with the information from the Browser and Device fields.