### PR TITLE
Fixes #2974 - Browser selection to say Yes/No as on current bug form

### DIFF
--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -53,7 +53,7 @@ BugForm.prototype.onDOMReadyInit = function() {
   this.step4Container = $(".step-container.step4");
   this.step5Container = $(".step-container.step5");
   this.step6Container = $(".step-container.step6");
-  this.step6Radio = $(".step-container.step6 input");
+  this.step6Radio = $(".step-container.step6 .input-control input");
   this.step7Container = $(".step-container.step7");
   this.step8Container = $(".step-container.step8");
   this.step9Container = $(".step-container.step9");
@@ -76,6 +76,8 @@ BugForm.prototype.onDOMReadyInit = function() {
   this.detectionBugId = "detection_bug";
   this.otherProblemElements = $(".other-problem");
   this.otherBrowserElements = $(".other-browser");
+  this.testedOtherBrowsersId = "#browser_test-0";
+  this.noOtherBrowserTestedId = "#browser_test-1";
   this.uploadTextElements = $(".up-message");
   this.isSubproblem = false;
   this.blockNext = false;
@@ -742,22 +744,14 @@ BugForm.prototype.setNextBtnStatus = function(step) {
       }
       break;
     case this.browserSelectionStepNo:
-      var browserVal = $.trim(this.otherBrowser.val());
-      var radioVal =
-        $(this.browserSelection)
-          .filter(":checked")
-          .val() || false;
-      if (
-        (radioVal && radioVal !== this.otherBrowserId) ||
-        (radioVal === this.otherBrowserId &&
-          this.checkSpecificRequiredValid("browser_test_type") &&
-          browserVal.length > 0)
-      ) {
+      var otherBrowser = this.otherBrowserElements
+        .find(this.testedOtherBrowsersId)
+        .prop("checked");
+
+      if (otherBrowser) {
         this.step6Btn.removeClass("disabled");
-        this.makeValid("browser_test_type");
       } else {
         this.step6Btn.addClass("disabled");
-        this.inputs["browser_test_type"].valid = false;
       }
       break;
   }
@@ -807,7 +801,10 @@ BugForm.prototype.nextStep = function(e) {
       trigger.attr("type") === "radio" &&
       trigger.attr("name") === this.browserSelectionName
     ) {
-      this.browserSelectionStep(trigger);
+      this.otherBrowserElements
+        .find(this.testedOtherBrowsersId)
+        .prop("checked", true);
+      this.setNextBtnStatus(this.browserSelectionStepNo);
       this.hideStep(this.browserSelectionStepNo);
       return;
     }
@@ -1008,30 +1005,6 @@ BugForm.prototype.toggleOtherProblem = function(action) {
       $(this)[0].style.animationName = obj.cssAnimations.slidedownandheight;
     });
   }
-};
-
-BugForm.prototype.browserSelectionStep = function(trigger) {
-  var isOther = trigger.val() === this.otherBrowserId;
-  if (isOther) {
-    $(
-      ".step" + this.browserSelectionStepNo
-    )[0].style.animationName = this.cssAnimations.slideup;
-    this.otherBrowser.val("");
-    this.makeInvalidSilent("browser_test_type");
-    // Skip next step and show input with button in the same container
-    this.toggleOtherBrowser("show");
-  } else {
-    this.toggleOtherBrowser("hide");
-    // If the user selects a browser, it gets inserted in the text input
-    this.otherBrowser.val(
-      trigger
-        .next("label")
-        .text()
-        .trim()
-    );
-  }
-  var step = 7;
-  this.setNextBtnStatus(step);
 };
 
 BugForm.prototype.toggleOtherBrowser = function(action) {
@@ -1254,9 +1227,9 @@ BugForm.prototype.resetProblemType = function() {
 };
 
 BugForm.prototype.resetBrowserSelection = function() {
-  this.otherBrowser.val("No");
-  this.makeInvalidSilent("browser_test_type");
-  this.toggleOtherBrowser("hide");
+  this.otherBrowserElements
+    .find(this.noOtherBrowserTestedId)
+    .prop("checked", true);
   this.resetRadio(this.step6Radio);
 };
 

--- a/webcompat/templates/home-page/issue-wizard-form.html
+++ b/webcompat/templates/home-page/issue-wizard-form.html
@@ -200,15 +200,10 @@
         </div>
       </div>
     </div>
-    <div class="row half centered other-browser form-element js-Form-groupform-element js-Form-group with-validation-icons low">
-      <div class="column full-width">
-        <div class="label">
-          Browser tested
-        </div>
-        {{ form.browser_test(class_='form-field text-field required',
-            placeholder='Browser',
-            required=True, type='text') }}
-      </div>
+    <div class="row half centered other-browser">
+      {{ form.browser_test(class_='form-field text-field required',
+          placeholder='Browser',
+          required=True, type='text') }}
     </div>
     <div class="button-control row">
       <div class="input-control">


### PR DESCRIPTION
This PR fixes issue #2974

## Proposed PR background

On the current bug form, there is only a Yes / No answer for the question whether the user tested in another browser. There was no browser selection. On the new bug form, the initial intention was to let the user select the browser type and even insert a browser name.

The back end does not accept values other than Yes / No. As described in issue #2974, the decision was to send the value "Yes" to the server when selecting a browser, and to send the value "No" when the user selects "I have only tested on this browser", and this is exactly what this PR is fixing.