### PR TITLE
Fixes #2983 - Upload a different image keeps the original image unless a new one is chosen

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -419,6 +419,12 @@
   color: var(--link-color);
 }
 
+.input-control .screenshot-select-trigger {
+  color: var(--link-color);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .step1 .hero {
   order: -1;
 }

--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -32,6 +32,7 @@ BugForm.prototype.onDOMReadyInit = function() {
   this.previewEl = $(".js-image-upload");
   this.reportButton = $("#js-ReportBug");
   this.removeBanner = $(".js-remove-upload");
+  this.uploadOther = $(".screenshot-select-trigger");
   this.submitButtons = $("#js-ReportForm .js-Button");
   this.submitButtonWrappers = $("#js-ReportForm .js-Button-wrapper");
   this.submitTypeInput = $("#submit_type:hidden");
@@ -1137,6 +1138,7 @@ BugForm.prototype.showRemoveUpload = function() {
   this.uploadLabel.removeClass("visually-hidden");
 
   this.removeBanner.removeClass("is-hidden");
+  this.uploadOther.removeClass("is-hidden");
   this.removeBanner.attr("tabIndex", "0");
   this.uploadLabel.addClass("visually-hidden");
   this.removeBanner.on("click", this.removeUploadPreview.bind(this));
@@ -1159,6 +1161,7 @@ BugForm.prototype.removeUploadPreview = function(e) {
   e.preventDefault();
   this.previewEl.css("background", "none");
   this.removeBanner.addClass("is-hidden");
+  this.uploadOther.addClass("is-hidden");
   this.removeBanner.attr("tabIndex", "-1");
   this.uploadLabel.removeClass("visually-hidden").removeClass("is-hidden");
   this.removeBanner.off("click");
@@ -1216,7 +1219,7 @@ BugForm.prototype.uploadImage = function(dataURI) {
   var dfd = $.Deferred();
   this.disableSubmits();
 
-  $(".js-remove-upload").addClass("is-hidden");
+  this.removeBanner.addClass("is-hidden");
 
   var formdata = new FormData();
   formdata.append("image", dataURI);

--- a/webcompat/templates/home-page/issue-wizard-form.html
+++ b/webcompat/templates/home-page/issue-wizard-form.html
@@ -311,7 +311,7 @@
             <button class="button next-step step-10 issue-btn disabled" data-nextstep="11">Confirm</button>
             <button class="button js-remove-upload is-hidden issue-btn red">Delete this image</button>
           </div>
-          <a class="js-remove-upload is-hidden spaced-link" href="#">Upload a different image</a>
+          <label for="image" class="is-hidden screenshot-select-trigger spaced-link" href="#">Upload a different image</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes issue #2983 and particularly this [comment](https://github.com/webcompat/webcompat.com/issues/2983#issuecomment-544926336).

## Proposed PR background

Right now "Upload a different image" has the same effect as "Delete this image". In both cases, it deletes the image. 

The desired effect of "Upload a different image" is that it opens up the "Select file" dialogue without deleting the image first. If a new image is selected than this will replace the previous image. If the "Select file" dialogue is closed than the previous image remains.