### PR TITLE
Issue #3005 - Screenshot submit button shouldn't be disabled by default

### DIFF
--- a/webcompat/templates/home-page/issue-wizard-form.html
+++ b/webcompat/templates/home-page/issue-wizard-form.html
@@ -303,7 +303,7 @@
       <div class="input-control">
         <div class="col center">
           <div class="row mobile-col">
-            <button class="button next-step step-10 issue-btn disabled" data-nextstep="11">Confirm</button>
+            <button class="button next-step step-10 issue-btn" data-nextstep="11">Confirm</button>
             <button class="button js-remove-upload is-hidden issue-btn red">Delete this image</button>
           </div>
           <label for="image" class="is-hidden screenshot-select-trigger spaced-link" href="#">Upload a different image</label>


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #3005 

## Proposed PR background

Submit button for the screenshot field shouldn't be disabled by default
