### PR TITLE
Issue #3005 - Don't disable button when deleting a screenshots

### DIFF
--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -1146,7 +1146,6 @@ BugForm.prototype.removeUploadPreview = function(e) {
   this.uploadField.val(this.uploadField.get(0).defaultValue);
 
   this.changeUploadText("deleted-screenshot");
-  this.step10Btn.addClass("disabled");
 };
 
 BugForm.prototype.showLoadingIndicator = function() {


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #nnnn

## Proposed PR background

Screenshot confirmation button shouldn't be disabled by default.
