### PR TITLE
Fixes #3009 - Adds a route for deployed version Git SHA

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -113,3 +113,12 @@ Contact: mailto:miket@mozilla.com
 # AB setup
 # Comma separated list of user IDs to exempt from experiments
 AB_EXEMPT_USERS = os.environ.get('AB_EXEMPT_USERS', '').split(',')
+
+# SHA reference for the current deployed version
+# The Git SHA is written in data/ at deployment time.
+# This is used in views.py for /.well-known/deployed-version route
+try:
+    with open(os.path.join(DATA_PATH, 'sha.txt')) as f:
+        SHA_VERSION = (f.read(), 200)
+except FileNotFoundError as oops:
+    SHA_VERSION = ('no sha.', 404)

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -552,10 +552,18 @@ def log_csp_report():
 @app.route('/.well-known/<path:subpath>')
 @cache_policy(private=False, uri_max_age=31104000, must_revalidate=False)
 def wellknown(subpath):
-    """Route for returning 404 for the currently unused well-known routes."""
+    """Route for returning 404 for the currently unused well-known routes.
+
+    /.well-known/security.txt
+        contact information for a security issue.
+    /.well-known/deployed-version
+        GIT SHA of the current deployed version.
+    """
     if subpath == 'security.txt':
         msg = app.config['WELL_KNOWN_SECURITY']
         status_code = 200
+    elif subpath == 'deployed-version':
+        msg, status_code = app.config['SHA_VERSION']
     else:
         msg = app.config['WELL_KNOWN_ALL'].format(subpath=subpath)
         status_code = 404


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #3009

## Proposed PR background

This adds a route to the project to get the Git SHA of the current deployed version.
To note that this is basically a static request to a value in a file which is set by deployment scripts.
and which is initialized when the project is restarted. There is no point reading it for each request. 
