### PR TITLE
Fixes #3076 - Remove maxlength for textarea

### DIFF
--- a/webcompat/templates/issue-wizard-form.html
+++ b/webcompat/templates/issue-wizard-form.html
@@ -240,7 +240,7 @@
         <div class="form-text form-element js-Form-group problem-description progress-textarea bordered-container">
           {{ form.description() }}
           {{ form.steps_reproduce(class_='form-field text-field js-autogrow-field',
-              rows=3, maxlength=200, placeholder="Describe what happened") }}
+              rows=3, placeholder="Describe what happened") }}
           <div class="progress">
             <img class="tick" src="{{ url_for('static', filename='img/svg/icons/svg-check-issue.svg') }}" title="Valid message" alt="Valid message" />
             <div class="bar"></div>


### PR DESCRIPTION
I have no idea why this was in there

I tested locally and filed https://staging.webcompat.com/issues/2155, seems to work just fine. 