### PR TITLE
Fixes #3041 - Use Operating System instead of Device

### DIFF
--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -234,7 +234,6 @@ class FormWizard(IssueForm):
     steps = NEW_ISSUE_STEPS
 
     browser = StringField(u'Browser', [Optional()])
-    device = StringField('Device', [Optional()])
     os = StringField('Operating System', [Optional()])
 
     problem_category = PrefixedRadioField(

--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -395,19 +395,19 @@
 }
 
 .form-message-error,
-.device-browser-error {
+.os-browser-error {
   color: var(--wizard-step-error);
   font-size: 16px;
   font-weight: 200;
   text-align: left;
 }
 
-.device-browser-error {
+.os-browser-error {
   display: none;
   font-size: 15px;
 }
 
-.is-error .device-browser-error {
+.is-error .os-browser-error {
   display: block;
 }
 

--- a/webcompat/templates/issue-wizard-form.html
+++ b/webcompat/templates/issue-wizard-form.html
@@ -165,12 +165,12 @@
           <div class="row mobile-col">
             <div class="form-element js-Form-group low with-validation-icons half">
               {{ form.browser.label(class_='form-label') }}
-              <small class="device-browser-error">Browser required</small>
+              <small class="os-browser-error">Browser required</small>
               {{ form.browser(class_='form-field text-field') }}
             </div>
             <div class="form-element js-Form-group low with-validation-icons half">
-              {{ form.device.label(class_='form-label') }}
-              <small class="device-browser-error">Device required</small>
+              {{ form.os.label(class_='form-label') }}
+              <small class="os-browser-error">OS required</small>
               {{ form.os(class_='form-field text-field') }}
             </div>
           </div>


### PR DESCRIPTION
Note: it seems like FormWizard.device wasn't even used -- it was populated
but never sent to GitHub. It was sending FormWizard.os all along.

I've tested that filing a bug still works, just to be safe. 