### PR TITLE
Issue #3070 - Add additional logging of experiment branch and IP

### DIFF
--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -244,31 +244,36 @@ class TestForm(unittest.TestCase):
 
     def test_is_valid_issue_form(self):
         """Assert that we get the form parameters we want."""
-        incomplete_form = MultiDict([('problem_category', 'unknown_bug')])
-        self.assertFalse(helpers.is_valid_issue_form(incomplete_form))
-        valid_form = MultiDict([
-            ('browser', 'Firefox 61.0'),
-            ('description', 'streamlining the form.'),
-            ('details', ''),
-            ('os', 'Mac OS X 10.13'),
-            ('problem_category', 'unknown_bug'),
-            ('submit_type', 'github-auth-report'),
-            ('url', 'http://2479.example.com'),
-            ('username', ''), ])
-        self.assertTrue(helpers.is_valid_issue_form(valid_form))
-        # The value for submit-Type can be only:
-        # - github-auth-report
-        # - github-proxy-report
-        wrong_value_form = MultiDict([
-            ('browser', 'Firefox 61.0'),
-            ('description', 'streamlining the form.'),
-            ('details', ''),
-            ('os', 'Mac OS X 10.13'),
-            ('problem_category', 'unknown_bug'),
-            ('submit_type', 'wrong-value'),
-            ('url', 'http://2479.example.com'),
-            ('username', ''), ])
-        self.assertFalse(helpers.is_valid_issue_form(wrong_value_form))
+        cookie = 'exp=form-v1; Path=/'
+        with webcompat.app.test_request_context(
+                environ_base={'HTTP_COOKIE': cookie}):
+            webcompat.app.preprocess_request()
+
+            incomplete_form = MultiDict([('problem_category', 'unknown_bug')])
+            self.assertFalse(helpers.is_valid_issue_form(incomplete_form))
+            valid_form = MultiDict([
+                ('browser', 'Firefox 61.0'),
+                ('description', 'streamlining the form.'),
+                ('details', ''),
+                ('os', 'Mac OS X 10.13'),
+                ('problem_category', 'unknown_bug'),
+                ('submit_type', 'github-auth-report'),
+                ('url', 'http://2479.example.com'),
+                ('username', ''), ])
+            self.assertTrue(helpers.is_valid_issue_form(valid_form))
+            # The value for submit-Type can be only:
+            # - github-auth-report
+            # - github-proxy-report
+            wrong_value_form = MultiDict([
+                ('browser', 'Firefox 61.0'),
+                ('description', 'streamlining the form.'),
+                ('details', ''),
+                ('os', 'Mac OS X 10.13'),
+                ('problem_category', 'unknown_bug'),
+                ('submit_type', 'wrong-value'),
+                ('url', 'http://2479.example.com'),
+                ('username', ''), ])
+            self.assertFalse(helpers.is_valid_issue_form(wrong_value_form))
 
     def test_is_blacklisted_domain(self):
         """Assert domains validity in issue reporting."""

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -598,6 +598,9 @@ def is_valid_issue_form(form):
         log.info('is_valid_issue_form: experiment branch => {0}'.format(
             ab_active('exp') or 'Unknown branch'
         ))
+        log.info('is_valid_issue_form: reporter ip => {0}'.format(
+            request.remote_addr
+        ))
     return valid_form
 
 

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -592,7 +592,7 @@ def is_valid_issue_form(form):
     valid_form = parameters_check and values_check
     if not valid_form:
         log.info('is_valid_issue_form: form[submit_type] => {0}'.format(
-            form.get('submit_type', 'missing submit_type value')))
+            form.get('submit_type') or 'empty submit_type value'))
         log.info('is_valid_issue_form: missing param(s)? => {0}'.format(
             set(must_parameters).difference(list(form.keys()))))
     return valid_form

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -595,6 +595,9 @@ def is_valid_issue_form(form):
             form.get('submit_type') or 'empty submit_type value'))
         log.info('is_valid_issue_form: missing param(s)? => {0}'.format(
             set(must_parameters).difference(list(form.keys()))))
+        log.info('is_valid_issue_form: experiment branch => {0}'.format(
+            ab_active('exp') or 'Unknown branch'
+        ))
     return valid_form
 
 


### PR DESCRIPTION
Tested locally:

```
[2019-11-12 14:35:18,817] INFO in views: 127.0.0.1 b'http://example.com'
[2019-11-12 14:35:18,818] INFO in helpers: is_valid_issue_form: form[submit_type] => empty submit_type value
[2019-11-12 14:35:18,818] INFO in helpers: is_valid_issue_form: missing param(s)? => set()
[2019-11-12 14:35:18,818] INFO in helpers: is_valid_issue_form: experiment branch => form-v1
[2019-11-12 14:35:18,818] INFO in views: 400: POST request w/o valid form (is_valid_issue_form).
```