### PR TITLE
Fixes #3100 - Send GA events for issue-wizard clicks/input changes

### DIFF
--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -283,6 +283,28 @@ BugForm.prototype.init = function() {
 
   window.addEventListener("pageshow", this.resetProblemType.bind(this));
 
+  // Send GA event for all the `next` button clicks
+  if ("ga" in window) {
+    this.stepsArray.forEach(function(element) {
+      $(element).on("click", function() {
+        let ga_event = {
+          eventAction: "click",
+          eventCategory: "wizard next-step click",
+          eventLabel: this.className
+        };
+        window.ga("send", "event", ga_event);
+      });
+      $(element).on("change", function() {
+        let ga_event = {
+          eventAction: "input",
+          eventCategory: "wizard input",
+          eventLabel: this.className
+        };
+        window.ga("send", "event", ga_event);
+      });
+    });
+  }
+
   // See if the user already has a valid form
   // (after a page refresh, back button, etc.)
   this.checkForm();


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #3100

## Proposed PR background

We would like to keep track of events in the redesigned issue form. This PR adds more detailed events for this specific page outside of the generic page views we send.

At the moment we track:
* Next step clicks
* Form input changes
