### PR TITLE
Fixes #2952 - Fixes husky pre-commit deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "virtualenv": "python3 -m venv env && source env/bin/activate || . env/bin/activate && npm run pip",
     "pip": "pip install -r config/requirements-dev.txt",
     "project-update": "pip install --upgrade pip && npm update",
-    "precommit": "lint-staged",
     "test": "npm run test:js && npm run test:python",
     "test:js": "node ./tests/functional/_intern.js",
     "test:python": "nosetests"


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #2952 

## Proposed PR background

Removes the "precommit" key from "scripts" in package.json since that is deprecated and moved to husky.hooks. This eliminates the warning message seen when one makes a commit.
