### PR TITLE
Fixes #3096 Wrong button label for screenshot step

### DIFF
--- a/webcompat/templates/issue-wizard-form.html
+++ b/webcompat/templates/issue-wizard-form.html
@@ -302,7 +302,7 @@
       <div class="input-control">
         <div class="col center">
           <div class="row mobile-col">
-            <button class="button next-step step-10 issue-btn" data-nextstep="11">Confirm</button>
+            <button class="button next-step step-10 issue-btn" data-nextstep="11">Continue without</button>
             <button class="button js-remove-upload is-hidden issue-btn red">Delete this image</button>
           </div>
           <label for="image" class="is-hidden screenshot-select-trigger spaced-link" href="#">Upload a different image</label>


### PR DESCRIPTION

This PR fixes issue #3096

## Proposed PR background

Please provide enough information so that others can review your pull request:
Currently users aren't aware that they can submit a report without a screenshot.
