### PR TITLE
Fixes #3004 Description step has no intro copy

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -583,11 +583,8 @@
 }
 
 .device-data-hero img {
-  max-width: 100%;
-}
-
-.device-data-hero {
   display: none;
+  max-width: 100%;
 }
 
 .final-step .button img {
@@ -1101,6 +1098,9 @@
   .device-data-hero {
     display: flex;
     width: 40%;
+  }
+  .device-data-hero img {
+    display: flex;
   }
 
   .device-data .input-description {


### PR DESCRIPTION


This PR fixes issue #3004 

## Proposed PR background

On mobile, users don't get a description for the text box, so they are unaware of what they should put in the box.
