### PR TITLE
Fixes #3136 - Adds inline images but inside details/summary markup

### DIFF
--- a/tests/functional/image-uploads-non-auth.js
+++ b/tests/functional/image-uploads-non-auth.js
@@ -111,7 +111,7 @@ registerSuite("Image Uploads (non-auth)", {
           .then(function(val) {
             assert.notInclude(
               val,
-              "[Screenshot(http://localhost:5000/uploads/",
+              "<img alt='Screenshot' src='http://localhost:5000/uploads/",
               "The data URI was not uploaded before form submission."
             );
           })
@@ -132,7 +132,7 @@ registerSuite("Image Uploads (non-auth)", {
           .then(function(val) {
             assert.notInclude(
               val,
-              "[Screenshot(http://localhost:5000/uploads/",
+              "<img alt='Screenshot' src='",
               "The data URI was not uploaded before form submission."
             );
           })
@@ -151,7 +151,7 @@ registerSuite("Image Uploads (non-auth)", {
         .then(function(val) {
           assert.notInclude(
             val,
-            "[Screenshot](http://localhost:5000/uploads/",
+            "<img alt='Screenshot' src='",
             "The data URI was not uploaded before form submission."
           );
         })

--- a/webcompat/static/js/lib/bugform.js
+++ b/webcompat/static/js/lib/bugform.js
@@ -766,7 +766,12 @@ BugForm.prototype.getDataURIFromPreviewEl = function() {
 */
 BugForm.prototype.addImageURL = function(response) {
   var img_url = response.url;
-  var imageURL = ["[Screenshot](", img_url, ")"].join("");
+  var imageURL = [
+    "<details><summary>View the screenshot</summary>",
+    "<img alt='Screenshot' src='",
+    img_url,
+    "'></details>"
+  ].join("");
 
   this.stepsToReproduceField.val(function(idx, value) {
     return value + "\n" + imageURL;

--- a/webcompat/static/js/lib/issue-wizard-bugform.js
+++ b/webcompat/static/js/lib/issue-wizard-bugform.js
@@ -1373,7 +1373,12 @@ BugForm.prototype.getDataURIFromPreviewEl = function() {
 */
 BugForm.prototype.addImageURL = function(response) {
   var img_url = response.url;
-  var imageURL = ["[Screenshot](", img_url, ")"].join("");
+  var imageURL = [
+    "<details><summary>View the screenshot</summary>",
+    "<img alt='Screenshot' src='",
+    img_url,
+    "'></details>"
+  ].join("");
 
   this.stepsToReproduceField.val(function(idx, value) {
     return value + "\n" + imageURL;

--- a/webcompat/static/js/lib/issues.js
+++ b/webcompat/static/js/lib/issues.js
@@ -252,7 +252,12 @@ issues.ImageUploadView = Backbone.View.extend({
     var textarea = $(".js-Comment-text");
     var textareaVal = textarea.val();
     var img_url = response.url;
-    var imageURL = ["[Screenshot](", img_url, ")"].join("");
+    var imageURL = [
+      "<details><summary>View the screenshot</summary>",
+      "<img alt='Screenshot' src='",
+      img_url,
+      "'></details>"
+    ].join("");
 
     if (!$.trim(textareaVal)) {
       textarea.val(imageURL);


### PR DESCRIPTION
This PR fixes issue #3136

## Proposed PR background

We had removed the inline images, to avoid too much into your face screenshot. Putting them behind a details/summary element is hiding it. 

Also we had to use directly the `img` element instead of the markdown markup. Because markdown is being escaped inside the `details` element.
