### PR TITLE
Fixes 3145 - Adds an action-needsmoderation label to anonymous issue

### DIFF
--- a/tests/fixtures/webhooks/new_event_valid.json
+++ b/tests/fixtures/webhooks/new_event_valid.json
@@ -2,6 +2,17 @@
   "action": "opened",
   "issue": {
     "number": 600,
-    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/"
+    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/",
+    "labels": [
+      {
+        "id": 1788251357,
+        "node_id": "MDU6TGFiZWwxNzg4MjUxMzU3",
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/action-needsmoderation",
+        "name": "action-needsmoderation",
+        "color": "d36200",
+        "default": false,
+        "description": "issue in the process of being moderated"
+      }
+    ]
   }
 }

--- a/tests/unit/test_issues.py
+++ b/tests/unit/test_issues.py
@@ -67,7 +67,22 @@ class TestIssue(unittest.TestCase):
 
     @patch.object(requests, 'post')
     def test_report_public_issue_returns_moderation_template(self, mockpost):
-        """Test that we get a moderation template back from a public issue report."""   # noqa
+        """Test the data in report_public_issue contains the right data."""
         report_public_issue()
-        data = json.dumps(moderation_template())
-        mockpost.assert_called_with(ANY, data=data, headers=ANY, params=ANY)
+        post_data = json.loads(mockpost.call_args.kwargs['data'])
+        self.assertIs(type(post_data), dict)
+        self.assertIn('title', post_data.keys())
+        self.assertIn('body', post_data.keys())
+        self.assertIn('labels', post_data.keys())
+        self.assertEqual(['action-needsmoderation'], post_data['labels'])
+
+    def test_moderation_template(self):
+        """Check the moderation template structure.
+
+        - must be a dictionary
+        - must contain the keys: title, body
+        """
+        actual = moderation_template()
+        self.assertIs(type(actual), dict)
+        self.assertIn('title', actual.keys())
+        self.assertIn('body', actual.keys())

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -57,7 +57,10 @@ def report_public_issue(form):
     Returns a requests.Response object.
     """
     path = 'repos/{0}'.format(REPO_URI)
-    return proxy_request('post', path, data=json.dumps(unmoderated_issue()))
+    public_data = unmoderated_issue()
+    # We add action-needsmoderation label, so reviewers can filter out
+    public_data['labels'] = ['action-needsmoderation']
+    return proxy_request('post', path, data=json.dumps(public_data))
 
 
 def report_issue(form, proxy=False):

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -188,7 +188,12 @@ def new_opened_issue(payload):
     """
     issue_body = payload.get('issue')['body']
     issue_number = payload.get('issue')['number']
+    # Grabs the labels already set so they will not be erased
+    original_labels = [label['name']
+                       for label in payload.get('issue')['labels']]
+    # Gets the labels from the body
     labels = get_issue_labels(issue_body)
+    labels.extend(original_labels)
     milestone = app.config['STATUSES']['needstriage']['id']
     # Preparing the proxy request
     headers = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])}


### PR DESCRIPTION

This PR fixes issue #3145

## Proposed PR background

This is adding the label necessary for triager to filter out the issues which have not been yet been accepted. 
It was necessary to modify the webhook so that it will not crush the existing issue labels. 
