### PR TITLE
Fixes #3163 - Scopes the URL of the repo before making actions on opened issues.

### DIFF
--- a/tests/fixtures/webhooks/new_event_invalid.json
+++ b/tests/fixtures/webhooks/new_event_invalid.json
@@ -1,8 +1,9 @@
 {
   "action": "foobar",
   "issue": {
+    "title": "www.netflix.com - test invalid event",
+    "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
     "number": 600,
-    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/",
-    "title": "www.chia-anime.tv - video doesn't play"
+    "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/"
   }
 }

--- a/tests/fixtures/webhooks/wrong_repo.json
+++ b/tests/fixtures/webhooks/wrong_repo.json
@@ -1,8 +1,8 @@
 {
   "action": "opened",
   "issue": {
-    "title": "www.netflix.com - test valid event",
-    "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+    "title": "www.netflix.com - test wrong repo",
+    "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests-private",
     "number": 600,
     "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n\n**URL**: https://www.netflix.com/",
     "labels": [

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -229,8 +229,8 @@ class TestWebhook(unittest.TestCase):
             actual = helpers.get_issue_labels(issue_body)
             self.assertEqual(sorted(expected), sorted(actual))
 
-    def test_is_github_hook(self):
-        """Validation tests for GitHub Webhooks."""
+    def test_is_github_hook_missing_x_github_event(self):
+        """Validation tests for GitHub Webhooks: Missing X-GitHub-Event."""
         json_event, signature = event_data('new_event_invalid.json')
         # Lack the X-GitHub-Event
         with self.app as client:
@@ -241,6 +241,10 @@ class TestWebhook(unittest.TestCase):
                         headers=headers)
             webhook_request = helpers.is_github_hook(flask.request)
             self.assertFalse(webhook_request, 'X-GitHub-Event is missing')
+
+    def test_is_github_hook_missing_x_hub_signature(self):
+        """Validation tests for GitHub Webhooks: Missing X-Hub-Signature."""
+        json_event, signature = event_data('new_event_invalid.json')
         # Lack the X-Hub-Signature
         with self.app as client:
             headers = self.headers.copy()
@@ -250,6 +254,10 @@ class TestWebhook(unittest.TestCase):
                         headers=headers)
             webhook_request = helpers.is_github_hook(flask.request)
             self.assertFalse(webhook_request, 'X-Hub-Signature is missing')
+
+    def test_is_github_hook_wrong_signature(self):
+        """Validation tests for GitHub Webhooks: Wrong X-Hub-Signature."""
+        json_event, signature = event_data('new_event_invalid.json')
         # X-Hub-Signature is wrong
         with self.app as client:
             headers = self.headers.copy()
@@ -260,6 +268,10 @@ class TestWebhook(unittest.TestCase):
                         headers=headers)
             webhook_request = helpers.is_github_hook(flask.request)
             self.assertFalse(webhook_request, 'X-Hub-Signature is wrong')
+
+    def test_is_github_hook_everything_ok(self):
+        """Validation tests for GitHub Webhooks: Everything ok."""
+        json_event, signature = event_data('new_event_invalid.json')
         # Everything is fine
         with self.app as client:
             headers = self.headers.copy()
@@ -276,9 +288,7 @@ class TestWebhook(unittest.TestCase):
         """Extract the right information from an issue."""
         json_event, signature = event_data('new_event_invalid.json')
         payload = json.loads(json_event)
-        expected = {'number': 600,
-                    'action': 'foobar',
-                    'domain': 'www.chia-anime.tv'}
+        expected = {'number': 600, 'repository_url': 'https://api.github.com/repos/webcompat/webcompat-tests', 'action': 'foobar', 'domain': 'www.netflix.com'}  # noqa
         actual = helpers.get_issue_info(payload)
         self.assertDictEqual(expected, actual)
 

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -146,7 +146,8 @@ def get_issue_info(payload):
     # Create the issue dictionary
     return {'action': payload.get('action'),
             'number': payload.get('issue')['number'],
-            'domain': title.partition(' ')[0]}
+            'domain': title.partition(' ')[0],
+            'repository_url': payload.get('issue')['repository_url']}
 
 
 def get_issue_labels(issue_body):


### PR DESCRIPTION
This PR fixes issue #3163

## Proposed PR background

This is a first step in solving #3140 
It means also that if we deploy now, we do not break the current workflow by adding the webhook to the private repo as recommended in #3155  
