### PR TITLE
Fixes #3180 - Use full not (relative) for terms page.

### DIFF
--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -652,7 +652,7 @@ class TestWebhook(unittest.TestCase):
     def test_prepare_rejected_issue(self):
         """Test we prepare the right payload for the rejected issue."""
         expected = {'body': "<p>The content of this issue doesn't meet our\n"
-                    '<a href="/acceptable-use">acceptable use</a>\n'
+                    '<a href="https://webcompat.com/terms#acceptable-use">acceptable use</a>\n'  # noqa
                     'guidelines. Its original content has been deleted.</p>',
                     'labels': ['status-notacceptable'],
                     'milestone': 8,

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -25,7 +25,7 @@ PRIVATE_REPO_MILESTONE = app.config['PRIVATE_REPO_MILESTONE']
 
 REJECTED_TITLE = 'Issue rejected.'
 REJECTED_BODY = '''<p>The content of this issue doesn't meet our
-<a href="/acceptable-use">acceptable use</a>
+<a href="https://webcompat.com/terms#acceptable-use">acceptable use</a>
 guidelines. Its original content has been deleted.</p>'''
 ONGOING_TITLE = 'In the moderation queue.'
 ONGOING_BODY = '''<p>This issue has been put in the moderation queue. A human

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -30,7 +30,7 @@ guidelines. Its original content has been deleted.</p>'''
 ONGOING_TITLE = 'In the moderation queue.'
 ONGOING_BODY = '''<p>This issue has been put in the moderation queue. A human
 will review if the message meets our current
-<a href="https://www.mozilla.org/en-US/about/legal/acceptable-use/">
+<a href="https://webcompat.com/terms#acceptable-use">
 acceptable use</a> guidelines.
 It will probably take a couple of days depending on the backlog.
 Once it has been reviewed, the content will be either made public

--- a/webcompat/templates/terms.html
+++ b/webcompat/templates/terms.html
@@ -16,7 +16,7 @@
             with the website stewards, or escalate bugs to browser vendors.
             For more details, see our <a href="/about" title="about page">About page</a>.
         </p>
-          <h3 class="headline-2">Acceptable Use</h3>
+          <h3 class="headline-2" id="acceptable-use">Acceptable Use</h3>
 
           <p>
               Your use of the webcompat.com website and service must not violate any applicable laws, including copyright or trademark laws,


### PR DESCRIPTION
Maybe this is awkward because we're hard-coding production links, even on staging, but I can't imagine why we would have a different set of terms between the two.

The intent here is to prevent following a hyperlink from GitHub (or email notification) and having that 404 on GitHub's side.