### PR TITLE
Fixes #3188 - Account for invalid domains before checking for is_darknet_domain

### DIFF
--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -602,6 +602,7 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(is_darknet_domain('www.gjobqjj7wyczbqie.onion'))
         self.assertFalse(is_darknet_domain('example.com'))
         self.assertFalse(is_darknet_domain('gjobqjj7wyczbqie.onion.com'))
+        self.assertFalse(is_darknet_domain(None))
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -117,6 +117,26 @@ class TestURLs(unittest.TestCase):
                 username='PunkCat',))
         self.assertEqual(rv.status_code, 400)
 
+    @patch('webcompat.views.report_issue')
+    def test_successful_post_new_issue_with_incorrect_url(self, mock_proxy):
+        """Test that anonymous post succeeds on /issues/new with incorrect url."""  # noqa
+        mock_proxy.return_value = POST_RESPONSE
+        rv = self.app.post(
+            '/issues/new',
+            content_type='multipart/form-data',
+            environ_base=headers,
+            data=dict(
+                browser='Firefox Mobile 45.0',
+                description='testing 2971',
+                os='macos',
+                problem_category='yada',
+                submit_type='github-proxy-report',
+                url='http:testing.example.org',
+                username='yeeha'))
+        self.assertEqual(rv.status_code, 302)
+        self.assertTrue(
+            b'<a href="/issues/1544">/issues/1544</a>' in rv.data)
+
     def test_about(self):
         """Test that /about exists."""
         rv = self.app.get('/about')

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -617,6 +617,8 @@ def is_blacklisted_domain(domain):
 
 def is_darknet_domain(domain):
     """Check if the domain ends with .onion."""
+    if not domain:
+        return False
     return domain.endswith('.onion')
 
 

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -24,6 +24,7 @@ from webcompat.form import AUTH_REPORT
 from webcompat.form import get_form
 from webcompat.form import FormWizard
 from webcompat.form import PROXY_REPORT
+from webcompat.form import normalize_url
 from webcompat.helpers import ab_active
 from webcompat.helpers import ab_current_experiments
 from webcompat.helpers import ab_init
@@ -299,7 +300,7 @@ def create_issue():
         if not is_valid_issue_form(form):
             log.info('400: POST request w/o valid form (is_valid_issue_form).')
             abort(400)
-        domain = urllib.parse.urlsplit(form['url']).hostname
+        domain = urllib.parse.urlsplit(normalize_url(form['url'])).hostname
         if is_darknet_domain(domain):
             msg = app.config['IS_DARKNET_DOMAIN'].format(form['url'])
             flash(msg, 'notimeout')


### PR DESCRIPTION
If a domain with an incorrect scheme gets reported (e.g. `https:www.test.com`) , urlsplit returns `None` as a hostname:
https://github.com/webcompat/webcompat.com/blob/4fcbd519fdef4ec07ba8236b3e42624e4f34e982/webcompat/views.py#L302-L303

In this case `is_darknet_domain` method fails with `AttributeError: 'NoneType' object has no attribute 'endswith'` 

To fix this I've added `normalize_url(form['url'])` to the above method

r? @miketaylr 