### PR TITLE
fixes #3197 - Adds fencing on accepted issues being closed in private

### DIFF
--- a/tests/fixtures/webhooks/private_milestone_accepted.json
+++ b/tests/fixtures/webhooks/private_milestone_accepted.json
@@ -16,7 +16,24 @@
         "description": "issue in the process of being moderated"
       }
     ],
-    "state": "open"
+    "state": "open",
+    "milestone": {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/2",
+      "html_url": "https://github.com/webcompat/webcompat-tests-private/milestone/2",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/2/labels",
+      "id": 5092463,
+      "node_id": "MDk6TWlsZXN0b25lNTA5MjQ2Mw==",
+      "number": 2,
+      "title": "accepted",
+      "description": "This is when a bug has been accepted for moderation",
+      "open_issues": 0,
+      "closed_issues": 2,
+      "state": "open",
+      "created_at": "2020-02-11T00:37:18Z",
+      "updated_at": "2020-02-11T18:34:04Z",
+      "due_on": null,
+      "closed_at": null
+    }
   },
   "milestone": {
     "title": "accepted"

--- a/tests/fixtures/webhooks/private_milestone_accepted_closed.json
+++ b/tests/fixtures/webhooks/private_milestone_accepted_closed.json
@@ -1,0 +1,47 @@
+{
+    "action": "closed",
+    "issue": {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/issues/600",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests-private",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/issues/600/labels{/name}",
+      "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/issues/600/comments",
+      "events_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/issues/600/events",
+      "html_url": "https://github.com/webcompat/webcompat-tests-private/issues/600",
+      "id": 563394454,
+      "node_id": "MDU6SXNzdWU1NjMzOTQ0NTQ=",
+      "number": 600,
+      "title": "www.netflix.com - test private issue accepted",
+      "labels": [
+
+      ],
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": {
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/2",
+        "html_url": "https://github.com/webcompat/webcompat-tests-private/milestone/2",
+        "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/2/labels",
+        "id": 5092463,
+        "node_id": "MDk6TWlsZXN0b25lNTA5MjQ2Mw==",
+        "number": 2,
+        "title": "accepted",
+        "description": "This is when a bug has been accepted for moderation",
+        "open_issues": 0,
+        "closed_issues": 2,
+        "state": "open",
+        "created_at": "2020-02-11T00:37:18Z",
+        "updated_at": "2020-02-11T18:34:04Z",
+        "due_on": null,
+        "closed_at": null
+      },
+      "comments": 0,
+      "created_at": "2020-02-11T18:28:46Z",
+      "updated_at": "2020-02-11T18:34:04Z",
+      "closed_at": "2020-02-11T18:34:04Z",
+      "author_association": "COLLABORATOR",
+      "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n<!-- @public_url: https://github.com/webcompat/webcompat-tests/issues/1  -->\n\n**URL**: https://www.netflix.com/"
+    }
+  }

--- a/tests/fixtures/webhooks/private_milestone_closed.json
+++ b/tests/fixtures/webhooks/private_milestone_closed.json
@@ -16,9 +16,36 @@
         "description": "issue in the process of being moderated"
       }
     ],
-    "state": "closed"
-},
-  "milestone": {
-    "title": "needstriage"
+    "state": "closed",
+    "milestone": {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/1",
+      "html_url": "https://github.com/webcompat/webcompat-tests-private/milestone/1",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/1/labels",
+      "id": 4995253,
+      "node_id": "MDk6TWlsZXN0b25lNDk5NTI1Mw==",
+      "number": 1,
+      "title": "unmoderated",
+      "description": "The default milestone. These issues may not be made public until they are determined to not violate terms of use.",
+      "creator": {
+        "login": "miketaylr",
+        "id": 67283,
+        "node_id": "MDQ6VXNlcjY3Mjgz",
+        "avatar_url": "https://avatars1.githubusercontent.com/u/67283?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/miketaylr",
+        "html_url": "https://github.com/miketaylr",
+        "followers_url": "https://api.github.com/users/miketaylr/followers",
+        "following_url": "https://api.github.com/users/miketaylr/following{/other_user}",
+        "gists_url": "https://api.github.com/users/miketaylr/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/miketaylr/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/miketaylr/subscriptions",
+        "organizations_url": "https://api.github.com/users/miketaylr/orgs",
+        "repos_url": "https://api.github.com/users/miketaylr/repos",
+        "events_url": "https://api.github.com/users/miketaylr/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/miketaylr/received_events",
+        "type": "User",
+        "site_admin": false
+      }
+    }
   }
 }

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -543,6 +543,34 @@ class TestWebhook(unittest.TestCase):
             self.assertEqual(rv.status_code, 200)
             self.assertEqual(rv.content_type, 'text/plain')
 
+    @patch('webcompat.webhooks.helpers.private_issue_rejected')
+    def test_patch_acceptable_issue_closed(self, mock_proxy):
+        """Test for accepted issues being closed.
+
+        payload: 'Not an interesting hook'
+        status: 403
+        content-type: text/plain
+
+        An accepted issue, which is being closed, should
+        not modify the public issue.
+        """
+        json_event, signature = event_data(
+            'private_milestone_accepted_closed.json')
+        headers = {
+            'X-GitHub-Event': 'issues',
+            'X-Hub-Signature': signature,
+        }
+        with webcompat.app.test_client() as c:
+            mock_proxy.return_value.status_code = 200
+            rv = c.post(
+                '/webhooks/labeler',
+                data=json_event,
+                headers=headers
+            )
+            self.assertEqual(rv.data, b'Not an interesting hook')
+            self.assertEqual(rv.status_code, 403)
+            self.assertEqual(rv.content_type, 'text/plain')
+
     @patch('webcompat.webhooks.helpers.private_issue_moderation')
     def test_patch_wrong_repo_for_moderation(self, mock_proxy):
         """Test for issues in the wrong repo.

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -119,6 +119,7 @@ class TestWebhook(unittest.TestCase):
             'action': 'milestoned',
             'state': 'open',
             'milestoned_with': 'accepted',
+            'milestone': 'accepted',
             'body': '<!-- @browser: Firefox 55.0 -->\n'
             '<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) '
             'Gecko/20100101 Firefox/55.0 -->\n'

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -164,6 +164,9 @@ def get_issue_info(payload):
     # If labels on the original issue, we need them.
     original_labels = [label['name'] for label in labels]
     issue_info['original_labels'] = original_labels
+    # webhook with a milestone already set
+    if issue.get('milestone'):
+        issue_info['milestone'] = issue['milestone']['title']
     # webhook with a milestoned action
     if payload.get('milestone'):
         issue_info['milestoned_with'] = payload.get('milestone')['title']

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -275,7 +275,9 @@ def process_issue_action(issue_info):
         else:
             msg_log('private:moving to public failed', issue_number)
             return ('ooops', 400, {'Content-Type': 'text/plain'})
-    elif (scope == 'private' and issue_info['state'] == 'closed'):
+    elif (scope == 'private' and
+          issue_info['state'] == 'closed' and
+          not issue_info['milestone'] == 'accepted'):
         # private issue has been closed. It is rejected
         # We need to patch with a template.
         response = private_issue_rejected(issue_info)


### PR DESCRIPTION
This PR fixes issue #3197

## Proposed PR background

it adds a couple of tests for the case where an accepted issue in the private repo is being closed.
it fences the editing of the public repo on not having accepted status.
it modifies the issue_info model