### PR TITLE
Fixes #3259 - i18n for Add-on URLs

### DIFF
--- a/webcompat/templates/nav/addon-links.html
+++ b/webcompat/templates/nav/addon-links.html
@@ -1,7 +1,7 @@
 <ul class="nav-left nav-addon">
     {%- if browser == 'firefox' %}
     <li class="nav-item">
-        <a class="nav-link js-addon-link" href="https://addons.mozilla.org/en-US/firefox/addon/webcompatcom-reporter/"
+        <a class="nav-link js-addon-link" href="https://addons.mozilla.org/firefox/addon/webcompatcom-reporter/"
            title="Navigate to Firefox Add-on store">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
                 <use xlink:href="#svg-download2" />
@@ -11,7 +11,7 @@
     </li>
     {%- elif browser == 'firefox mobile' -%}
     <li class="nav-item">
-        <a class="nav-link js-addon-link" href="https://addons.mozilla.org/en-US/android/addon/webcompatcom-mobile-reporter/"
+        <a class="nav-link js-addon-link" href="https://addons.mozilla.org/android/addon/webcompatcom-mobile-reporter/"
            title="Navigate to Firefox Add-on store">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
                 <use xlink:href="#svg-download2" />
@@ -31,7 +31,7 @@
     </li>
     {%- elif browser == 'opera' -%}
     <li class="nav-item">
-        <a class="nav-link js-addon-link" href="https://addons.opera.com/en/extensions/details/webcompatcom-reporter/?display=en"
+        <a class="nav-link js-addon-link" href="https://addons.opera.com/extensions/details/webcompatcom-reporter/"
            title="Navigate to Opera Add-ons">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
                 <use xlink:href="#svg-download2" />


### PR DESCRIPTION
To foster improved i18n support, I changed the AMO and AOC links to no longer force a single language or a single region.

Both AMO and AOC correctly direct users to the appropriate URLs for their own language and region.

Examples:
https://addons.mozilla.org/fr/firefox/addon/webcompatcom-reporter/
https://addons.opera.com/it/extensions/details/webcompatcom-reporter/

<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #nnnn

## Proposed PR background

Please provide enough information so that others can review your pull request:
