### PR TITLE
Fixes #3233 - Update progress tracker to indicate which step we're on

### DIFF
--- a/tests/functional/reporting-issue-wizard-non-auth.js
+++ b/tests/functional/reporting-issue-wizard-non-auth.js
@@ -76,6 +76,13 @@ registerSuite("Reporting with wizard", {
     "Wizard stepper - scenario 1"() {
       return (
         FunctionalHelpers.openPage(this, url("issues/new"), "#js-ReportForm")
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Web address"
+            assert.include(text, "Web address");
+          })
+          .end()
           // Manual url enter
           .findByCssSelector("#url")
           .type("http://example.com")
@@ -83,6 +90,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Confirm"
           .findByCssSelector(".next-url")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Issue"
+            assert.include(text, "Issue");
+          })
           .end()
           .execute(function () {
             // Click on "Desktop site instead of mobile site"
@@ -96,11 +110,25 @@ registerSuite("Reporting with wizard", {
             assert.include(val, "Desktop site instead of mobile site");
           })
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Details"
+            assert.include(text, "Details");
+          })
+          .end()
           // Click on "Yes"
           .findByCssSelector(".next-browser")
           .click()
           .end()
           .sleep(500)
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Testing"
+            assert.include(text, "Testing");
+          })
+          .end()
           .findByCssSelector(".next-tested")
           .getAttribute("disabled")
           .then(function (attribute) {
@@ -116,6 +144,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Confirm"
           .findByCssSelector(".next-tested")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Description"
+            assert.include(text, "Description");
+          })
           .end()
           // Enter less than 30 characters in the description field
           .findById("steps_reproduce")
@@ -139,6 +174,13 @@ registerSuite("Reporting with wizard", {
           .findByCssSelector(".next-description")
           .click()
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Screenshot"
+            assert.include(text, "Screenshot");
+          })
+          .end()
           // Upload an image
           .findByCssSelector("#image")
           .type(VALID_IMAGE_PATH)
@@ -153,6 +195,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Continue"
           .click()
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Send report"
+            assert.include(text, "Send report");
+          })
+          .end()
           // Make sure "Report via Github" is visible
           .findDisplayedById("submitgithub")
           .end()
@@ -164,6 +213,13 @@ registerSuite("Reporting with wizard", {
     "Wizard stepper - scenario 2"() {
       return (
         FunctionalHelpers.openPage(this, url("issues/new"), "#js-ReportForm")
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Web address"
+            assert.include(text, "Web address");
+          })
+          .end()
           // Manual url enter
           .findByCssSelector("#url")
           .type("http://example.com")
@@ -171,6 +227,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Confirm"
           .findByCssSelector(".next-url")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Issue"
+            assert.include(text, "Issue");
+          })
           .end()
           .execute(function () {
             // Click on "Design is broken"
@@ -186,9 +249,23 @@ registerSuite("Reporting with wizard", {
             assert.include(val, "Images not loaded");
           })
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Details"
+            assert.include(text, "Details");
+          })
+          .end()
           // Click on "different device or browser"
           .findByCssSelector(".next-custom")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is still "Details"
+            assert.include(text, "Details");
+          })
           .end()
           // Clear the "Browser" field
           .findById("browser")
@@ -214,6 +291,13 @@ registerSuite("Reporting with wizard", {
           .click()
           .end()
           .sleep(1000)
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Testing"
+            assert.include(text, "Testing");
+          })
+          .end()
           // Click on "I have only tested on this browser"
           .findByCssSelector(".no-other-browser")
           .click()
@@ -238,6 +322,13 @@ registerSuite("Reporting with wizard", {
           })
           .click()
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Description"
+            assert.include(text, "Description");
+          })
+          .end()
           // Enter more than 30 characters in the description field
           .findById("steps_reproduce")
           .type("This paragraph contains more than 30 characters")
@@ -248,6 +339,13 @@ registerSuite("Reporting with wizard", {
           .click()
           .end()
           .sleep(500)
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Screenshot"
+            assert.include(text, "Screenshot");
+          })
+          .end()
           .findDisplayedByCssSelector(".next-screenshot")
           .getVisibleText()
           .then(function (text) {
@@ -261,6 +359,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Continue without"
           .click()
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Send report"
+            assert.include(text, "Send report");
+          })
+          .end()
           // Make sure "Report via Github" is visible
           .findDisplayedById("submitgithub")
           .end()
@@ -272,6 +377,13 @@ registerSuite("Reporting with wizard", {
     "Wizard stepper - scenario 3"() {
       return (
         FunctionalHelpers.openPage(this, url("issues/new"), "#js-ReportForm")
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Web address"
+            assert.include(text, "Web address");
+          })
+          .end()
           // Manual url enter
           .findByCssSelector("#url")
           .type("http://example.com")
@@ -291,6 +403,13 @@ registerSuite("Reporting with wizard", {
           // Click on "Confirm"
           .findByCssSelector(".next-url")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Issue"
+            assert.include(text, "Issue");
+          })
           .end()
           .execute(function () {
             // Click on "Something else"
@@ -314,6 +433,13 @@ registerSuite("Reporting with wizard", {
           .click()
           .end()
           .sleep(1000)
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Details"
+            assert.include(text, "Details");
+          })
+          .end()
           // Click on "Yes"
           .findDisplayedByCssSelector(".next-browser")
           .click()
@@ -336,6 +462,13 @@ registerSuite("Reporting with wizard", {
           .findDisplayedByCssSelector(".next-tested")
           .click()
           .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Description"
+            assert.include(text, "Description");
+          })
+          .end()
           // Enter less than 30 characters
           .findById("steps_reproduce")
           .type("not enough characters")
@@ -357,6 +490,13 @@ registerSuite("Reporting with wizard", {
           // Click "Continue"
           .findByCssSelector(".next-description")
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Screenshot"
+            assert.include(text, "Screenshot");
+          })
           .end()
           // Upload an image
           .findByCssSelector("#image")
@@ -436,6 +576,13 @@ registerSuite("Reporting with wizard", {
           })
           // Click "Continue"
           .click()
+          .end()
+          .findByCssSelector(".step.active .description")
+          .getVisibleText()
+          .then(function (text) {
+            // Make sure that progress label is "Send report"
+            assert.include(text, "Send report");
+          })
           .end()
           // Make sure "Report via Github" is visible
           .findDisplayedById("submitgithub")

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -46,36 +46,43 @@ GITHUB_HELP = '_From [webcompat.com](https://webcompat.com/) with ❤️_'
 NEW_ISSUE_STEPS = [
     {
         'number': 1,
+        'id': 'address',
         'className': 'active',
         'label': 'Web address'
     },
     {
         'number': 2,
+        'id': 'issue',
         'className': '',
         'label': 'Issue'
     },
     {
         'number': 3,
+        'id': 'details',
         'className': '',
         'label': 'Details'
     },
     {
         'number': 4,
+        'id': 'testing',
         'className': '',
         'label': 'Testing'
     },
     {
         'number': 5,
+        'id': 'description',
         'className': '',
         'label': 'Description'
     },
     {
         'number': 6,
+        'id': 'screenshot',
         'className': '',
         'label': 'Screenshot'
     },
     {
         'number': 7,
+        'id': 'send',
         'className': 'last',
         'label': 'Send report'
     }

--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -59,13 +59,17 @@
   position: fixed;
   top: 75px;
   transform: none;
-  transition: top 400ms ease;
+  transition: top 400ms ease, box-shadow 200ms ease-in;
   width: calc(100% + var(--grid-outermargin-s));
   z-index: 31;
 }
 
 #wizard-container.is-offscreen {
   top: 35px;
+}
+
+#wizard-container.shadow {
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .5);
 }
 
 #wizard-container .grid {

--- a/webcompat/static/js/lib/navbar.js
+++ b/webcompat/static/js/lib/navbar.js
@@ -29,6 +29,14 @@ function NavBar() {
     });
   };
 
+  this.addShadow = function (el, scroll) {
+    if (scroll > 0) {
+      el.addClass("shadow");
+    } else {
+      el.removeClass("shadow");
+    }
+  };
+
   this.navbarHandler = function () {
     var $navbar = $(".js-navigation");
     var $newIssueStepper = $("#wizard-container");
@@ -36,13 +44,20 @@ function NavBar() {
     var lastScrollY = window.pageYOffset;
     var scrollTimeout = null;
     var isScrolling = false;
-    $(window).on("scroll", function () {
-      isScrolling = true;
-      window.clearTimeout(scrollTimeout);
-      scrollTimeout = window.setTimeout(function () {
-        isScrolling = false;
-      }, 500);
-    });
+
+    $(window).on(
+      "scroll",
+      function () {
+        isScrolling = true;
+        window.clearTimeout(scrollTimeout);
+        scrollTimeout = window.setTimeout(function () {
+          isScrolling = false;
+        }, 500);
+
+        this.addShadow($newIssueStepper, $(window).scrollTop());
+      }.bind(this)
+    );
+
     window.setInterval(function () {
       if (!isScrolling) {
         return;

--- a/webcompat/static/js/lib/wizard/app.js
+++ b/webcompat/static/js/lib/wizard/app.js
@@ -4,6 +4,8 @@
 
 import stepper from "./stepper.js";
 import prefill from "./prefill.js";
+import progress from "./progress.js";
 
 prefill.init();
 stepper.init();
+progress.init();

--- a/webcompat/static/js/lib/wizard/progress.js
+++ b/webcompat/static/js/lib/wizard/progress.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import notify from "./notify.js";
+import { STEPS } from "./steps/index.js";
+
+const setProgress = (progressId) => {
+  const currentId = `#pr-${progressId}`;
+  const currentEl = $(currentId);
+
+  currentEl.prevAll(".step").removeClass("active").addClass("complete");
+  currentEl.removeClass("complete").addClass("active");
+  currentEl.nextAll(".step").removeClass("active").removeClass("complete");
+};
+
+const setProgressByStep = (id) => {
+  if (id in STEPS && "progress" in STEPS[id]) {
+    setProgress(STEPS[id].progress);
+  }
+};
+
+const setProgressById = (id) => {
+  setProgress(id);
+};
+
+export default {
+  init: () => {
+    notify.subscribe("showStep", ({ id }) => setProgressByStep(id));
+    // Manually set progress here for cases when progress update
+    // is not triggered by showStep
+    notify.subscribe("setProgress", ({ id }) => setProgressById(id));
+  },
+};

--- a/webcompat/static/js/lib/wizard/stepper.js
+++ b/webcompat/static/js/lib/wizard/stepper.js
@@ -6,19 +6,19 @@ import notify from "./notify.js";
 import { STEPS } from "./steps/index.js";
 
 const hideStep = (id) => {
-  STEPS[id].hide();
+  STEPS[id].module.hide();
 };
 
 const showStep = (message) => {
   const { id, data } = message;
   const step = STEPS[id];
-  step.show(data);
+  step.module.show(data);
 };
 
 const updateStep = (message) => {
   const { id, data } = message;
   const step = STEPS[id];
-  step.update(data);
+  step.module.update(data);
 };
 
 export default {

--- a/webcompat/static/js/lib/wizard/steps/category.js
+++ b/webcompat/static/js/lib/wizard/steps/category.js
@@ -28,6 +28,7 @@ const showStep = (id, data) => notify.publish("showStep", { id, data });
 const hideStep = (id) => notify.publish("hideStep", id);
 const updateStep = (id, data) =>
   notify.publish("updateStep", { id: "hidden", data });
+const setProgress = (id) => notify.publish("setProgress", { id });
 
 const updateDescription = (text) => {
   const toUpdate = {
@@ -55,6 +56,7 @@ const handleUnknownBug = () => {
   showUnknown();
   hideStep("subCategory");
   hideStep("confirmBrowser");
+  setProgress("issue");
 };
 
 const onChange = (event) => {

--- a/webcompat/static/js/lib/wizard/steps/index.js
+++ b/webcompat/static/js/lib/wizard/steps/index.js
@@ -11,15 +11,48 @@ import submit from "./submit.js";
 import hidden from "./hidden.js";
 
 export const STEPS = {
-  url: url,
-  category: category,
-  subCategory: subCategory,
-  confirmBrowser: confirmBrowser,
-  differentBrowser: differentBrowser,
-  testedBrowsers: testedBrowsers,
-  warningBrowser: warningBrowser,
-  description: description,
-  screenshot: screenshot,
-  submit: submit,
-  hidden: hidden,
+  url: {
+    module: url,
+    progress: "address",
+  },
+  category: {
+    module: category,
+    progress: "issue",
+  },
+  subCategory: {
+    module: subCategory,
+    progress: "issue",
+  },
+  confirmBrowser: {
+    module: confirmBrowser,
+    progress: "details",
+  },
+  differentBrowser: {
+    module: differentBrowser,
+    progress: "details",
+  },
+  testedBrowsers: {
+    module: testedBrowsers,
+    progress: "testing",
+  },
+  warningBrowser: {
+    module: warningBrowser,
+    progress: "testing",
+  },
+  description: {
+    module: description,
+    progress: "description",
+  },
+  screenshot: {
+    module: screenshot,
+    progress: "screenshot",
+  },
+  submit: {
+    module: submit,
+    progress: "send",
+  },
+  hidden: {
+    module: hidden,
+    progress: "",
+  },
 };

--- a/webcompat/templates/issue-wizard-form.html
+++ b/webcompat/templates/issue-wizard-form.html
@@ -337,7 +337,7 @@
                     type={{ 'submit' if anonymous_reporting else 'button' }}
                     {{ '' if anonymous_reporting else 'disabled' }}
                     >
-                    {{'Report Anonymously' if anonymous_reporting else 'Anonymous reports temporarily disabled'}}
+                    {{'Report anonymously' if anonymous_reporting else 'Anonymous reports temporarily disabled'}}
             </button>
           </div>
           <div class="optional-username centered low">

--- a/webcompat/templates/nav/issue-wizard-stepper.html
+++ b/webcompat/templates/nav/issue-wizard-stepper.html
@@ -1,7 +1,7 @@
 <div id="wizard-container">
     <div class="grid row">
         {% for step in form.steps %}
-            <div id="step-{{ step.number }}" class="step {{ step.className }}">
+            <div id="pr-{{ step.id }}" class="step {{ step.className }}">
                 <div class="circle">
                 <div class="number">{{ step.number }}</div>
                 <div class="icon"></div>


### PR DESCRIPTION
This PR contains a refactored version of the progress tracker + some improvements fixing the following:

1.  Adding a drop shadow https://github.com/webcompat/webcompat.com/issues/2996 and https://github.com/webcompat/webcompat.com/issues/2962
2. Indicate last step in the header https://github.com/webcompat/webcompat.com/issues/3006
3. Confirming browser/device is step 3, not 4 https://github.com/webcompat/webcompat.com/issues/2969
4. Altering the past causes two "current" states in header https://github.com/webcompat/webcompat.com/issues/2968

r? @miketaylr 