### PR TITLE
Fixes #3321 - Converts to pytest and improves coverage

### DIFF
--- a/tests/unit/test_api_urls.py
+++ b/tests/unit/test_api_urls.py
@@ -41,6 +41,11 @@ def mock_api_response(response_config={}):
     # Request headers are case insensitive dicts,
     # so we need to turn our mock headers into one.
     api_response.headers = CaseInsensitiveDict(headers)
+    # We build a json() method for the mock based on the true content.
+    content = response_config.get('content')
+    if content != '[]':
+        attrs = {'json.return_value': json.loads(content)[0]}
+        api_response.configure_mock(**attrs)
     return api_response
 
 

--- a/tests/unit/test_issues.py
+++ b/tests/unit/test_issues.py
@@ -39,12 +39,12 @@ FORM_AUTH['submit_type'] = 'github-auth-report'
 
 
 @pytest.fixture
-def client():
+def setup():
     """Test client for requests."""
     webcompat.app.config['TESTING'] = True
 
 
-def test_report_with_auth_on(client):
+def test_report_with_auth_on(setup):
     """Test that we can still work with github-auth-report."""
     with patch('webcompat.issues.github.post') as json_resp:
         json_resp.return_value = {'number': 2}
@@ -53,7 +53,7 @@ def test_report_with_auth_on(client):
         assert json_data.get('number') == 2
 
 
-def test_report_issue_returns_number(client):
+def test_report_issue_returns_number(setup):
     """Test issue posting report the right json."""
     with patch('webcompat.issues.proxy_request') as github_data:
         github_data.return_value = mock_api_response({
@@ -68,13 +68,13 @@ def test_report_issue_returns_number(client):
             assert json_data.get('number') == 2
 
 
-def test_report_issue_fails_400_for_unknown_type(client):
+def test_report_issue_fails_400_for_unknown_type(setup):
     """Test request fails with a 400 because type unknown."""
     with pytest.raises(BadRequest):
         rv = report_issue(FORM, proxy=True)
 
 
-def test_report_issue_fails_400_for_proxy(client):
+def test_report_issue_fails_400_for_proxy(setup):
     """Test github-proxy-report fails with a 400."""
     with patch('webcompat.issues.proxy_request') as github_data:
         github_data.return_value = mock_api_response({
@@ -85,7 +85,7 @@ def test_report_issue_fails_400_for_proxy(client):
             rv = report_issue(FORM_ANON, proxy=True)
 
 
-def test_report_private_issue_returns_nothing(client):
+def test_report_private_issue_returns_nothing(setup):
     """Test that we get nothing back from a private issue report."""
     with patch('webcompat.issues.proxy_request') as github_data:
         github_data.return_value = mock_api_response({
@@ -96,7 +96,7 @@ def test_report_private_issue_returns_nothing(client):
         assert rv is None
 
 
-def test_report_public_issue_returns_moderation_template(client):
+def test_report_public_issue_returns_moderation_template(setup):
     """Test the data in report_public_issue contains the right data."""
     with patch('webcompat.issues.proxy_request') as req:
         req.return_value = mock_api_response({
@@ -113,7 +113,7 @@ def test_report_public_issue_returns_moderation_template(client):
         assert ['action-needsmoderation'] == post_data['labels']
 
 
-def test_moderation_template(client):
+def test_moderation_template(setup):
     """Check the moderation template structure.
 
     - must be a dictionary
@@ -125,14 +125,14 @@ def test_moderation_template(client):
     assert 'body' in actual.keys()
 
 
-def test_moderation_template_rejected(client):
+def test_moderation_template_rejected(setup):
     """Check the return values are for the rejected case."""
     actual = moderation_template('rejected')
     assert actual['title'] == 'Issue rejected.'
     assert 'Its original content has been deleted' in actual['body']
 
 
-def test_moderation_template_ongoing(client):
+def test_moderation_template_ongoing(setup):
     """Check the return values are for the needsmoderation case."""
     # test the default
     actual = moderation_template()

--- a/tests/unit/test_issues.py
+++ b/tests/unit/test_issues.py
@@ -6,109 +6,143 @@
 
 """Tests for issue creation."""
 
-
 import json
-import requests
-import unittest
+
+import pytest
+from unittest.mock import MagicMock
 from unittest.mock import patch
-from unittest.mock import ANY
-
 from werkzeug.datastructures import MultiDict
+from werkzeug.exceptions import BadRequest
 
+from .test_api_urls import mock_api_response
+import webcompat
 from webcompat import app
+from webcompat.issues import moderation_template
 from webcompat.issues import report_issue
 from webcompat.issues import report_private_issue
 from webcompat.issues import report_public_issue
-from webcompat.issues import moderation_template
+
+FORM = MultiDict([
+    ('browser', 'Firefox 99.0'),
+    ('description', 'sup'),
+    ('details', ''),
+    ('os', 'Mac OS X 13'),
+    ('problem_category', 'unknown_bug'),
+    ('submit_type', ''),
+    ('url', 'http://3139.example.com'),
+    ('username', ''), ])
+
+FORM_ANON = FORM.copy()
+FORM_ANON['submit_type'] = 'github-proxy-report'
+FORM_AUTH = FORM.copy()
+FORM_AUTH['submit_type'] = 'github-auth-report'
 
 
-class TestIssue(unittest.TestCase):
-    """Tests for issue creation."""
+@pytest.fixture
+def client():
+    """Test client for requests."""
+    webcompat.app.config['TESTING'] = True
 
-    def setUp(self):
-        """Set up the tests."""
-        pass
 
-    def tearDown(self):
-        """Tear down the tests."""
-        pass
+def test_report_with_auth_on(client):
+    """Test that we can still work with github-auth-report."""
+    with patch('webcompat.issues.github.post') as json_resp:
+        json_resp.return_value = {'number': 2}
+        json_data = report_issue(FORM_AUTH, proxy=False)
+        assert type(json_data) is dict
+        assert json_data.get('number') == 2
 
-    @patch.object(requests, 'post')
-    def test_report_issue_returns_number(self, mockpost):
-        """Test we can expect an issue number back."""
-        with app.test_request_context():
-            mockpost.return_value.status_code = 201
-            mockpost.return_value.json.return_value = {'number': 2}
-            form = MultiDict([
-                ('browser', 'Firefox 99.0'),
-                ('description', 'sup'),
-                ('details', ''),
-                ('os', 'Mac OS X 13'),
-                ('problem_category', 'unknown_bug'),
-                ('submit_type', 'github-proxy-report'),
-                ('url', 'http://3139.example.com'),
-                ('username', ''), ])
-            rv = report_issue(form, True)
-            self.assertEqual(rv.get('number'), 2)
 
-    @patch.object(requests, 'post')
-    def test_report_private_issue_returns_nothing(self, mockpost):
-        """Test that we get nothing back from a private issue report."""
-        with app.test_request_context():
-            mockpost.return_value.json.return_value = {'number': 2}
-            form = MultiDict([
-                ('browser', 'Firefox 99.0'),
-                ('description', 'sup'),
-                ('details', ''),
-                ('os', 'Mac OS X 13'),
-                ('problem_category', 'unknown_bug'),
-                ('submit_type', 'github-proxy-report'),
-                ('url', 'http://3139.example.com'),
-                ('username', ''), ])
-            rv = report_private_issue(form, 'http://public.example.com')
-            self.assertIsNone(rv)
+def test_report_issue_returns_number(client):
+    """Test issue posting report the right json."""
+    with patch('webcompat.issues.proxy_request') as github_data:
+        github_data.return_value = mock_api_response({
+            'status_code': 201,
+            'content': '[{"number":2}]',
+        })
+        with patch('webcompat.issues.report_private_issue') as silent:
+            # We avoid making a call to report_private_issue
+            silent.return_value = None
+            json_data = report_issue(FORM_ANON, proxy=True)
+            assert type(json_data) is dict
+            assert json_data.get('number') == 2
 
-    @patch.object(requests, 'post')
-    def test_report_public_issue_returns_moderation_template(self, mockpost):
-        """Test the data in report_public_issue contains the right data."""
-        with app.test_request_context():
-            report_public_issue()
-            args, kwargs = mockpost.call_args
-            post_data = json.loads(kwargs['data'])
-            self.assertIs(type(post_data), dict)
-            self.assertIn('title', post_data.keys())
-            self.assertIn('body', post_data.keys())
-            self.assertIn('labels', post_data.keys())
-            self.assertEqual(['action-needsmoderation'], post_data['labels'])
 
-    def test_moderation_template(self):
-        """Check the moderation template structure.
+def test_report_issue_fails_400_for_unknown_type(client):
+    """Test request fails with a 400 because type unknown."""
+    with pytest.raises(BadRequest):
+        rv = report_issue(FORM, proxy=True)
 
-        - must be a dictionary
-        - must contain the keys: title, body
-        """
-        actual = moderation_template('ongoing')
-        self.assertIs(type(actual), dict)
-        self.assertIn('title', actual.keys())
-        self.assertIn('body', actual.keys())
 
-    def test_moderation_template_rejected(self):
-        """Check the return values are for the rejected case."""
-        actual = moderation_template('rejected')
-        self.assertEqual(actual['title'], 'Issue rejected.')
-        self.assertIn('Its original content has been deleted', actual['body'])
+def test_report_issue_fails_400_for_proxy(client):
+    """Test github-proxy-report fails with a 400."""
+    with patch('webcompat.issues.proxy_request') as github_data:
+        github_data.return_value = mock_api_response({
+            'status_code': 400,
+            'content': '[{"number":2}]',
+        })
+        with pytest.raises(BadRequest):
+            rv = report_issue(FORM_ANON, proxy=True)
 
-    def test_moderation_template_ongoing(self):
-        """Check the return values are for the needsmoderation case."""
-        # test the default
-        actual = moderation_template()
-        self.assertEqual(actual['title'], 'In the moderation queue.')
-        self.assertIn('put in the moderation queue.', actual['body'])
-        # test the keyword
-        actual = moderation_template('ongoing')
-        self.assertEqual(actual['title'], 'In the moderation queue.')
-        self.assertIn('put in the moderation queue.', actual['body'])
-        # bad keyword, we go back to the default.
-        actual = moderation_template('punkcat')
-        self.assertEqual(actual['title'], 'In the moderation queue.')
-        self.assertIn('put in the moderation queue.', actual['body'])
+
+def test_report_private_issue_returns_nothing(client):
+    """Test that we get nothing back from a private issue report."""
+    with patch('webcompat.issues.proxy_request') as github_data:
+        github_data.return_value = mock_api_response({
+            'status_code': 400,
+            'content': '[{"number":2}]',
+        })
+        rv = report_private_issue(FORM_ANON, 'http://public.example.com')
+        assert rv is None
+
+
+def test_report_public_issue_returns_moderation_template(client):
+    """Test the data in report_public_issue contains the right data."""
+    with patch('webcompat.issues.proxy_request') as req:
+        req.return_value = mock_api_response({
+            'status_code': 201,
+            'content': '[{"number":2}]',
+        })
+        report_public_issue()
+        args, kwargs = req.call_args
+        post_data = json.loads(kwargs['data'])
+        assert type(post_data) is dict
+        assert 'title' in post_data.keys()
+        assert 'body' in post_data.keys()
+        assert 'labels' in post_data.keys()
+        assert ['action-needsmoderation'] == post_data['labels']
+
+
+def test_moderation_template(client):
+    """Check the moderation template structure.
+
+    - must be a dictionary
+    - must contain the keys: title, body
+    """
+    actual = moderation_template('ongoing')
+    assert type(actual) is dict
+    assert 'title' in actual.keys()
+    assert 'body' in actual.keys()
+
+
+def test_moderation_template_rejected(client):
+    """Check the return values are for the rejected case."""
+    actual = moderation_template('rejected')
+    assert actual['title'] == 'Issue rejected.'
+    assert 'Its original content has been deleted' in actual['body']
+
+
+def test_moderation_template_ongoing(client):
+    """Check the return values are for the needsmoderation case."""
+    # test the default
+    actual = moderation_template()
+    assert actual['title'] == 'In the moderation queue.'
+    assert 'put in the moderation queue.' in actual['body']
+    # test the keyword
+    actual = moderation_template('ongoing')
+    assert actual['title'] == 'In the moderation queue.'
+    assert 'put in the moderation queue.' in actual['body']
+    # bad keyword, we go back to the default.
+    actual = moderation_template('punkcat')
+    assert actual['title'] == 'In the moderation queue.'
+    assert 'put in the moderation queue.' in actual['body']

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -82,7 +82,8 @@ def report_public_issue():
     public_data = moderation_template('ongoing')
     # We add action-needsmoderation label, so reviewers can filter out
     public_data['labels'] = ['action-needsmoderation']
-    return proxy_request('post', path, data=json.dumps(public_data))
+    resp = proxy_request('post', path, data=json.dumps(public_data))
+    return resp.status_code, resp.json()
 
 
 def report_issue(form, proxy=False):
@@ -91,9 +92,8 @@ def report_issue(form, proxy=False):
     path = 'repos/{0}'.format(REPO_URI)
     submit_type = form.get('submit_type')
     if proxy and submit_type == 'github-proxy-report':
-        response = report_public_issue()
-        if (response.status_code == 201):
-            json_response = response.json()
+        status_code, json_response = report_public_issue()
+        if status_code == 201:
             report_private_issue(form, json_response.get('html_url'))
         else:
             abort(400)


### PR DESCRIPTION
This PR fixes issue #3321 

## Proposed PR background

Please provide enough information so that others can review your pull request:

This took a bit more time than I was expecting but I have figured out a couple of things. 
This also should lead to more test organization. I need to open an issue so that we put the mock_api_response outside of test_api_urls.  (probably in conftest.py if I understood well pytest) 

Anyway.

It basically 
1. Converts the test for test_issues.py to pytest
2. Adds missing tests for cases which were not covered in the tests (thanks to coverage for finding them.)
3. Modifies mock_api_response to add `.json()` method for the mocks.


Now we have 100% coverage for the issues.py module. See #3205 for the work to do still.
 
```
(env) ~/code/webcompat.com % COLUMNS=50 coverage report -m                                            
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
…
webcompat/issues.py                       48      0   100%
…
--------------------------------------------------------------------
TOTAL                                   1897    343    82%
```

ok let's see if we stay green or if we broke something.