### PR TITLE
Issue #3315 - Removes type-hunt-from-home from EXTRA_LABELS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -214,7 +214,6 @@ EXTRA_LABELS = [
     'browser-firefox-reality',
     'type-fastclick',
     'type-google',
-    'type-hunt-from-home',
     'type-marfeel',
     'type-media',
     'type-mobify',


### PR DESCRIPTION
Fixes #3315 

Removes `type-hunt-from-home` from `EXTRA_LABELS`