### PR TITLE
Fixes #3330 - separate bundle for modern browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,14 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "bugfixes": true,
+        "modules": false,
+        "targets": {
+          "esmodules": true
+        }
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "yargs": "15.3.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.7",
-    "@babel/preset-env": "^7.8.7",
-    "@babel/register": "^7.8.6",
+    "@babel/core": "^7.10.2",
+    "@babel/preset-env": "^7.10.2",
+    "@babel/register": "^7.10.1",
     "babel-loader": "^8.1.0",
     "css-loader": "^3.5.3",
     "ejs-loader": "^0.3.6",
@@ -99,7 +99,8 @@
     "test:unit-js": "intern config=./webcompat/static/js/lib/wizard/tests/intern.json",
     "test:python": "pip install -e . && pytest",
     "dev": "webpack --config ./webpack/webpack.dev.js --watch",
-    "prod": "webpack --config ./webpack/webpack.prod.js"
+    "prod": "webpack --config ./webpack/webpack.prod.js && npm run prod:es5",
+    "prod:es5": "webpack --config ./webpack/webpack.prod.js --env.es5"
   },
   "husky": {
     "hooks": {

--- a/webcompat/templates/__init__.py
+++ b/webcompat/templates/__init__.py
@@ -25,7 +25,9 @@ def bust_cache(file_path):
     Uses a simple cache_dict to we don't have to hash each file for every
     request. This is kept in-memory so it will be blown away when the app
     is restarted (which is when file changes would have been deployed).
+    Doesn't return hash on development
     """
+
     def get_checksum(file_path):
         try:
             checksum = cache_dict[file_path]
@@ -33,6 +35,9 @@ def bust_cache(file_path):
             checksum = md5_checksum(file_path)
             cache_dict[file_path] = checksum
         return checksum
+
+    if app.config['LOCALHOST']:
+        return file_path
 
     return file_path + '?' + get_checksum(STATIC_PATH + file_path)
 

--- a/webcompat/templates/console-logs.html
+++ b/webcompat/templates/console-logs.html
@@ -27,6 +27,9 @@
 {% endfor %}
 </div>
 
-<script src="{{ url_for('static', filename='dist/console-logs.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/console-logs.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/console-logs.es5.js')|bust_cache }}"></script>
+{%- endif %}
 </body>
 </html>

--- a/webcompat/templates/contributors.html
+++ b/webcompat/templates/contributors.html
@@ -394,5 +394,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
+{%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors.html
+++ b/webcompat/templates/contributors.html
@@ -394,9 +394,5 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
-{%- if config.PRODUCTION or config.STAGING -%}
 <script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
-{%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/build-tools.html
+++ b/webcompat/templates/contributors/build-tools.html
@@ -36,9 +36,9 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+  <script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/diagnose-bug.html
+++ b/webcompat/templates/contributors/diagnose-bug.html
@@ -58,9 +58,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/organize-webcompat-events.html
+++ b/webcompat/templates/contributors/organize-webcompat-events.html
@@ -94,9 +94,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/report-bug.html
+++ b/webcompat/templates/contributors/report-bug.html
@@ -136,9 +136,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/reproduce-bug.html
+++ b/webcompat/templates/contributors/reproduce-bug.html
@@ -114,9 +114,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/site-outreach.html
+++ b/webcompat/templates/contributors/site-outreach.html
@@ -176,9 +176,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/contributors/web-platform-research.html
+++ b/webcompat/templates/contributors/web-platform-research.html
@@ -48,9 +48,8 @@
 </div>
 {% endblock %}
 {%- block extrascripts -%}
+<script type="module" src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
 {%- if config.PRODUCTION or config.STAGING -%}
-<script src="{{ url_for('static', filename='dist/contributors.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/contributors.js') }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/contributors.es5.js')|bust_cache }}"></script>
 {%- endif %}
 {%- endblock %}

--- a/webcompat/templates/index.html
+++ b/webcompat/templates/index.html
@@ -10,10 +10,5 @@
 </main>
 {% endblock %}
 {%- block extrascripts -%}
-{%- if config.PRODUCTION or config.STAGING -%}
 <script src="{{ url_for('static', filename='dist/index.js')|bust_cache }}"></script>
-{%- else -%}
-<script src="{{ url_for('static', filename='dist/index.js') }}"></script>
-
-{%- endif -%}
 {%- endblock %}

--- a/webcompat/templates/index.html
+++ b/webcompat/templates/index.html
@@ -10,5 +10,8 @@
 </main>
 {% endblock %}
 {%- block extrascripts -%}
-<script src="{{ url_for('static', filename='dist/index.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/index.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/index.es5.js')|bust_cache }}"></script>
+{%- endif %}
 {%- endblock %}

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -44,10 +44,6 @@
     </section>
   </main>
 {% endblock %}
-{% block extrascripts %}
-{%- if config.PRODUCTION or config.STAGING -%}
+{% block extrascripts %
 <script src="{{ url_for('static', filename='dist/issue-page.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/issue-page.js') }}"></script>
-{%- endif %}
 {% endblock %}

--- a/webcompat/templates/issue.html
+++ b/webcompat/templates/issue.html
@@ -44,6 +44,9 @@
     </section>
   </main>
 {% endblock %}
-{% block extrascripts %
-<script src="{{ url_for('static', filename='dist/issue-page.js')|bust_cache }}"></script>
+{% block extrascripts %}
+<script type="module" src="{{ url_for('static', filename='dist/issue-page.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/issue-page.es5.js')|bust_cache }}"></script>
+{%- endif %}
 {% endblock %}

--- a/webcompat/templates/issue/issue-labels-sub.jst
+++ b/webcompat/templates/issue/issue-labels-sub.jst
@@ -1,5 +1,5 @@
 <script type="text/template">
-<% _.each(labels, function(label) { %>
+<% _.each(data.labels, function(label) { %>
   <span class="label label-<%= label.remoteName %> js-Label">
     <%= label.name %>
   </span>

--- a/webcompat/templates/issue/issue-labels.jst
+++ b/webcompat/templates/issue/issue-labels.jst
@@ -12,10 +12,10 @@
     <% } %>
   </header>
    <div class="js-Category-list">
-  <% _.each(labels, function(label) { %>
+  <% _.each(data.labels, function(label) { %>
     <span class="label label-<%= label.remoteName %> js-Label">
       <%= label.name %>
     </span>
   <% }); %>
-  </span>
+  </div>
 </script>

--- a/webcompat/templates/issue/issue-milestones-sub.jst
+++ b/webcompat/templates/issue/issue-milestones-sub.jst
@@ -1,5 +1,5 @@
 <script type="text/template">
-<span class="label label-<%= milestone %> js-Milestone">
-  <%= milestone %>
+<span class="label label-<%= data.milestone %> js-Milestone">
+  <%= data.milestone %>
 </span>
 </script>

--- a/webcompat/templates/issue/issue-milestones.jst
+++ b/webcompat/templates/issue/issue-milestones.jst
@@ -12,8 +12,8 @@
     <% } %>
   </header>
    <div class="js-Category-list">
-    <span class="label label-<%= milestoneClass %> js-Milestone">
-      <%= milestone %>
+    <span class="label label-<%= data.milestoneClass %> js-Milestone">
+      <%= data.milestone %>
     </span>
   </span>
 </script>

--- a/webcompat/templates/issue/thanks.jst
+++ b/webcompat/templates/issue/thanks.jst
@@ -3,10 +3,10 @@
   <h4 class="headline-1">Thanks for reporting an issue!</h4>
   <p>You're helping us make the web a better place to work and play. Tell your friends about the bug you just filed:</p>
   <a class="button button-primary button-thanks"
-     href="https://twitter.com/intent/tweet?text=<%- encodeURIComponent("I just filed a bug on the internet:") %>&url=<%- encodeURIComponent("https://webcompat.com/issues/") %><%= number %>&via=webcompat"
+     href="https://twitter.com/intent/tweet?text=<%- encodeURIComponent("I just filed a bug on the internet:") %>&url=<%- encodeURIComponent("https://webcompat.com/issues/") %><%= data.number %>&via=webcompat"
      target="_blank">Share on Twitter</a>
   <a class="button button-primary button-thanks"
-     href="https://facebook.com/sharer/sharer.php?u=<%- encodeURIComponent("https://webcompat.com/issues/") %><%= number %>"
+     href="https://facebook.com/sharer/sharer.php?u=<%- encodeURIComponent("https://webcompat.com/issues/") %><%= data.number %>"
      target="_blank">Share on Facebook</a>
   <p>You can return to this web page at any time to track the progress of this report.</p>
 </section>

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -21,10 +21,12 @@
 <!-- Google Analytics -->
 <script src="{{ url_for('static', filename='dist/ga.js') }}"></script>
 <script async src='https://www.google-analytics.com/analytics.js'></script>
+<script nomodule src="{{ url_for('static', filename='dist/vendor.es5.js')|bust_cache }}"></script>
+<script nomodule src="{{ url_for('static', filename='dist/webcompat.es5.js')|bust_cache }}"></script>
 <!-- End Google Analytics -->
 {% endif -%}
-<script src="{{ url_for('static', filename='dist/vendor.js')|bust_cache }}"></script>
-<script src="{{ url_for('static', filename='dist/webcompat.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/vendor.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/webcompat.js')|bust_cache }}"></script>
 
 {%- if config['LOCALHOST'] %}
 <script src="{{ url_for('get_test_helper',

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -22,15 +22,13 @@
 <script src="{{ url_for('static', filename='dist/ga.js') }}"></script>
 <script async src='https://www.google-analytics.com/analytics.js'></script>
 <!-- End Google Analytics -->
+{% endif -%}
 <script src="{{ url_for('static', filename='dist/vendor.js')|bust_cache }}"></script>
 <script src="{{ url_for('static', filename='dist/webcompat.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/vendor.js') }}"></script>
-<script src="{{ url_for('static', filename='dist/webcompat.js') }}"></script>
+
 {%- if config['LOCALHOST'] %}
 <script src="{{ url_for('get_test_helper',
                          filename='functional/lib/window-helpers.js') }}"></script>
-{% endif -%}
 {% endif -%}
 {%- for category, message in get_flashed_messages(with_categories=True) %}
 <script src="{{ url_for('static', filename='dist/flashed-messages.js') }}"

--- a/webcompat/templates/list-issue.html
+++ b/webcompat/templates/list-issue.html
@@ -40,5 +40,8 @@
 
 {% endblock %}
 {% block extrascripts %}
-<script src="{{ url_for('static', filename='dist/issues-list.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/issues-list.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/issues-list.es5.js')|bust_cache }}"></script>
+{%- endif %}
 {% endblock %}

--- a/webcompat/templates/list-issue.html
+++ b/webcompat/templates/list-issue.html
@@ -40,9 +40,5 @@
 
 {% endblock %}
 {% block extrascripts %}
-{%- if config.PRODUCTION or config.STAGING -%}
 <script src="{{ url_for('static', filename='dist/issues-list.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/issues-list.js') }}"></script>
-{%- endif %}
 {% endblock %}

--- a/webcompat/templates/list-issue/dropdown.jst
+++ b/webcompat/templates/list-issue/dropdown.jst
@@ -1,12 +1,12 @@
 <script type="text/template">
   <button type="button" class="button js-Dropdown-toggle">
-     <span class="js-Dropdown-label"><%= dropdownTitle %></span>
+     <span class="js-Dropdown-label"><%= data.dropdownTitle %></span>
      <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
         <use xlink:href="#svg-chevron-right" />
     </svg>
   </button>
   <ul class="dropdown js-Dropdown-options" aria-hidden="false">
-    <% _.each(dropdownOptions, function(option) { %>
+    <% _.each(data.dropdownOptions, function(option) { %>
     <li class="js-Dropdown-item nav-dropdown-item">
       <a href="#" class="js-Dropdown-link nav-link" data-params="<%= option.params %>">
         <%= option.title %>

--- a/webcompat/templates/list-issue/issuelist-issue.jst
+++ b/webcompat/templates/list-issue/issuelist-issue.jst
@@ -1,6 +1,6 @@
 <script type="text/template">
-<% if (issues.length) { %>
-  <% _.each(issues, function(issue) { %>
+<% if (data.issues.length) { %>
+  <% _.each(data.issues, function(issue) { %>
     <div class="grid-row issue label-<%= issue.stateClass %> js-IssueList">
       <article class="grid-cell x2 issue-description js-issue-desc">
         <a href="/issues/<%= issue.number %>">

--- a/webcompat/templates/new-issue.html
+++ b/webcompat/templates/new-issue.html
@@ -13,11 +13,7 @@
 
 {%- block extrascripts -%}
 
-{%- if config.PRODUCTION or config.STAGING -%}
 <script src="{{ url_for('static', filename='dist/formv2.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/formv2.js') }}"></script>
-{%- endif %}
 
 {% if source and campaign %}
 <script nonce={{nonce}}>

--- a/webcompat/templates/new-issue.html
+++ b/webcompat/templates/new-issue.html
@@ -13,7 +13,10 @@
 
 {%- block extrascripts -%}
 
-<script src="{{ url_for('static', filename='dist/formv2.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/formv2.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/formv2.es5.js')|bust_cache }}"></script>
+{%- endif %}
 
 {% if source and campaign %}
 <script nonce={{nonce}}>

--- a/webcompat/templates/user-activity.html
+++ b/webcompat/templates/user-activity.html
@@ -11,5 +11,9 @@
 </main>
 {% endblock %}
 {% block extrascripts %}
-<script src="{{ url_for('static', filename='dist/user-activity.js')|bust_cache }}"></script>
+<script type="module" src="{{ url_for('static', filename='dist/user-activity.js')|bust_cache }}"></script>
+{%- if config.PRODUCTION or config.STAGING -%}
+<script nomodule src="{{ url_for('static', filename='dist/user-activity.es5.js')|bust_cache }}"></script>
+{%- endif %}
+
 {% endblock %}

--- a/webcompat/templates/user-activity.html
+++ b/webcompat/templates/user-activity.html
@@ -11,9 +11,5 @@
 </main>
 {% endblock %}
 {% block extrascripts %}
-{%- if config.PRODUCTION or config.STAGING -%}
 <script src="{{ url_for('static', filename='dist/user-activity.js')|bust_cache }}"></script>
-{% else %}
-<script src="{{ url_for('static', filename='dist/user-activity.js') }}"></script>
-{%- endif %}
 {% endblock %}

--- a/webcompat/templates/web_modules/issue-list.jst
+++ b/webcompat/templates/web_modules/issue-list.jst
@@ -1,6 +1,6 @@
 <script type="text/template">
-  <% if (issues.length) { %>
-    <% _.each(issues, function(issue) { %>
+  <% if (data.issues.length) { %>
+    <% _.each(data.issues, function(issue) { %>
       <div class="grid-row issue label-<%= issue.stateClass %> js-IssueList">
         <article class="grid-cell x2 issue-description js-issue-desc">
             <a href="/issues/<%= issue.number %>">

--- a/webcompat/templates/web_modules/label-editor.jst
+++ b/webcompat/templates/web_modules/label-editor.jst
@@ -11,7 +11,7 @@
       </button>
     </div>
     <div class="label-editor-list" tabindex="-1">
-      <% _.each(labels, function(label) { %>
+      <% _.each(data.labels, function(label) { %>
         <input class="label-editor-list-item-checkbox"
                 type="checkbox" name="<%= label.name %>"
                 id="label-<%= label.remoteName %>"

--- a/webcompat/templates/web_modules/milestone-editor.jst
+++ b/webcompat/templates/web_modules/milestone-editor.jst
@@ -11,7 +11,7 @@
       </button>
     </div>
     <div class="label-editor-list" tabindex="-1">
-      <% _.each(milestones, function(milestone) { %>
+      <% _.each(data.milestones, function(milestone) { %>
         <input class="label-editor-list-item-checkbox"
                 type="checkbox" name="<%= milestone.name %>"
                 id="milestone-<%= milestone.name %>"

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -28,16 +28,6 @@ module.exports = {
         ],
       },
       {
-        test: /\.js$/,
-        exclude: [
-          /node_modules/,
-          path.resolve(__dirname, "../webcompat/static/js/vendor"),
-        ],
-        use: {
-          loader: "babel-loader",
-        },
-      },
-      {
         test: /\.css$/,
         use: [
           MiniCssExtractPlugin.loader,

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -21,6 +21,9 @@ module.exports = {
           },
           {
             loader: "ejs-loader",
+            options: {
+              variable: "data",
+            },
           },
         ],
       },

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -5,4 +5,15 @@ module.exports = () =>
   webpackMerge(commonConfig, {
     mode: "development",
     devtool: "inline-source-map",
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: [/node_modules/],
+          use: {
+            loader: "babel-loader",
+          },
+        },
+      ],
+    },
   });

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -4,12 +4,43 @@ const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const commonConfig = require("./webpack.common.js");
 const ImageminPlugin = require("imagemin-webpack-plugin").default;
 
-module.exports = () =>
+const isEs5 = (env) => env && env.es5;
+
+// If it's a es5 build, use babel env preset
+// without additional configuration, which means it will transpile
+// everything. If it's not a es5 build, .babelrc config is used
+// (for modern browsers)
+
+const getOptions = (env) => {
+  if (!isEs5(env)) return {};
+
+  return {
+    babelrc: false,
+    presets: ["@babel/env"],
+  };
+};
+
+module.exports = (env) =>
   webpackMerge(commonConfig, {
     mode: "production",
+    output: {
+      filename: isEs5(env) ? "[name].es5.js" : "[name].js",
+    },
     devtool: "source-map",
     optimization: {
       minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
     },
     plugins: [new ImageminPlugin({ test: /\.(jpe?g|png|gif|svg)$/i })],
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: [/node_modules/],
+          use: {
+            loader: "babel-loader",
+            options: getOptions(env),
+          },
+        },
+      ],
+    },
   });


### PR DESCRIPTION
r? @miketaylr 

In this PR I've changed webpack production build script to create two versions of the same script, one for modern browsers and another for browsers that do not support es6.
The files are included in html the following way:
```js
  <script type="module" src="file.js"></script>
  <script nomodule src="file.es5.js"></script>
```
Browsers that do not support `type="module"` will download nomodule version, and browsers that do support it, will download the modern build with less transpiled code and ignore nomodule version.

This is based on the idea from these two blog posts:
https://philipwalton.com/articles/deploying-es2015-code-in-production-today/
https://web.dev/serve-modern-code-to-modern-browsers/