### PR TITLE
Fixes #3334 - Fix for "Thanks for reporting an issue" not showing 

### DIFF
--- a/webcompat/static/js/lib/flashed-messages.js
+++ b/webcompat/static/js/lib/flashed-messages.js
@@ -7,13 +7,19 @@
 // in flash-message.js. See layout.html for how category and message data
 // attributes are set.
 
+import $ from "jquery";
 import { wcEvents } from "./flash-message.js";
 
-var currentScript = document.currentScript;
+const showMessage = (el) => {
+  const category = el.getAttribute("data-category");
+  const message = el.getAttribute("data-message");
+  if (category && message) {
+    wcEvents.trigger("flash:" + category, { message: message, timeout: 4000 });
+  }
+};
 
-if (currentScript) {
-  var category = currentScript.dataset.category || "";
-  var message = currentScript.dataset.message || "";
+const messagesEl = $(".flashed-message");
 
-  wcEvents.trigger("flash:" + category, { message: message, timeout: 4000 });
+if (messagesEl.length) {
+  messagesEl.each((i, el) => showMessage(el));
 }

--- a/webcompat/templates/layout.html
+++ b/webcompat/templates/layout.html
@@ -32,11 +32,9 @@
 <script src="{{ url_for('get_test_helper',
                          filename='functional/lib/window-helpers.js') }}"></script>
 {% endif -%}
-{%- for category, message in get_flashed_messages(with_categories=True) %}
-<script src="{{ url_for('static', filename='dist/flashed-messages.js') }}"
-        data-category="{{ category }}"
-        data-message="{{ message }}"></script>
-{% endfor -%}
+
+{% include "shared/flashed-messages.html" %}
+
 {% block extrascripts %}{% endblock %}
 </body>
 </html>

--- a/webcompat/templates/shared/flashed-messages.html
+++ b/webcompat/templates/shared/flashed-messages.html
@@ -1,0 +1,14 @@
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    {% for category, message in messages %}
+      <div class="flashed-message"
+           data-category="{{ category }}"
+           data-message="{{ message }}">
+      </div>
+    {% endfor %}
+    <script type="module" src="{{ url_for('static', filename='dist/flashed-messages.js')|bust_cache }}"></script>
+    {%- if config.PRODUCTION or config.STAGING -%}
+      <script nomodule src="{{ url_for('static', filename='dist/flashed-messages.e5.js')|bust_cache }}"></script>
+    {% endif -%}
+  {% endif %}
+{% endwith %}


### PR DESCRIPTION
Seems that `document.currentScript` is null with the way webpack loads `flashed-messages.js`, and also currentScript it's not available for es6 modules https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript . I've changed the script a bit, so it'll work with both modern and legacy bundles

r? @miketaylr 