### PR TITLE
fixes #3368 - adds .coverage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ nohup.out
 
 # tests
 .noseids
+.coverage


### PR DESCRIPTION
This PR fixes issue #3368

## Proposed PR background

simple fix to be sure to not make mistake when using coverage for checking test coverage.
