### PR TITLE
fix #3360 - creates controled values list for reported_with

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -223,6 +223,17 @@ EXTRA_LABELS = [
     'type-webvr',
 ]
 
+# List of accepted values for browser sources.
+REPORTED_WITH = [
+    "addon-reporter-chrome",
+    "addon-reporter-firefox-mobile",
+    "addon-reporter-firefox",
+    "addon-reporter-opera",
+    "desktop-reporter",
+    "mobile-reporter",
+    "web-fxr",
+]
+
 # Get AB experiment variation values from the environement.
 AB_VARIATIONS = {
     'V1_VARIATION': os.environ.get('V1_VARIATION', '0 100'),

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -120,13 +120,15 @@ class TestForm(unittest.TestCase):
         """Check we return the right form with the appropriate data."""
         with webcompat.app.test_request_context('/issues/new'):
             form_data = {'user_agent': FIREFOX_UA,
-                         'url': 'http://example.net/'}
+                         'url': 'http://example.net/',
+                         'src': 'desktop-reporter'}
             actual = form.get_form(form_data)
             expected_browser = 'Firefox 48.0'
             expected_os = 'Mac OS X 10.11'
             self.assertIsInstance(actual, form.IssueForm)
             self.assertEqual(actual.browser.data, expected_browser)
             self.assertEqual(actual.os.data, expected_os)
+            self.assertEqual(actual.reported_with.data, 'desktop-reporter')
 
     def test_get_metadata(self):
         """HTML comments need the right values depending on the keys."""

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -6,6 +6,7 @@
 import json
 import unittest
 
+import pytest
 from werkzeug.datastructures import MultiDict
 
 import webcompat
@@ -319,6 +320,19 @@ class TestForm(unittest.TestCase):
                     url='http://testing.example.org',
                     username='yeeha'))
             self.assertEqual(rv.status_code, 400)
+
+
+@pytest.mark.parametrize(
+    'test_input,expected',
+    [({}, 'web'),
+     ({'src': ''}, 'unknown'),
+     ({'src': 'punkCat'}, 'unknown'),
+     ({'src': 'mobile-reporter'}, 'mobile-reporter'),
+     ]
+)
+def test_report_source(test_input, expected):
+    """Extract the reporting source when valid and invalid."""
+    assert form.extract_report_source(test_input) == expected
 
 
 if __name__ == '__main__':

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -294,7 +294,7 @@ def get_form(form_data, form=IssueForm):
     bug_form.details.data = json.dumps(form_data.get('details'), indent=2)
     bug_form.extra_labels = form_data.get('extra_labels', None)
     bug_form.os.data = get_os(ua_header)
-    bug_form.reported_with.data = form_data.get('src', 'web')
+    bug_form.reported_with.data = extract_report_source(form_data)
     bug_form.ua_header.data = ua_header
     bug_form.url.data = form_data.get('url', None)
     return bug_form
@@ -441,6 +441,28 @@ def add_metadata(form, metadata_dict):
     """
     form['extra_metadata'] = metadata_dict
     return form
+
+
+def extract_report_source(form_data):
+    """Extract the source of report.
+
+    This also controls if the src argument is part of a known list.
+    """
+    reported_with = 'unknown'
+    try:
+        reported_with = form_data['src']
+        if not is_valid_source(reported_with):
+            reported_with = 'unknown'
+    except KeyError:
+        reported_with = 'web'
+    return reported_with
+
+
+def is_valid_source(reported_with):
+    """Only a known subset of known values are accepted."""
+    if reported_with in app.config['REPORTED_WITH']:
+        return True
+    return False
 
 
 def build_formdata(form_object):


### PR DESCRIPTION
fix #3360 
fix #3359

## Proposed PR background


```
issue #3360 - adds list of reported_with values
e48e2e7

This makes a controled list of accepted values for the parameter reported_with which is added to the body of the bug report.

The reports which are out of this list will be either web (default) or unknown.

Ultimately we will move this list and a couple of others outside of the committed code but still loaded by the config file. So we can have more flexibility when it's time to add or retire a value without having to merge a pull request.

issue #3360 - adds a test for reported_with
037fd68

We were not testing that we were getting the value we needed when it exists.

Issue #3360 - Adds control for reported_with
22c964c

This makes a couple of modifications

1. It uses a list of controled values coming from the config file.
2. it makes sure the extracted value is part of the controled list
3. It also records when the value is not known aka not part of the controled list. This is important to not screw the stats for the Web values AND to understand when there is a new client.

It creates the tests associated with the function.

Probably we need to convert test_form.py fully to pytest, but that should be done in another PR to not muddy this one.

```