### PR TITLE
Fixes #3291 - Make issue moderation slightly more efficient

### DIFF
--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -71,10 +71,8 @@ def extract_browser_label(metadata_dict):
             if 'tablet' in remainder:
                 browser_type = 'tablet'
             if browser_type:
-                dash_browser = '{dash_browser}-{browser_type}'.format(
-                    dash_browser=dash_browser,
-                    browser_type=browser_type)
-    return 'browser-{name}'.format(name=dash_browser)
+                dash_browser = f'{dash_browser}-{browser_type}'
+    return f'browser-{dash_browser}'
 
 
 def extract_extra_labels(metadata_dict):
@@ -95,7 +93,7 @@ def extract_priority_label(body):
         priorities = ['critical', 'important', 'normal']
         # Find host_name in DB
         for site in site_db.query(Site).filter_by(url=hostname):
-            return 'priority-{}'.format(priorities[site.priority - 1])
+            return f'priority-{priorities[site.priority - 1]}'
         # No host_name in DB, find less-level domain (>2)
         # If host_name is lv4.lv3.example.com, find lv3.example.com/example.com
         subparts = hostname.split('.')
@@ -104,7 +102,7 @@ def extract_priority_label(body):
                    if 0 < i < hostname.count('.')]
         for domain in domains:
             for site in site_db.query(Site).filter_by(url=domain):
-                return 'priority-{}'.format(priorities[site.priority - 1])
+                return f'priority-{priorities[site.priority - 1]}'
     return None
 
 
@@ -231,7 +229,7 @@ def tag_new_public_issue(issue_info):
     labels.extend(issue_info['original_labels'])
     milestone = app.config['STATUSES']['needstriage']['id']
     # Preparing the proxy request
-    path = 'repos/{0}/{1}'.format(PUBLIC_REPO, issue_number)
+    path = f'repos/{PUBLIC_REPO}/{issue_number}'
     payload_request = {'labels': labels, 'milestone': milestone}
     proxy_response = make_request('patch', path, payload_request)
     return proxy_response
@@ -324,7 +322,7 @@ def msg_log(msg, issue_number):
     """Write a log with the reason and the issue number."""
     log = app.logger
     log.setLevel(logging.INFO)
-    msg = 'issue {issue} {msg}'.format(issue=issue_number, msg=msg)
+    msg = f'issue {issue_number} {msg}'
     log.info(msg)
 
 
@@ -376,7 +374,7 @@ def private_issue_moderation(issue_info):
     payload_request = prepare_accepted_issue(issue_info)
     public_number = get_public_issue_number(issue_info['public_url'])
     # Preparing the proxy request
-    path = 'repos/{0}/{1}'.format(PUBLIC_REPO, public_number)
+    path = f'repos/{PUBLIC_REPO}/{public_number}'
     proxy_response = make_request('patch', path, payload_request)
     return proxy_response
 
@@ -386,7 +384,7 @@ def private_issue_rejected(issue_info):
     payload_request = prepare_rejected_issue()
     public_number = get_public_issue_number(issue_info['public_url'])
     # Preparing the proxy request
-    path = 'repos/{0}/{1}'.format(PUBLIC_REPO, public_number)
+    path = f'repos/{PUBLIC_REPO}/{public_number}'
     proxy_response = make_request('patch', path, payload_request)
     return proxy_response
 
@@ -420,12 +418,9 @@ def comment_public_uri(issue_info):
     public_url = issue_info['public_url']
     public_number = get_public_issue_number(public_url)
     # prepare the payload
-    comment_body = '[Original issue {nb}]({url})'.format(
-        nb=public_number,
-        url=public_url
-    )
+    comment_body = f'[Original issue {public_number}]({public_url})'
     payload = {'body': comment_body}
     # Preparing the proxy request
-    path = 'repos/{0}/{1}/comments'.format(PRIVATE_REPO, number)
+    path = f'repos/{PRIVATE_REPO}/{number}/comments'
     proxy_response = make_request('post', path, payload)
     return proxy_response

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -278,6 +278,7 @@ def process_issue_action(issue_info):
         # private issue have been moderated and we will make it public
         response = private_issue_moderation(issue_info)
         if response.status_code == 200:
+            # if it succeeded, we can close the private issue
             return ('Moderated issue accepted',
                     200, {'Content-Type': 'text/plain'})
         else:

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -281,6 +281,8 @@ def process_issue_action(issue_info):
         response = private_issue_moderation(issue_info)
         if response.status_code == 200:
             # if it succeeded, we can close the private issue
+            path = f'repos/{PRIVATE_REPO}/{issue_info["number"]}'
+            make_request('patch', path, {'state': 'closed'})
             return ('Moderated issue accepted',
                     200, {'Content-Type': 'text/plain'})
         else:

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -198,6 +198,13 @@ def get_issue_labels(issue_body):
     return labelslist
 
 
+def make_request(method, path, payload_request):
+    """Helper method to wrap webcompat.helpers.proxy_request."""
+    headers = {'Authorization': f'token {app.config["OAUTH_TOKEN"]}'}
+    return proxy_request(method, path, headers=headers, data=json.dumps(
+        payload_request))
+
+
 def tag_new_public_issue(issue_info):
     """Set the core actions on new opened issues.
 
@@ -224,14 +231,9 @@ def tag_new_public_issue(issue_info):
     labels.extend(issue_info['original_labels'])
     milestone = app.config['STATUSES']['needstriage']['id']
     # Preparing the proxy request
-    headers = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])}
     path = 'repos/{0}/{1}'.format(PUBLIC_REPO, issue_number)
     payload_request = {'labels': labels, 'milestone': milestone}
-    proxy_response = proxy_request(
-        'patch',
-        path,
-        headers=headers,
-        data=json.dumps(payload_request))
+    proxy_response = make_request('patch', path, payload_request)
     return proxy_response
 
 
@@ -372,13 +374,8 @@ def private_issue_moderation(issue_info):
     payload_request = prepare_accepted_issue(issue_info)
     public_number = get_public_issue_number(issue_info['public_url'])
     # Preparing the proxy request
-    headers = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])}
     path = 'repos/{0}/{1}'.format(PUBLIC_REPO, public_number)
-    proxy_response = proxy_request(
-        method='patch',
-        path=path,
-        headers=headers,
-        data=json.dumps(payload_request))
+    proxy_response = make_request('patch', path, payload_request)
     return proxy_response
 
 
@@ -387,13 +384,8 @@ def private_issue_rejected(issue_info):
     payload_request = prepare_rejected_issue()
     public_number = get_public_issue_number(issue_info['public_url'])
     # Preparing the proxy request
-    headers = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])}
     path = 'repos/{0}/{1}'.format(PUBLIC_REPO, public_number)
-    proxy_response = proxy_request(
-        method='patch',
-        path=path,
-        headers=headers,
-        data=json.dumps(payload_request))
+    proxy_response = make_request('patch', path, payload_request)
     return proxy_response
 
 
@@ -432,11 +424,6 @@ def comment_public_uri(issue_info):
     )
     payload = {'body': comment_body}
     # Preparing the proxy request
-    headers = {'Authorization': 'token {0}'.format(app.config['OAUTH_TOKEN'])}
     path = 'repos/{0}/{1}/comments'.format(PRIVATE_REPO, number)
-    proxy_response = proxy_request(
-        method='post',
-        path=path,
-        headers=headers,
-        data=json.dumps(payload))
+    proxy_response = make_request('post', path, payload)
     return proxy_response


### PR DESCRIPTION
@karlcow this is still WIP, I'd like to do 2 things:

1. close an accepted issue automatically (what these patches do)
2. create a few milestones like "accepted - invalid" and "accepted - incomplete" that will make an issue public, but close it and stick it in the corresponding milestone (not yet tackled)

Do you have any suggestions for testing part 1? I'm not sure if it's useful to mock the entire github interaction "github will tell me it's closed => assert is closed". Thoughts?