### PR TITLE
Fixes #3398 - Add analytics event and vurtual page view tracking

### DIFF
--- a/webcompat/static/js/lib/issue-wizard-popup.js
+++ b/webcompat/static/js/lib/issue-wizard-popup.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import $ from "jquery";
+import { sendAnalyticsEvent } from "./wizard/analytics.js";
 
 function Popup() {
   this.init = function () {
@@ -20,6 +21,7 @@ function Popup() {
     modalTriggers.forEach(function (trigger) {
       trigger.addEventListener("click", function (e) {
         e.preventDefault();
+        sendAnalyticsEvent("whatIsCompat", "click");
         var popupTrigger = trigger.dataset.popupTrigger;
         var popupModal = document.querySelector(
           '[data-popup-modal="'.concat(popupTrigger, '"]')

--- a/webcompat/static/js/lib/wizard/analytics.js
+++ b/webcompat/static/js/lib/wizard/analytics.js
@@ -2,8 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const sendAnalytics = (data) => {
+export const sendAnalyticsCS = (campaign, source) => {
+  if (window.ga && campaign && source) {
+    ga("set", {
+      campaignName: campaign,
+      campaignSource: source,
+    });
+  }
+};
+
+const sendAnalyticsVpv = (label) => {
+  ga("set", "page", `/vpv-${label}`);
+  ga("send", "pageview");
+};
+
+export const sendAnalyticsEvent = (label, action = "step") => {
   if (window.ga) {
-    ga("set", data);
+    ga("send", "event", {
+      eventCategory: "wizard",
+      eventAction: action,
+      eventLabel: label,
+    });
+
+    sendAnalyticsVpv(label);
   }
 };

--- a/webcompat/static/js/lib/wizard/helpers/postMessageParser.js
+++ b/webcompat/static/js/lib/wizard/helpers/postMessageParser.js
@@ -5,21 +5,12 @@
 import notify from "../notify.js";
 import { isSelfReport, convertToDataURI } from "../utils.js";
 import { blobOrFileTypeValid, isImageDataURIValid } from "../validation.js";
-import { sendAnalytics } from "../analytics.js";
+import { sendAnalyticsCS } from "../analytics.js";
 
 const updateStep = (id, data) => notify.publish("updateStep", { id, data });
 const updateUrl = (url) => updateStep("url", { url });
 const updateHidden = (data) => updateStep("hidden", { data });
 const updateScreenshot = (dataURI) => updateStep("screenshot", { dataURI });
-
-const setAnalytics = (campaign, source) => {
-  if (campaign && source) {
-    sendAnalytics({
-      campaignName: campaign,
-      campaignSource: source,
-    });
-  }
-};
 
 const handleMessage = (message) => {
   if (!message) return;
@@ -27,7 +18,7 @@ const handleMessage = (message) => {
 
   updateUrl(url);
   updateHidden(additional);
-  setAnalytics(utm_campaign, utm_source);
+  sendAnalyticsCS(utm_campaign, utm_source);
 };
 
 const handleScreenshot = (screenshot) => {

--- a/webcompat/static/js/lib/wizard/stepper.js
+++ b/webcompat/static/js/lib/wizard/stepper.js
@@ -4,6 +4,7 @@
 
 import notify from "./notify.js";
 import { STEPS } from "./steps/index.js";
+import { sendAnalyticsEvent } from "./analytics.js";
 
 const hideStep = (id) => {
   STEPS[id].module.hide();
@@ -13,6 +14,7 @@ const showStep = (message) => {
   const { id, data } = message;
   const step = STEPS[id];
   step.module.show(data);
+  sendAnalyticsEvent(id);
 };
 
 const updateStep = (message) => {

--- a/webcompat/static/js/lib/wizard/steps/submit.js
+++ b/webcompat/static/js/lib/wizard/steps/submit.js
@@ -12,6 +12,7 @@ import { isGithubUserNameValid } from "../validation.js";
 import { uploadConsoleLogs } from "./upload-helper/console-logs-upload.js";
 import { uploadImage } from "./upload-helper/image-upload.js";
 import { showError, hideError } from "../ui-utils.js";
+import { sendAnalyticsEvent } from "../analytics.js";
 
 const GITHUB_USERNAME_ERROR =
   "GitHub nicknames are 39 characters max, alphanumeric and hyphens only.";
@@ -51,6 +52,8 @@ const enableSubmits = () => {
 const submitForm = function () {
   const dfd = $.Deferred();
   const formEl = form.get(0);
+
+  sendAnalyticsEvent("success", "end");
 
   formEl.submit();
   dfd.resolve();

--- a/webcompat/static/js/lib/wizard/steps/url.js
+++ b/webcompat/static/js/lib/wizard/steps/url.js
@@ -10,6 +10,7 @@ import notify from "../notify.js";
 import { isUrlValid } from "../validation.js";
 import { extractPrettyUrl } from "../utils.js";
 import { showError, showSuccess, hideSuccess } from "../ui-utils.js";
+import { sendAnalyticsEvent } from "../analytics.js";
 
 const urlField = $("#url");
 const nextStepButton = $(".next-url");
@@ -42,11 +43,15 @@ const onBlur = (value) => {
   handleEvent(value, () => showError(urlField, "A valid URL is required."));
 };
 
-urlField.on("input", (event) => onChange(event.target.value));
-urlField.on("blur", (event) => onBlur(event.target.value));
-nextStepButton.on("click", onClick);
+const initListeners = () => {
+  urlField.on("input", (event) => onChange(event.target.value));
+  urlField.on("blur", (event) => onBlur(event.target.value));
+  nextStepButton.on("click", onClick);
+  urlField.trigger("input");
+};
 
-urlField.trigger("input");
+initListeners();
+sendAnalyticsEvent("url", "start");
 
 export default {
   update: ({ url }) => {


### PR DESCRIPTION
I've added two types of analytics:

1) Events tracking 
we used to have this before, but with different labels

2) Virtual page views 
each step is a "virtual page", this type allows to set goal (in our case issue submission) and get funnel report.

An example of a funnel report:
![image](https://user-images.githubusercontent.com/1303908/87816565-8ba6ae80-c835-11ea-8158-900375d1ba70.png)

These two types pretty much track the same actions, but the funnel report is easier to analyze. As far as I understand, it's not possible to create a funnel report with events, so I've added virtual page views for now.

r? @miketaylr 
