### PR TITLE
Fixes #3401 - Unbreak bust_cache

### DIFF
--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -139,7 +139,7 @@ def test_bust_cache_localhost():
 
 def test_bust_cache_production_missing_file():
     """Test for cache_bust the path is missing."""
-    expected = '/punkcat/nowhere?missing_file'
+    expected = 'punkcat/nowhere?missing_file'
     webcompat.app.config['LOCALHOST'] = None
     assert bust_cache('/punkcat/nowhere') == expected
 

--- a/webcompat/templates/__init__.py
+++ b/webcompat/templates/__init__.py
@@ -30,6 +30,8 @@ def bust_cache(file_path):
     """
     if app.config['LOCALHOST']:
         return file_path
+    if file_path.startswith('/'):
+        file_path = file_path[1:]
     absolute_path = os.path.join(STATIC_PATH, file_path)
     return file_path + '?' + get_checksum(absolute_path)
 
@@ -41,6 +43,7 @@ def get_checksum(file_path):
     except KeyError:
         checksum = md5_checksum(file_path)
         cache_dict[str(file_path)] = checksum
+        print('GET_CHECKSUM (after cache miss)', cache_dict)
     return checksum
 
 


### PR DESCRIPTION
We unintentionally regressed behavior for non-LOCALHOST envs in https://github.com/webcompat/webcompat.com/pull/3355

This is sort of a bandaid to get it working - reverting a line in `bust_cache` and getting the one failing test to pass.

If we think the previous absolute path behavior is better, we need to update staging and production STATIC_PATH and do some testing, I think.