### PR TITLE
Fixes #3401 - Don't modify the file_path inside bust_cache

### DIFF
--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -139,9 +139,11 @@ def test_bust_cache_localhost():
 
 def test_bust_cache_production_missing_file():
     """Test for cache_bust the path is missing."""
-    expected = 'punkcat/nowhere?missing_file'
+    expected = '/punkcat/nowhere?missing_file'
+    expected2 = 'punkcat/nowhere?missing_file'
     webcompat.app.config['LOCALHOST'] = None
     assert bust_cache('/punkcat/nowhere') == expected
+    assert bust_cache('punkcat/nowhere') == expected2
 
 
 def test_bust_cache_production_file_exists(tmpdir):
@@ -151,4 +153,6 @@ def test_bust_cache_production_file_exists(tmpdir):
     file_path = tmpdir.join('space.js')
     file_path.write_text('punkcat', encoding='utf-8')
     expected = 'space.js' + '?501753e94c8bfbbbd53c792c9688c8b5'
+    expected2 = '/space.js' + '?501753e94c8bfbbbd53c792c9688c8b5'
     assert bust_cache('space.js') == expected
+    assert bust_cache('/space.js') == expected2

--- a/webcompat/templates/__init__.py
+++ b/webcompat/templates/__init__.py
@@ -30,9 +30,10 @@ def bust_cache(file_path):
     """
     if app.config['LOCALHOST']:
         return file_path
+    trimmed_file_path = file_path
     if file_path.startswith('/'):
-        file_path = file_path[1:]
-    absolute_path = os.path.join(STATIC_PATH, file_path)
+        trimmed_file_path = file_path[1:]
+    absolute_path = os.path.join(STATIC_PATH, trimmed_file_path)
     return file_path + '?' + get_checksum(absolute_path)
 
 


### PR DESCRIPTION
Actually fixes it this time. 

(Modifying the file_path var had bad consequences for some of the files, they could end up as 404)

![Screen Shot 2020-07-20 at 5 00 06 PM](https://user-images.githubusercontent.com/67283/87992921-e139c000-caae-11ea-97ee-0e0a64e75c46.png)


r? @ksy36 