### PR TITLE
Fixes #3408 - Remove active `exp` experiment (that was no longer active)

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -248,15 +248,8 @@ AB_DEFAULTS = {
 EXP_MAX_AGE = int(os.environ.get('EXP_MAX_AGE', 0))
 
 # AB testing config
-AB_EXPERIMENTS = {
-    'exp': {
-        'variations': {
-            'v1': get_variation('V1_VARIATION', AB_VARIATIONS, AB_DEFAULTS),
-            'v2': get_variation('V2_VARIATION', AB_VARIATIONS, AB_DEFAULTS),
-        },
-        'max-age': EXP_MAX_AGE
-    }
-}
+# See /docs/ab-testing.md for configuration instructions
+AB_EXPERIMENTS = {}
 
 
 from webcompat import app  # noqa

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -347,6 +347,14 @@ class TestHelpers(unittest.TestCase):
                 method='GET',
                 environ_base={'HTTP_COOKIE': cookie}):
 
+            webcompat.app.config['AB_EXPERIMENTS'] = {
+                'exp': {
+                    'variations': {
+                        'ui-change-v1': (0, 100)
+                    },
+                    'max-age': 86400
+                }
+            }
             webcompat.app.preprocess_request()
 
             self.assertEqual(ab_active('exp'), 'ui-change-v1')


### PR DESCRIPTION
I also updated the test to preload the configuration -- it was relying on that configuration being active.

r? @karlcow 