### PR TITLE
fix #3425 - Adds a pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# configuration file for pytest
+[pytest]
+testpaths = tests/unit


### PR DESCRIPTION
This PR fixes issue #3425

## Proposed PR background

without this pytest takes a lot of times to scan and discover the tests.
This will speed up when we just type pytest.
It might also accelerate CircleCi. 
