### PR TITLE
Fix #3440 - Add browser-android-components to EXTRA_LABELS

### DIFF
--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -21,7 +21,8 @@ from webcompat.helpers import to_bytes
 from webcompat.issues import moderation_template
 
 BROWSERS = ['blackberry', 'brave', 'chrome', 'edge', 'firefox', 'iceweasel', 'ie', 'lynx', 'myie', 'opera', 'puffin', 'qq', 'safari', 'samsung', 'seamonkey', 'uc', 'vivaldi']  # noqa
-MOZILLA_BROWSERS = ['browser-fenix',
+MOZILLA_BROWSERS = ['browser-android-components',
+                    'browser-fenix',
                     'browser-firefox',
                     'browser-firefox-mobile',
                     'browser-firefox-reality',


### PR DESCRIPTION
This PR fixes #3440

## Proposed PR background

In [bug 1645844](https://bugzilla.mozilla.org/show_bug.cgi?id=1645844), we added the ability to provide a customized `browser-XXX` label for android-components based product. If no label like `browser-fenix` is provided, `browser-android-components` will be the default. 

r? @karlcow 