### PR TITLE
Issue #3440 - Actually add browser-android-components to EXTRA_LABELS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -209,6 +209,7 @@ for cat_label in cat_labels:
 # labels that we allow to be added via a `label` GET param, when
 # creating an issue.
 EXTRA_LABELS = [
+    'browser-android-components',
     'browser-fenix',
     'browser-focus-geckoview',
     'browser-firefox-reality',


### PR DESCRIPTION
This PR fixes #3440, again

## Proposed PR background

The earlier commit added it to `MOZILLA_BROWSERS`, which was correct, but I forgot to actually add it to `EXTRA_LABELS` as well (I actually just forgot to `git add` that file). I realized that during local testing, so, uh, follow-up PR.

r? @karlcow 