### PR TITLE
Fixes #3422 - Improve color contrast for disabled buttons

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -514,7 +514,9 @@
 }
 
 .button:disabled {
-  opacity: .5;
+  color: var(--button-disabled-color);
+  cursor: not-allowed;
+  opacity: .6;
 }
 
 .spaced-link {

--- a/webcompat/static/css/src/variables.css
+++ b/webcompat/static/css/src/variables.css
@@ -18,6 +18,7 @@
   --unit-modul-s: calc(1 / 3 * var(--unit-modul-l) - var(--unit-space)); /* x1 grid unit */
   --button-primary-padding: 12px 23px;
   --button-thanks-padding: 7px 10px;
+  --button-disabled-color: #000;
   --color-bg-page: rgba(250, 250, 250, 1); /* #fafafa; */
   --color-bg-box: rgba(255, 255, 255, 1); /* #ffffff */
   --color-bg-comment-header: rgba(245, 245, 245, 1); /* #f5f5f5 */


### PR DESCRIPTION
Also, show the not-allowed cursor to make it more obvious.
(I got that idea from https://medium.com/@sean_1138/a11y-tips-disabled-buttons-and-colour-contrast-f8824d5e9610)