### PR TITLE
fix #3448 - removes `git add` in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,12 +93,10 @@
   },
   "lint-staged": {
     "*.js": [
-      "npx eslint ./webpack ./tests ./webcompat/static/js/lib postcss.config.js",
-      "git add"
+      "npx eslint ./webpack ./tests ./webcompat/static/js/lib postcss.config.js"
     ],
     "*.css": [
-      "npx stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css'",
-      "git add"
+      "npx stylelint './webcompat/static/css/src/**/*.css' './webcompat/static/css/webcompat.dev.css'"
     ]
   },
   "license": "MPL-2.0"


### PR DESCRIPTION
fix #3448 

## Proposed PR background

The git add is now automatically included in lint-staged.
See https://github.com/okonet/lint-staged#v10