### PR TITLE
Issue #3491 - Remove unused yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "cssrecipes-reset": "^0.5.0",
     "cssrecipes-utils": "^0.6.2",
     "suitcss-utils-align": "^1.0.0",
-    "suitcss-utils-display": "^1.0.2",
-    "yargs": "16.0.3"
+    "suitcss-utils-display": "^1.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
We used yargs here:

https://github.com/webcompat/webcompat.com/commit/52afe464d8abf7a37be3845a840291abb10235da

But that no longer exists.

r? @magsout 