### PR TITLE
Fixes #2859 - Remove addon link for mobile Firefox users

### DIFF
--- a/tests/unit/test_rendering.py
+++ b/tests/unit/test_rendering.py
@@ -19,9 +19,6 @@ BROWSERS = {
     'firefox': (
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/61.0',  # noqa
         b'<span class="link-text">Download Firefox Add-on</span>'),
-    'firefox_mob': (
-        'Mozilla/5.0 (Android; Mobile; rv:61.0) Gecko/61.0 Firefox/61.0',
-        b'<span class="link-text">Download Firefox Add-on</span>'),
     'opera': (
         'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Safari/537.36 OPR/15.0.1147.100',  # noqa
         b'<span class="link-text">Download Opera Add-on</span>'),

--- a/webcompat/templates/nav/addon-links.html
+++ b/webcompat/templates/nav/addon-links.html
@@ -2,17 +2,7 @@
     {%- if browser == 'firefox' %}
     <li class="nav-item">
         <a class="nav-link js-addon-link" href="https://addons.mozilla.org/firefox/addon/webcompatcom-reporter/"
-           title="Navigate to Firefox Add-on store">
-            <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
-                <use xlink:href="#svg-download2" />
-            </svg>
-            <span class="link-text">Download Firefox Add-on</span>
-        </a>
-    </li>
-    {%- elif browser == 'firefox mobile' -%}
-    <li class="nav-item">
-        <a class="nav-link js-addon-link" href="https://addons.mozilla.org/android/addon/webcompatcom-mobile-reporter/"
-           title="Navigate to Firefox Add-on store">
+            title="Navigate to Firefox Add-on store">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
                 <use xlink:href="#svg-download2" />
             </svg>
@@ -21,8 +11,9 @@
     </li>
     {%- elif browser == 'chrome' -%}
     <li class="nav-item">
-        <a class="nav-link js-addon-link" href="https://chrome.google.com/webstore/detail/webcompatcom-reporter/ffnnhckjcpbbjlmgfjigknkoffakclol"
-           title="Navigate to Chrome webstore">
+        <a class="nav-link js-addon-link"
+            href="https://chrome.google.com/webstore/detail/webcompatcom-reporter/ffnnhckjcpbbjlmgfjigknkoffakclol"
+            title="Navigate to Chrome webstore">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation" aria-hidden="true">
                 <use xlink:href="#svg-download2" />
             </svg>
@@ -32,7 +23,7 @@
     {%- elif browser == 'opera' -%}
     <li class="nav-item">
         <a class="nav-link js-addon-link" href="https://addons.opera.com/extensions/details/webcompatcom-reporter/"
-           title="Navigate to Opera Add-ons">
+            title="Navigate to Opera Add-ons">
             <svg class="icon nav-icon" viewBox="0 0 30 30" role="presentation">
                 <use xlink:href="#svg-download2" />
             </svg>
@@ -41,7 +32,8 @@
     </li>
     {%- else -%}
     <li class="nav-item">
-        <a class="nav-link" href="https://github.com/webcompat/webcompat.com/issues?state=open" title="Navigate to GitHub issues">
+        <a class="nav-link" href="https://github.com/webcompat/webcompat.com/issues?state=open"
+            title="Navigate to GitHub issues">
             <span class="link-text">Give Feedback</span>
         </a>
     </li>


### PR DESCRIPTION
Fennec is basically EOL, and Fenix doesn't yet support arbitrary
addons in the release channel (as far as I know...). So let's just
remove the prompt for mobile users entirely, rather than parse the
UA version and offer the addono for whatever existing Fennec users
there are.


