### PR TITLE
Fixes #3374: Adds a link to the github issue that will point to the outreach generator

### DIFF
--- a/tests/fixtures/webhooks/public_milestone_needscontact.json
+++ b/tests/fixtures/webhooks/public_milestone_needscontact.json
@@ -1,0 +1,49 @@
+{
+  "action": "milestoned",
+  "issue": {
+    "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598",
+    "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+    "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/labels{/name}",
+    "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/comments",
+    "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/events",
+    "html_url": "https://github.com/webcompat/webcompat-tests/issues/2598",
+    "id": 735747598,
+    "node_id": "MDU6SXNzdWU3MzU3NDc1OTg=",
+    "number": 2598,
+    "title": "bugzilla.mozilla.org - see bug description",
+    "state": "open",
+    "locked": false,
+    "assignee": null,
+    "assignees": [
+
+    ],
+    "milestone": {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/3",
+      "html_url": "https://github.com/webcompat/webcompat-tests/milestone/3",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/3/labels",
+      "id": 2744176,
+      "node_id": "MDk6TWlsZXN0b25lMjc0NDE3Ng==",
+      "number": 3,
+      "title": "needscontact",
+      "description": "We are looking for an appropriate contact",
+      "open_issues": 62,
+      "closed_issues": 3,
+      "state": "open",
+      "created_at": "2017-09-05T03:40:35Z",
+      "updated_at": "2020-11-07T03:21:44Z",
+      "due_on": null,
+      "closed_at": null
+    },
+    "comments": 0,
+    "created_at": "2020-11-04T01:41:16Z",
+    "updated_at": "2020-11-07T03:21:44Z",
+    "closed_at": null,
+    "author_association": "NONE",
+    "active_lock_reason": null,
+    "body": "<!-- @browser: not set -->\n<!-- @ua_header: None -->\n<!-- @reported_with: None -->\n<!-- @public_url: https://github.com/webcompat/webcompat-tests/issues/2598 -->\n\n**URL**: https://bugzilla.mozilla.org/show_bug.cgi?id=1651119\n\n**Browser / Version**: not set\n**Operating System**: not set\n**Tested Another Browser**: Unknown \n\n**Problem type**: Something else\n**Description**: moved from bugzilla\n**Steps to Reproduce**:\ndescription from bugzilla\n\n\n\n_From [webcompat.com](https://webcompat.com/) with ❤️_",
+    "performed_via_github_app": null
+  },
+  "milestone": {
+    "title": "needscontact"
+  }
+}

--- a/tests/functional/reporting-issue-wizard-non-auth.js
+++ b/tests/functional/reporting-issue-wizard-non-auth.js
@@ -200,7 +200,7 @@ registerSuite("Reporting with wizard", {
           .findByCssSelector("#image")
           .type(VALID_IMAGE_PATH)
           .end()
-          .sleep(500)
+          .sleep(1000)
           .findDisplayedByCssSelector(".next-screenshot")
           .getVisibleText()
           .then(function (text) {

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -360,6 +360,11 @@ class TestURLs(unittest.TestCase):
         # do we not have a <script nonce=hash> in our response body?
         self.assertNotIn(b'<script nonce=', rv.data)
 
+    def outreach_template_generator(self):
+        """Request to /outreach/123 should be 308."""
+        rv = self.app.get('/outreach/123')
+        self.assertEqual(rv.status_code, 308)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -600,3 +600,13 @@ def show_logs(subpath, file_id):
         return render_template('console-logs.html', logs=logs)
     else:
         abort(404)
+
+
+@app.route('/outreach/<int:number>')
+def outreach_template_generator(number):
+    """Route redirecting to outreach template generator."""
+
+    return redirect(
+        'https://webcompat-outreach.herokuapp.com/issue/' + str(number),
+        code=308
+    )

--- a/webcompat/webhooks/__init__.py
+++ b/webcompat/webhooks/__init__.py
@@ -33,7 +33,7 @@ def hooklistener():
     event_type = request.headers.get('X-GitHub-Event')
     # Treating events related to issues
     if event_type == 'issues':
-        webhook_issue = WebHookIssue.from_dict(payload)
+        webhook_issue = WebHookIssue.from_dict(payload, request.url_root)
         # we process the action
         return webhook_issue.process_issue_action()
     elif event_type == 'ping':


### PR DESCRIPTION
Once a milestone is changed to needscontact a comment is added to an issue with a link to `https://webcompat.com/outreach/<issue_id>` (which is redirecting to `https://webcompat-outreach.herokuapp.com/issue/<issue_id>`)
will need to test this on staging :)

r? @karlcow 