### PR TITLE
Fixes #3161 - Adds action keyword for labels regex

### DIFF
--- a/webcompat/static/js/lib/models/label-list.js
+++ b/webcompat/static/js/lib/models/label-list.js
@@ -27,7 +27,10 @@ var issues = issues || {}; // eslint-disable-line no-use-before-define
 
 const LabelList = Backbone.Model.extend({
   initialize: function () {
-    this.set("namespaceRegex", /(browser|closed|os|priority|status)-(.+)/i);
+    this.set(
+      "namespaceRegex",
+      /(browser|closed|os|priority|status|action)-(.+)/i
+    );
     // Temporarily set pagination to 100 labels per page, until
     // we fix Issue #781
     this.set("defaultLabelURL", "/api/issues/labels?per_page=100");


### PR DESCRIPTION


This PR fixes issue #3161

## Proposed PR background

We now have a label with `action-` prefix. 
