### PR TITLE
Fixes #3456 - Add aria-labelled-by attributes to wizard step icons

### DIFF
--- a/webcompat/templates/nav/issue-wizard-stepper.html
+++ b/webcompat/templates/nav/issue-wizard-stepper.html
@@ -1,14 +1,14 @@
 <div id="wizard-container">
     <div class="grid row">
         {% for step in form.steps %}
-            <div id="pr-{{ step.id }}" class="step {{ step.className }}">
-                <div class="circle">
+        <div id="pr-{{ step.id }}" class="step {{ step.className }}">
+            <div class="circle">
                 <div class="number">{{ step.number }}</div>
-                <div class="icon"></div>
-                </div>
-                <div class="description">{{ step.label }}</div>
+                <div aria-labelled-by="step-label-{{ step.id }}" role="img" class="icon"></div>
             </div>
-            <div class="description">{{ step.label }}</div>
+            <div id="step-label-{{ step.id }}" class="description">{{ step.label }}</div>
+        </div>
+        <div class="description">{{ step.label }}</div>
         {% endfor %}
     </div>
 </div>

--- a/webcompat/templates/nav/issue-wizard-stepper.html
+++ b/webcompat/templates/nav/issue-wizard-stepper.html
@@ -4,7 +4,7 @@
         <div id="pr-{{ step.id }}" class="step {{ step.className }}">
             <div class="circle">
                 <div class="number">{{ step.number }}</div>
-                <div aria-labelled-by="step-label-{{ step.id }}" role="img" class="icon"></div>
+                <div aria-labelledby="step-label-{{ step.id }}" role="img" class="icon"></div>
             </div>
             <div id="step-label-{{ step.id }}" class="description">{{ step.label }}</div>
         </div>


### PR DESCRIPTION
In theory this should fix #3456, but the devtools accessbility inspector doesn't recognize the `aria-labelled-by` attribute, but I think that's a bug (I will file one and post a link here).

![Screen Shot 2021-01-17 at 2 52 17 PM](https://user-images.githubusercontent.com/67283/104855709-e5b32a00-58d3-11eb-9136-af850f540105.png)

We can fix this error by duplicating the description text, but then a screen reader will read it twice, which seems bad. 
![Screen Shot 2021-01-17 at 2 51 40 PM](https://user-images.githubusercontent.com/67283/104855710-e64bc080-58d3-11eb-9a1a-8da25169b49e.png)
