### PR TITLE
Fixes #3207 - Adds Terms of Service message to user upload

### DIFF
--- a/webcompat/templates/steps/screenshot.html
+++ b/webcompat/templates/steps/screenshot.html
@@ -5,15 +5,20 @@
         <strong>We deleted the screenshot.</strong><br>
         Do you have a different screenshot you would like to share?<br>
         <br class="desktop-only">
-        <strong>Uploaded images are publicly viewable.</strong>
+        <strong>Uploaded images are publicly viewable.</strong><br>
+        Avoid uploading images that contain sensitive information or violate our <a href="/terms">Terms of Service</a>.
       </div>
       <div class="description-text top up-message uploaded-screenshot">
         Image uploaded.<br>
-        <strong>Uploaded images are publicly viewable.</strong>
+        <br class="desktop-only">
+        <strong>Uploaded images are publicly viewable.</strong><br>
+        Avoid uploading images that contain sensitive information or violate our <a href="/terms">Terms of Service</a>.
       </div>
       <div class="description-text top up-message reset-screenshot">
         Do you have a screenshot of the issue you would like to share? <br>
-        <strong>Uploaded images are publicly viewable.</strong>
+        <br class="desktop-only">
+        <strong>Uploaded images are publicly viewable.</strong><br>
+        Avoid uploading images that contain sensitive information or violate our <a href="/terms">Terms of Service</a>.
       </div>
     </div>
     <div class="input-control half col">


### PR DESCRIPTION
Issue #3207 - Adds Terms message to user upload

This PR fixes issue #3207.

It seems to be the case that, in different countries, illegal content is supposed to be reported in different places. For example, in the US it's supposed to be reported to the FBI. Specific links to report illegal sites haven't been included for now.

## Current
<img src="https://user-images.githubusercontent.com/44381810/105259087-f7990500-5b3f-11eb-8e57-bc5a96ceac7b.png" width="400" />
<img src="https://user-images.githubusercontent.com/44381810/105259178-257e4980-5b40-11eb-8acb-9ce1bb7d38a6.png" width="400" />

## Previous

<img src="https://user-images.githubusercontent.com/44381810/105259350-78f09780-5b40-11eb-950a-1a5e4b9aedaa.png" width="400" />
<img src="https://user-images.githubusercontent.com/44381810/105259382-86a61d00-5b40-11eb-85c8-530d75ce76ef.png" width="400" />


