### PR TITLE
Fixes #3522: Fix outreach comment for auth reports

### DIFF
--- a/tests/fixtures/webhooks/public_milestone_needscontact_auth_report.json
+++ b/tests/fixtures/webhooks/public_milestone_needscontact_auth_report.json
@@ -1,0 +1,48 @@
+{
+  "action": "milestoned",
+  "issue": {
+    "url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598",
+    "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests",
+    "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/labels{/name}",
+    "comments_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/comments",
+    "events_url": "https://api.github.com/repos/webcompat/webcompat-tests/issues/2598/events",
+    "html_url": "https://github.com/webcompat/webcompat-tests/issues/2598",
+    "id": 735747598,
+    "node_id": "MDU6SXNzdWU3MzU3NDc1OTg=",
+    "number": 2598,
+    "title": "bugzilla.mozilla.org - see bug description",
+    "state": "open",
+    "locked": false,
+    "assignee": null,
+    "assignees": [
+
+    ],
+    "milestone": {
+      "url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/3",
+      "html_url": "https://github.com/webcompat/webcompat-tests/milestone/3",
+      "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests/milestones/3/labels",
+      "id": 2744176,
+      "node_id": "MDk6TWlsZXN0b25lMjc0NDE3Ng==",
+      "number": 3,
+      "title": "needscontact",
+      "description": "We are looking for an appropriate contact",
+      "open_issues": 62,
+      "closed_issues": 3,
+      "state": "open",
+      "created_at": "2017-09-05T03:40:35Z",
+      "updated_at": "2020-11-07T03:21:44Z",
+      "due_on": null,
+      "closed_at": null
+    },
+    "comments": 0,
+    "created_at": "2020-11-04T01:41:16Z",
+    "updated_at": "2020-11-07T03:21:44Z",
+    "closed_at": null,
+    "author_association": "NONE",
+    "active_lock_reason": null,
+    "body": "<!-- @browser: Firefox 87.0 -->\n<!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:87.0) Gecko/20100101 Firefox/87.0 -->\n<!-- @reported_with: unknown -->\n\n**URL**: https://www.optimum.net/\n\n**Browser / Version**: Firefox 87.0\n**Operating System**: Mac OS X 10.14\n**Tested Another Browser**: Yes Chrome\n\n**Problem type**: Desktop site instead of mobile site\n**Description**: Desktop site instead of mobile site\n**Steps to Reproduce**:\nertytrw345rty v2345ty45rty 4rtytet5\n\n<details>\n<summary>Browser Configuration</summary>\n<ul>\n  <li>None</li>\n</ul>\n</details>\n\n_From [webcompat.com](https://webcompat.com/) with ❤️_",    "performed_via_github_app": null
+  },
+  "milestone": {
+    "title": "needscontact"
+  }
+}

--- a/tests/unit/test_webhook_model.py
+++ b/tests/unit/test_webhook_model.py
@@ -190,6 +190,16 @@ def test_prepare_outreach_comment():
         expected_payload).get('body')
 
 
+def test_prepare_outreach_comment_for_auth_report():
+    """Test we prepare the right comment body."""
+    expected_payload = '{"body": "[Generate outreach template](https://webcompat.com/outreach/2598)"}'  # noqa
+    json_event, signature = event_data('public_milestone_needscontact_auth_report.json')    # noqa
+    payload = json.loads(json_event)
+    issue = WebHookIssue.from_dict(payload, "https://webcompat.com/")
+    assert issue.prepare_outreach_comment() == json.loads(
+        expected_payload).get('body')
+
+
 def test_get_public_issue_number():
     """Test the extraction of the issue number from the public_url."""
     json_event, signature = event_data('private_issue_opened.json')

--- a/webcompat/webhooks/model.py
+++ b/webcompat/webhooks/model.py
@@ -174,13 +174,11 @@ class WebHookIssue:
 
     def prepare_outreach_comment(self):
         """Build the comment with a link to the outreach generator page."""
-        # public issue data
-        public_number = self.get_public_issue_number()
         host = self.host_reported_from
         if not host:
             host = "https://webcompat.com/"
         # prepare the payload
-        return f'[Generate outreach template]({host}outreach/{public_number})'
+        return f'[Generate outreach template]({host}outreach/{self.number})'
 
     def close_public_issue(self, reason='rejected'):
         """Close a public issue for the given reason.


### PR DESCRIPTION
I've been getting issue id from `public_url` in `WebHookIssue` model, which gets extracted from the issue body:

`public_url = extract_metadata(issue_body).get('public_url', '').strip()`

However `@public_url:` is only added to the body of issues that require moderation. Therefore issues that are reported with github don't have it and the id is empty (ooops 🤦‍♀️). 

To fix this I've used `number` property instead