### PR TITLE
fix #3528 - Fix CSS for description textarea

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -420,7 +420,7 @@
 }
 
 .issue-form .text-field {
-  padding: 4px 32px 5px 8px;
+  padding: 4px 32px 3ch 8px;
 }
 
 .with-validation-icons.is-validated .input-wrapper::after,
@@ -962,7 +962,7 @@
   }
 
   .issue-form .text-field {
-    padding: 11px 36px 11px 8px;
+    padding: 11px 36px 3ch 8px;
   }
 
   .low .text-field {


### PR DESCRIPTION

This PR fixes issue #3528

## Proposed PR background

This is fixing an issue with the CSS in the textarea where the green progress bar was hiding the rest of the text.
