### PR TITLE
Fix #3528 - Fix CSS for description textarea

### DIFF
--- a/webcompat/static/css/src/issue-wizard-textarea.css
+++ b/webcompat/static/css/src/issue-wizard-textarea.css
@@ -22,21 +22,16 @@
 .progress-textarea .progress {
   background: #b3f4d7;
   border-radius: 2px;
-  bottom: 0;
-  content: "";
   height: 20px;
-  left: 0;
   margin: 4px;
   overflow: hidden;
-  position: absolute;
-  width: calc(100% - 8px);
+  position: relative;
   z-index: 2;
 }
 
 .progress-textarea .progress .bar {
   background: #22b573;
   bottom: 0;
-  content: "";
   height: 20px;
   left: 0;
   min-width: 1%;


### PR DESCRIPTION
Make the progress bar not overlap the textarea. While at it, also remove useless `content: ""` rules which do nothing, and an useless `width` declaration which also does nothing because it's the same width as the block would have minus margins.

This PR fixes issue #3528

## Proposed PR background

See #3528