### PR TITLE
fix #3541. Adds detection for firefox iOS mobile reporter

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -212,6 +212,7 @@ EXTRA_LABELS = [
     'browser-android-components',
     'browser-fenix',
     'browser-focus-geckoview',
+    'browser-firefox-ios',
     'browser-firefox-reality',
     'type-fastclick',
     'type-google',

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -101,6 +101,21 @@ class TestWebhook(unittest.TestCase):
         <!-- @public_url: http://test.example.org/issues/1 -->
         """
 
+        self.issue_body8 = """
+        <!-- @browser: Firefox iOS 31.0 -->
+        <!-- @ua_header: Mozilla/5.0 (iPhone; CPU OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/31.0  Mobile/15E148 Safari/605.1.15 -->
+        <!-- @reported_with: mobile-reporter -->
+        <!-- @extra_labels: browser-firefox-ios -->
+        <!-- @public_url: https://github.com/webcompat/web-bugs/issues/67156 -->
+
+
+        **URL**: https://example.com/
+
+        **Browser / Version**: Firefox iOS 31.0
+        **Operating System**: iOS 14.4
+        **Tested Another Browser**: Yes Safari
+        """  # noqa
+
         self.issue_info1 = {
             'action': 'foobar',
             'state': 'open',
@@ -317,6 +332,7 @@ class TestWebhook(unittest.TestCase):
             (self.issue_body5, ['browser-firefox-reality', 'engine-gecko',
                                 'type-media']),
             (self.issue_body6, ['browser-safari']),
+            (self.issue_body8, ['browser-firefox-ios', 'os-ios']),
         ]
         for issue_body, expected in labels_tests:
             actual = helpers.get_issue_labels(issue_body)

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -23,7 +23,7 @@ from webcompat.helpers import to_bytes
 from webcompat.issues import moderation_template
 
 BROWSERS = ['blackberry', 'brave', 'chrome', 'edge', 'firefox', 'iceweasel', 'ie', 'lynx', 'myie', 'opera', 'puffin', 'qq', 'safari', 'samsung', 'seamonkey', 'uc', 'vivaldi']  # noqa
-MOZILLA_BROWSERS = ['browser-android-components',
+GECKO_BROWSERS = ['browser-android-components',
                     'browser-fenix',
                     'browser-firefox',
                     'browser-firefox-mobile',
@@ -157,7 +157,7 @@ def get_issue_labels(issue_body):
         labelslist.extend(extra_labels)
     priority_label = extract_priority_label(issue_body)
     labelslist.extend([browser_label, priority_label])
-    if any(label for label in labelslist if label in MOZILLA_BROWSERS):
+    if any(label for label in labelslist if label in GECKO_BROWSERS):
         labelslist.append('engine-gecko')
     labelslist = [label for label in labelslist if label is not None]
     return labelslist

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -24,14 +24,14 @@ from webcompat.issues import moderation_template
 
 BROWSERS = ['blackberry', 'brave', 'chrome', 'edge', 'firefox', 'iceweasel', 'ie', 'lynx', 'myie', 'opera', 'puffin', 'qq', 'safari', 'samsung', 'seamonkey', 'uc', 'vivaldi']  # noqa
 GECKO_BROWSERS = ['browser-android-components',
-                    'browser-fenix',
-                    'browser-firefox',
-                    'browser-firefox-mobile',
-                    'browser-firefox-reality',
-                    'browser-firefox-tablet',
-                    'browser-focus-geckoview',
-                    'browser-geckoview',
-                    ]
+                  'browser-fenix',
+                  'browser-firefox',
+                  'browser-firefox-mobile',
+                  'browser-firefox-reality',
+                  'browser-firefox-tablet',
+                  'browser-focus-geckoview',
+                  'browser-geckoview', ]
+IOS_BROWSERS = ['browser-firefox-ios', ]
 PUBLIC_REPO = app.config['ISSUES_REPO_URI']
 PRIVATE_REPO = app.config['PRIVATE_REPO_URI']
 
@@ -159,6 +159,8 @@ def get_issue_labels(issue_body):
     labelslist.extend([browser_label, priority_label])
     if any(label for label in labelslist if label in GECKO_BROWSERS):
         labelslist.append('engine-gecko')
+    if any(label for label in labelslist if label in IOS_BROWSERS):
+        labelslist.append('os-ios')
     labelslist = [label for label in labelslist if label is not None]
     return labelslist
 


### PR DESCRIPTION
This PR fixes issue #3541 
Fix #3540 

## Proposed PR background

The PR adds a list for IOS Browsers
and a list for Gecko Browsers.

It also detects browser firefox ios and adds appropriate labels. 
This is related to the work done in https://github.com/mozilla-mobile/firefox-ios/issues/6498
