### PR TITLE
Fixes #3574: Incorporate bugbug ml labelling into moderation process

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -41,6 +41,7 @@ if PRODUCTION:
     )
     BUGBUG_HTTP_SERVER = "https://bugbug.herokuapp.com"
     CLASSIFIER_PATH = "needsdiagnosis/predict/github/webcompat/web-bugs-private"  # noqa
+    AUTOCLOSED_MILESTONE_ID = 15
 
 if STAGING:
     GITHUB_CLIENT_ID = os.environ.get('STAGING_GITHUB_CLIENT_ID')
@@ -59,6 +60,7 @@ if STAGING:
     )
     BUGBUG_HTTP_SERVER = "https://bugbug.herokuapp.com"
     CLASSIFIER_PATH = "needsdiagnosis/predict/github/webcompat/webcompat-tests-private"  # noqa
+    AUTOCLOSED_MILESTONE_ID = 5
 
 if LOCALHOST:
     # for now we are using .env only on localhost
@@ -82,6 +84,7 @@ if LOCALHOST:
     )
     BUGBUG_HTTP_SERVER = "http://0.0.0.0:8000"
     CLASSIFIER_PATH = "needsdiagnosis/predict/github/webcompat/webcompat-tests-private"  # noqa
+    AUTOCLOSED_MILESTONE_ID = 5
 
 # BUG STATUS
 # The id will be initialized when the app is started.

--- a/tests/fixtures/webhooks/private_issue_opened.json
+++ b/tests/fixtures/webhooks/private_issue_opened.json
@@ -16,6 +16,7 @@
         "description": "issue in the process of being moderated"
       }
     ],
-    "state": "open"
+    "state": "open",
+    "html_url": "https://github.com/webcompat/webcompat-tests-private/issues/600"
   }
 }

--- a/tests/fixtures/webhooks/private_milestone_accepted.json
+++ b/tests/fixtures/webhooks/private_milestone_accepted.json
@@ -16,6 +16,7 @@
         "description": "issue in the process of being moderated"
       }
     ],
+    "html_url": "https://github.com/webcompat/webcompat-tests-private/issues/600",
     "state": "open",
     "milestone": {
       "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/2",

--- a/tests/fixtures/webhooks/private_milestone_ml_autoclosed.json
+++ b/tests/fixtures/webhooks/private_milestone_ml_autoclosed.json
@@ -1,0 +1,42 @@
+{
+    "action": "milestoned",
+    "issue": {
+      "title": "www.netflix.com - test private issue autoclosed",
+      "repository_url": "https://api.github.com/repos/webcompat/webcompat-tests-private",
+      "number": 600,
+      "html_url": "https://github.com/webcompat/webcompat-tests-private/issues/600",
+      "body": "<!-- @browser: Firefox 55.0 -->\n<!-- @ua_header: Mozilla/5.0 (X11; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0 -->\n<!-- @reported_with: web -->\n<!-- @public_url: https://github.com/webcompat/webcompat-tests/issues/1  -->\n\n**URL**: https://www.netflix.com/",
+      "labels": [
+        {
+          "id": 1788251357,
+          "node_id": "MDU6TGFiZWwxNzg4MjUxMzU3",
+          "url": "https://api.github.com/repos/webcompat/webcompat-tests/labels/action-needsmoderation",
+          "name": "action-needsmoderation",
+          "color": "d36200",
+          "default": false,
+          "description": "issue in the process of being moderated"
+        }
+      ],
+      "state": "open",
+      "milestone": {
+        "url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/5",
+        "html_url": "https://github.com/webcompat/webcompat-tests-private/milestone/5",
+        "labels_url": "https://api.github.com/repos/webcompat/webcompat-tests-private/milestones/5/labels",
+        "id": 6795520,
+        "node_id": "MDk6TWlsZXN0b25lNjc5NTUyMA==",
+        "number": 5,
+        "title": "ml-autoclosed",
+        "description": "Issues closed automatically based on ml prediction",
+        "open_issues": 1,
+        "closed_issues": 3,
+        "state": "open",
+        "created_at": "2021-05-26T20:24:14Z",
+        "updated_at": "2021-05-27T16:56:08Z",
+        "due_on": null,
+        "closed_at": null
+      }
+    },
+    "milestone": {
+      "title": "ml-autoclosed"
+    }
+  }

--- a/tests/unit/test_issues.py
+++ b/tests/unit/test_issues.py
@@ -132,6 +132,13 @@ def test_moderation_template_rejected(setup):
     assert 'Its original content has been deleted' in actual['body']
 
 
+def test_moderation_template_autoclosed(setup):
+    """Check the return values are for the rejected case."""
+    actual = moderation_template('autoclosed')
+    assert actual['title'] == 'Issue closed.'
+    assert 'We have closed this issue\nautomatically as we suspect it is invalid' in actual['body']     # noqa
+
+
 def test_moderation_template_ongoing(setup):
     """Check the return values are for the needsmoderation case."""
     # test the default
@@ -142,7 +149,6 @@ def test_moderation_template_ongoing(setup):
     actual = moderation_template('ongoing')
     assert actual['title'] == 'In the moderation queue.'
     assert 'put in the moderation queue.' in actual['body']
-    # bad keyword, we go back to the default.
-    actual = moderation_template('punkcat')
-    assert actual['title'] == 'In the moderation queue.'
-    assert 'put in the moderation queue.' in actual['body']
+    # bad keyword causes error.
+    with pytest.raises(ValueError):
+        moderation_template('punkcat')

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -454,6 +454,21 @@ class TestWebhook(unittest.TestCase):
         self.assertEqual(type(actual), dict)
         self.assertEqual(actual, expected)
 
+    def test_prepare_rejected_issue_autoclosed(self):
+        """Test payload for the rejected issue that we want to auto close."""
+        expected = {
+            'body': '<p>Thanks for the report. We have closed this issue\n'
+                    'automatically as we suspect it is invalid. If we made '
+                    'a mistake, please\nfile a new issue and try to provide '
+                    'more context.</p>',
+                    'labels': ['bugbug-probability-high'],
+                    'milestone': 8,
+                    'state': 'closed',
+                    'title': 'Issue closed.'}
+        actual = helpers.prepare_rejected_issue("autoclosed")
+        self.assertEqual(type(actual), dict)
+        self.assertEqual(actual, expected)
+
     @patch('webcompat.webhooks.ml.make_classification_request')
     def test_get_issue_classification(self, mock_class):
         """Make only one request if it returns 200 status code right away.
@@ -478,6 +493,14 @@ class TestWebhook(unittest.TestCase):
             ml.get_issue_classification(12345)
 
         assert mock_class.call_count == 4
+
+    def test_prepare_private_url(self):
+        """Test private issue url is in the right format."""
+        expected = '\n<!-- @private_url: https://github.com/webcompat/webcompat-tests-private/issues/600 -->\n'     # noqa
+        actual = helpers.prepare_private_url(
+            'https://github.com/webcompat/webcompat-tests-private/issues/600'
+        )
+        self.assertEqual(actual, expected)
 
 
 if __name__ == '__main__':

--- a/webcompat/issues.py
+++ b/webcompat/issues.py
@@ -43,6 +43,33 @@ REJECTED_TITLE = 'Issue rejected.'
 REJECTED_BODY = '''<p>The content of this issue doesn't meet our
 <a href="https://webcompat.com/terms#acceptable-use">acceptable use</a>
 guidelines. Its original content has been deleted.</p>'''
+AUTOCLOSE_TITLE = 'Issue closed.'
+AUTOCLOSE_BODY = '''<p>Thanks for the report. We have closed this issue
+automatically as we suspect it is invalid. If we made a mistake, please
+file a new issue and try to provide more context.</p>'''
+
+TEMPLATE_CONFIG = {
+    'rejected': {
+        'title': REJECTED_TITLE,
+        'body': REJECTED_BODY
+    },
+    'invalid': {
+        'title': '',
+        'body': INVALID_BODY
+    },
+    'incomplete': {
+        'title': '',
+        'body': INCOMPLETE_BODY
+    },
+    'autoclosed': {
+        'title': AUTOCLOSE_TITLE,
+        'body': AUTOCLOSE_BODY
+    },
+    'ongoing': {
+        'title': ONGOING_TITLE,
+        'body': ONGOING_BODY
+    }
+}
 
 
 def moderation_template(choice='ongoing'):
@@ -53,22 +80,20 @@ def moderation_template(choice='ongoing'):
     - rejected: the issue has been rejected.
     - incomplete: the issue is incomplete (but not rejected)
     - invalid: the issue is invalid (but not rejected)
+    - autoclosed: the issue is auto closed by ml bot
 
     The default is 'ongoing' even with unknown keywords.
     """
-    if choice == 'rejected':
-        title = REJECTED_TITLE
-        body = REJECTED_BODY
-    elif choice == 'invalid':
-        title = ''
-        body = INVALID_BODY
-    elif choice == 'incomplete':
-        title = ''
-        body = INCOMPLETE_BODY
+    if choice in TEMPLATE_CONFIG:
+        return {
+            'title': TEMPLATE_CONFIG[choice].get('title'),
+            'body': TEMPLATE_CONFIG[choice].get('body')
+        }
     else:
-        title = ONGOING_TITLE
-        body = ONGOING_BODY
-    return {'title': title, 'body': body}
+        temp = (", ".join(TEMPLATE_CONFIG.keys()))
+        raise ValueError(
+            f'Template choice must be one of the following: {temp}'
+        )
 
 
 def report_private_issue(form, public_url):


### PR DESCRIPTION
In this PR I've added functionality to automatically close issues marked by bugbug as invalid.

1. Issues marked by bugbug as invalid moved to "ml-autoclosed" milestone. 
2. Once milestone event is received, public issue content is replaced with a placeholder text and label "bugbug-probability-high" is added, public issue closed.
3. Private issue closed

Discussed in https://github.com/webcompat/webcompat.com/issues/3574

Example of a public test issue that was closed using this code: https://github.com/webcompat/webcompat-tests/issues/2638
