### PR TITLE
fixes #3578 - Adds device-tablet to the list of accepted extra labels

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -214,6 +214,7 @@ EXTRA_LABELS = [
     'browser-focus-geckoview',
     'browser-firefox-ios',
     'browser-firefox-reality',
+    'device-tablet',
     'type-fastclick',
     'type-google',
     'type-marfeel',

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -164,6 +164,24 @@ class TestForm(unittest.TestCase):
         expected = '<!-- @browser: Firefox 59.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 59.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: browser-focus-geckoview -->\n'  # noqa
         self.assertEqual(actual, expected)
 
+    def test_bad_extra_labels_get_removed(self):
+        """Test that filtering out of not accepted EXTRA_LABELS is working.
+
+        type-punkcat is not a valid extra labels
+        """
+        form_object = MultiDict([
+            ('reported_with', 'mobile-reporter'),
+            ('url', 'http://localhost:5000/issues/new'),
+            ('extra_labels', ['browser-firefox-ios',
+                              'device-tablet', 'type-punkcat']),
+            ('ua_header', 'Mozilla/5.0...Firefox 91.0'),
+            ('browser', 'Firefox 91.0')])
+        metadata_keys = ['browser', 'ua_header', 'reported_with',
+                         'extra_labels']
+        actual = form.get_metadata(metadata_keys, form_object)
+        expected = '<!-- @browser: Firefox 91.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 91.0 -->\n<!-- @reported_with: mobile-reporter -->\n<!-- @extra_labels: browser-firefox-ios, device-tablet -->\n'  # noqa
+        self.assertEqual(actual, expected)
+
     def test_normalize_metadata(self):
         """Avoid some type of strings."""
         cases = [('blue sky -->', 'blue sky'),

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -142,6 +142,19 @@ class TestWebhook(unittest.TestCase):
         **Tested Another Browser**: No
         """  # noqa
 
+        self.issue_body11 = """
+        <!-- @browser: Safari 13.1 -->
+        <!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15 -->
+        <!-- @reported_with: mobile-reporter -->
+        <!-- @extra_labels: browser-firefox-ios, device-tablet -->
+
+        **URL**: http://mozilla.org/
+
+        **Browser / Version**: Safari 13.1
+        **Operating System**: Mac OS X 10.15.4
+        **Tested Another Browser**: Yes Edge
+        """  # noqa
+
         self.issue_info1 = {
             'action': 'foobar',
             'state': 'open',
@@ -362,6 +375,8 @@ class TestWebhook(unittest.TestCase):
             (self.issue_body8, ['browser-firefox-ios', 'os-ios']),
             (self.issue_body9, ['browser-firefox-ios', 'os-ios']),
             (self.issue_body10, ['browser-firefox-ios', 'device-tablet',
+                                 'os-ios']),
+            (self.issue_body11, ['browser-firefox-ios', 'device-tablet',
                                  'os-ios']),
         ]
         for issue_body, expected in labels_tests:

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -102,7 +102,7 @@ class TestWebhook(unittest.TestCase):
 
         self.issue_body8 = """
         <!-- @browser: Firefox iOS 31.0 -->
-        <!-- @ua_header: Mozilla/5.0 (iPhone; CPU OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/31.0  Mobile/15E148 Safari/605.1.15 -->
+        <!-- @ua_header: Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/31.0  Mobile/15E148 Safari/605.1.15 -->
         <!-- @reported_with: mobile-reporter -->
         <!-- @extra_labels: browser-firefox-ios -->
         <!-- @public_url: https://github.com/webcompat/web-bugs/issues/67156 -->
@@ -117,13 +117,27 @@ class TestWebhook(unittest.TestCase):
 
         self.issue_body9 = """
         <!-- @browser: Firefox iOS 33.1 -->
-        <!-- @ua_header: Mozilla/5.0 (iPhone; CPU OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1  Mobile/15E148 Safari/605.1.15 -->
+        <!-- @ua_header: Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1  Mobile/15E148 Safari/605.1.15 -->
         <!-- @reported_with: mobile-reporter -->
 
 
         **URL**: https://example.com/
 
         **Browser / Version**: Firefox iOS 33.1
+        **Operating System**: iOS 14.5
+        **Tested Another Browser**: No
+        """  # noqa
+
+        self.issue_body10 = """
+        <!-- @browser: Firefox iOS 34.1 -->
+        <!-- @ua_header: Mozilla/5.0 (iPad; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.1  Mobile/15E148 Safari/605.1.15 -->
+        <!-- @reported_with: mobile-reporter -->
+        <!-- @extra_labels: browser-firefox-ios, device-tablet -->
+
+
+        **URL**: https://example.com/
+
+        **Browser / Version**: Firefox iOS 34.1
         **Operating System**: iOS 14.5
         **Tested Another Browser**: No
         """  # noqa
@@ -347,6 +361,8 @@ class TestWebhook(unittest.TestCase):
             (self.issue_body6, ['browser-safari']),
             (self.issue_body8, ['browser-firefox-ios', 'os-ios']),
             (self.issue_body9, ['browser-firefox-ios', 'os-ios']),
+            (self.issue_body10, ['browser-firefox-ios', 'device-tablet',
+                                 'os-ios']),
         ]
         for issue_body, expected in labels_tests:
             actual = helpers.get_issue_labels(issue_body)


### PR DESCRIPTION
This adds device-tablet to the list of valid extra_labels.
This is the server counterpart to 
https://github.com/mozilla-mobile/firefox-ios/pull/8615
https://github.com/mozilla-mobile/firefox-ios/issues/8614