### PR TITLE
fix #3585 - fixes the misspelled dependabot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "11:00"
   open-pull-requests-limit: 10
   labels:
-  - "type : dependencies"
+  - "type: dependencies"
   ignore:
   - dependency-name: webpack-merge
     versions:


### PR DESCRIPTION

This fixes the spelling of the dependabot label to avoid unecessary comments in github.