### PR TITLE
Fix #3612 - Adds version100 labeling to identify 3 digits version of browsers

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -224,6 +224,7 @@ EXTRA_LABELS = [
     'type-tracking-protection-strict',
     'type-webrender-enabled',
     'type-webvr',
+    'version100',
 ]
 
 # List of accepted values for browser sources.

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -14,6 +14,7 @@ from webcompat import form
 from webcompat import helpers
 
 FIREFOX_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0'  # noqa
+FIREFOX_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:100.0) Gecko/20100101 Firefox/100.0'  # noqa
 
 
 class TestForm(unittest.TestCase):
@@ -180,6 +181,20 @@ class TestForm(unittest.TestCase):
                          'extra_labels']
         actual = form.get_metadata(metadata_keys, form_object)
         expected = '<!-- @browser: Firefox 91.0 -->\n<!-- @ua_header: Mozilla/5.0...Firefox 91.0 -->\n<!-- @reported_with: mobile-reporter -->\n<!-- @extra_labels: browser-firefox-ios, device-tablet -->\n'  # noqa
+        self.assertEqual(actual, expected)
+
+    def test_extra_labels_version100(self):
+        """Test that we set version100 for extra_labels."""
+        form_object = MultiDict([
+            ('reported_with', 'desktop-reporter'),
+            ('url', 'http://localhost:5000/issues/new'),
+            ('extra_labels', ['version100']),
+            ('ua_header', FIREFOX_V100),
+            ('browser', 'Firefox 100.0')])
+        metadata_keys = ['browser', 'ua_header', 'reported_with',
+                         'extra_labels']
+        actual = form.get_metadata(metadata_keys, form_object)
+        expected = '<!-- @browser: Firefox 100.0 -->\n<!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:100.0) Gecko/20100101 Firefox/100.0 -->\n<!-- @reported_with: desktop-reporter -->\n<!-- @extra_labels: version100 -->\n'  # noqa
         self.assertEqual(actual, expected)
 
     def test_normalize_metadata(self):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -24,6 +24,7 @@ from webcompat.helpers import form_type
 from webcompat.helpers import format_link_header
 from webcompat.helpers import get_browser
 from webcompat.helpers import get_browser_name
+from webcompat.helpers import get_browser_version
 from webcompat.helpers import get_name
 from webcompat.helpers import get_os
 from webcompat.helpers import get_response_headers
@@ -250,6 +251,10 @@ class TestHelpers(unittest.TestCase):
         ]
         for test in tests:
             self.assertEqual(get_version_string(test[0]), test[1])
+
+    def test_get_browser_version(self):
+        """Test version extraction."""
+        self.assertEqual(get_browser_version(FIREFOX_V100), 100)
 
     def test_get_name(self):
         """Test name extraction from Dict via get_name helper method."""

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -59,7 +59,6 @@ SAFARI_TABLET_UA = 'Mozilla/5.0 (iPad; CPU OS 5_1_1 like Mac OS X) AppleWebKit/5
 CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2720.0 Safari/537.36'  # noqa
 CHROME_MOBILE_UA = 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19'  # noqa
 CHROME_TABLET_UA = 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19'  # noqa
-
 FIREFOX_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0'  # noqa
 EDGE_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4596.0 Safari/537.36 Edg/100.0.979.0'  # noqa
 CHROME_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36'  # noqa

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -59,6 +59,9 @@ CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 
 CHROME_MOBILE_UA = 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19'  # noqa
 CHROME_TABLET_UA = 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19'  # noqa
 
+FIREFOX_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0'  # noqa
+EDGE_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4596.0 Safari/537.36 Edg/100.0.979.0'  # noqa
+CHROME_V100 = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36'  # noqa
 
 class TestHelpers(unittest.TestCase):
     """Class for testing helpers."""
@@ -170,6 +173,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(get_browser_name(True), 'unknown')
         self.assertEqual(get_browser_name(False), 'unknown')
         self.assertEqual(get_browser_name(None), 'unknown')
+        self.assertEqual(get_browser_name(EDGE_V100), 'edge')
 
     def test_get_browser(self):
         """Test browser parsing via get_browser helper method."""
@@ -193,6 +197,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(get_browser(True), 'Unknown')
         self.assertEqual(get_browser(False), 'Unknown')
         self.assertEqual(get_browser(None), 'Unknown')
+        self.assertEqual(get_browser(FIREFOX_V100), 'Firefox 100.0')
 
     def test_get_os(self):
         """Test OS parsing via get_os helper method."""

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -155,6 +155,19 @@ class TestWebhook(unittest.TestCase):
         **Tested Another Browser**: Yes Edge
         """  # noqa
 
+        self.issue_body12 = """
+        <!-- @browser: Firefox 100.0 -->
+        <!-- @ua_header: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0 -->
+        <!-- @reported_with: desktop-reporter -->
+        <!-- @extra_labels: version100 -->
+
+        **URL**: http://mozilla.org/
+
+        **Browser / Version**: Firefox 100.0
+        **Operating System**: Mac OS X 10.15
+        **Tested Another Browser**: Yes Edge
+        """  # noqa
+
         self.issue_info1 = {
             'action': 'foobar',
             'state': 'open',
@@ -332,6 +345,7 @@ class TestWebhook(unittest.TestCase):
              'extra_labels': 'browser-focus-geckoview'}, 'browser-firefox'),
             ({}, 'browser-fixme'),
             ({'browser': 'Firefox iOS 33.1'}, 'browser-firefox-ios'),
+            ({'browser': 'Firefox 100.0'}, 'browser-firefox'),
         ]
         for metadata_dict, expected in metadata_tests:
             actual = helpers.extract_browser_label(metadata_dict)
@@ -376,6 +390,8 @@ class TestWebhook(unittest.TestCase):
                                  'os-ios']),
             (self.issue_body11, ['browser-firefox-ios', 'device-tablet',
                                  'os-ios']),
+            (self.issue_body12, ['browser-firefox', 'engine-gecko',
+                                 'version100']),
         ]
         for issue_body, expected in labels_tests:
             actual = helpers.get_issue_labels(issue_body)

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -32,6 +32,7 @@ from webcompat.api.uploads import ImageUpload
 from webcompat.helpers import get_browser
 from webcompat.helpers import get_os
 from webcompat.helpers import get_details_list
+from webcompat.helpers import get_browser_version
 from webcompat.helpers import is_json_object
 
 SCHEMES = ('http://', 'https://')
@@ -483,8 +484,18 @@ def build_formdata(form_object):
 
     metadata_keys = ['browser', 'ua_header', 'reported_with']
     extra_labels = form_object.get('extra_labels', None)
+    # As a temporary experiment we will be adding version 100 to the labels.
+    # It will hopefully help us detect breakages related to 3 digit
+    # version numbers.
+    version = get_browser_version(form_object.get('ua_header'))
     if extra_labels:
+        if version == 100:
+            extra_labels.append('version100')
         metadata_keys.append('extra_labels')
+    else:
+        if version == 100:
+            extra_labels = ['version100']
+            metadata_keys.append('extra_labels')
     extra_metadata = form_object.get('extra_metadata', None)
     if extra_metadata:
         for key in extra_metadata.keys():
@@ -532,4 +543,5 @@ def build_formdata(form_object):
     # Append "from webcompat.com" message to bottom (for GitHub issue viewers)
     body += '\n\n{0}'.format(GITHUB_HELP)
     rv = {'title': summary, 'body': body}
+    print(body)
     return rv

--- a/webcompat/helpers.py
+++ b/webcompat/helpers.py
@@ -133,6 +133,15 @@ def get_name(dictionary):
     return name
 
 
+def get_browser_version(user_agent_string=None):
+    """Return browser version number as an integer."""
+    if user_agent_string and isinstance(user_agent_string, str):
+        ua_dict = user_agent_parser.Parse(user_agent_string)
+        version = int(ua_dict['user_agent']['major'])
+        return version
+    return 0
+
+
 def get_browser(user_agent_string=None):
     """Return browser name family and version.
 


### PR DESCRIPTION
This PR fixes issue #3612 

## Proposed PR background

This will help to identify probably breakage due to 3 digits user agents. 
