### PR TITLE
Fix #3618 - Fix unset submit_type

### DIFF
--- a/webcompat/static/js/lib/wizard/steps/submit.js
+++ b/webcompat/static/js/lib/wizard/steps/submit.js
@@ -55,7 +55,7 @@ const onFormSubmit = (event) => {
 // about which <button> was clicked (since one wasn't clicked).
 // So we send that with the form data via a hidden input.
 const saveSubmitType = (event) => {
-  submitTypeField.val(event.target.name);
+  submitTypeField.val(event.currentTarget.name);
 };
 
 submitButtons.on("click", saveSubmitType);


### PR DESCRIPTION
This is a fix for the bug that leads to 400 because submit type (github/anonymous) is not set. 

The issue is happening when you click on the GitHub logo inside the button, so the target ends up being that logo and not the button itself. Because that logo doesn't have a name, submit_type was set as an empty string. 

