### PR TITLE
Fix #3624: Add `version100` to the `label` GET param list

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -224,6 +224,7 @@ EXTRA_LABELS = [
     'type-tracking-protection-strict',
     'type-webrender-enabled',
     'type-webvr',
+    'version100',
 ]
 
 # List of accepted values for browser sources.


### PR DESCRIPTION
This PR fixes issue #3624

This will allow sending out the link https://webcompat.com/issues/new?label=version100 to create issues for the impending 3-digit major version number for both Firefox and Chromium.
