### PR TITLE
Fixes #3642 - Add `browser-focus` to the EXTRA_LABELS allowlist.

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -211,9 +211,10 @@ for cat_label in cat_labels:
 EXTRA_LABELS = [
     'browser-android-components',
     'browser-fenix',
-    'browser-focus-geckoview',
     'browser-firefox-ios',
     'browser-firefox-reality',
+    'browser-focus',
+    'browser-focus-geckoview',
     'device-tablet',
     'type-fastclick',
     'type-google',

--- a/webcompat/webhooks/helpers.py
+++ b/webcompat/webhooks/helpers.py
@@ -28,6 +28,7 @@ GECKO_BROWSERS = ['browser-android-components',
                   'browser-firefox-mobile',
                   'browser-firefox-reality',
                   'browser-firefox-tablet',
+                  'browser-focus'
                   'browser-focus-geckoview',
                   'browser-geckoview', ]
 IOS_BROWSERS = ['browser-firefox-ios', ]


### PR DESCRIPTION
This PR fixes issue #3642

## Proposed PR background

The [Firefox Focus team added the webcompat-reporter](https://github.com/mozilla-mobile/focus-android/blob/7f8879347df74c3b56a0d18185ec582ec8b7d697/app/src/main/java/org/mozilla/focus/Components.kt#L105) and unfortunately did not tell us. The `browser-focus` label won't be applied because of this.

This PR allows the label to be set, and also marks it as a Gecko browser.

r? @ksy36 