### PR TITLE
Issue #3655 - Avoid flaky tests

### DIFF
--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -146,6 +146,7 @@ def test_get_checksum_not_in_cache(tmp_path):
     file_path.write_text('punkcat')
     get_checksum(file_path)
     assert str(file_path) in cache_dict
+    cache_dict.clear()  # avoid flaky tests
 
 
 def test_bust_cache_localhost():


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #3655

## Proposed PR background

When running `$ pytest --flake-finder` (It requires [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder), `test_template.py:: test_get_checksum_not_in_cache` fails since it depends on the dict's state. So I added a line to clear the dict.
