### PR TITLE
Fixes #3596 - Fixes overlapped check-marks

### DIFF
--- a/webcompat/static/css/src/issue-wizard.css
+++ b/webcompat/static/css/src/issue-wizard.css
@@ -463,7 +463,7 @@
 .low.is-validated .input-wrapper::after,
 .low.is-error .input-wrapper::before {
   height: 20px;
-  right: 18px;
+  right: 8px;
   width: 20px;
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: Please do not create a Pull Request without creating an issue first. 

Read the Guidelines, If you haven't done it yet.
https://github.com/webcompat/webcompat.com/blob/master/docs/pr-coding-guidelines.md
-->

This PR fixes issue #3596

## Proposed PR background

The checkmark's right margin looks too much. So I reduced it.

<img width="489" alt="Screen Shot 2022-01-06 at 22 07 57" src="https://user-images.githubusercontent.com/3948353/148387678-d44afbf7-ff9b-4829-a28f-6b5790941604.png">

