### PR TITLE
Fixes #3688 - Freeze Werkzeug version

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -9,4 +9,5 @@ Pillow==9.0.1
 python-dotenv==0.15.0
 requests==2.25.1
 ua-parser==0.10.0
+Werkzeug==2.0.1
 WTForms==2.3.3


### PR DESCRIPTION
There are some failing tests in CircleCI and I want to freeze Werkzeug version to 2.0.1 to fix them.

As we're not pinning Werkzeug version in requirements.txt, the most recent one is installed in CircleCI (2.1.0). In version 2.1.0, werkzeug has removed the as_tuple argument in the test client. Our current version of Flask is 2.0.1 still passes it, therefore the error is thrown. So freezing Werkzeug to 2.0.1 will address this.


https://flask.palletsprojects.com/en/2.1.x/changes/#version-2-1-0
`The test client’s as_tuple parameter is removed. Use response.request.environ instead.`


There is a separate issue for upgrading Flask to 2.1.1 (https://github.com/webcompat/webcompat.com/issues/3687), which requires additional testing as there are some failing tests. I want to deploy https://github.com/webcompat/webcompat.com/pull/3686 first, before updating Flask, in case something breaks :)