### PR TITLE
Fixes for broken/invalid links and typos

### DIFF
--- a/webcompat/templates/contact.html
+++ b/webcompat/templates/contact.html
@@ -34,12 +34,6 @@
 		    			webcompat public channel
 		    		</a>
 		    	</li>
-		    	<li>
-		    		Join us on our
-		    		<a href="https://lists.mozilla.org/listinfo/compatibility">
-		    			mailing list
-		    		</a>
-		    	</li>
 		    </ul>
 		</div>
 		<div class="grid-cell x2">

--- a/webcompat/templates/contributors/organize-webcompat-events.html
+++ b/webcompat/templates/contributors/organize-webcompat-events.html
@@ -26,7 +26,7 @@
           <h2 id="before" class="headline-1 heading">Before</h2>
           <ol>
             <li>
-              Carefully read the <a href="contributors/report-bug" target="_blank">Report a bug</a> page.
+              Carefully read the <a href="/contributors/report-bug" target="_blank">Report a bug</a> page.
             </li>
             <li>
               Understand what is and what is not a webcompat issue.

--- a/webcompat/templates/contributors/report-bug.html
+++ b/webcompat/templates/contributors/report-bug.html
@@ -114,7 +114,7 @@
           <p>
             You can find "Report site issue" button in
             <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#beta" target="_blank">Firefox Beta</a>,
-            <a href=https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly" target="_blank">Firefox Nightly</a> an
+            <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly" target="_blank">Firefox Nightly</a> and
             <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#developer" target="_blank">Firefox Developer Edition</a> on desktop and in
 
             <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta" target="_blank">Firefox for Android Beta</a>,

--- a/webcompat/templates/privacy.html
+++ b/webcompat/templates/privacy.html
@@ -52,7 +52,7 @@
 
         <h3 class="headline-2">Reporting via GitHub</h3>
         <p>
-            If you choose the GitHub option, webcompat.com will receive your GitHub username and avatar.  You can revoke our access to this information at any time from the <a href="https://github.com/settings/applications" title="link to Githubs application settings" target="_blank">"Applications" section of your profile page</a>.
+            If you choose the GitHub option, webcompat.com will receive your GitHub username and avatar.  You can revoke our access to this information at any time from the <a href="https://github.com/settings/apps/authorizations" title="link to Githubs application settings" target="_blank">"Applications" section of your profile page</a>.
         </p>
         </div>
     </article>


### PR DESCRIPTION
This is a combined PR to address the following issues:

Redirect link of "Firefox Nightly" on "TOOLS TO REPORT AN ISSUE" section has an extra character (https://github.com/webcompat/webcompat.com/issues/3712)
Typo displayed in the description of "In Browser" from "TOOLS TO REPORT AN ISSUE" (https://github.com/webcompat/webcompat.com/issues/3713)
Unable to join mailing list, page not found (https://github.com/webcompat/webcompat.com/issues/3716)
The link to revoke webcompat app authorization is wrong  (https://github.com/webcompat/webcompat.com/issues/3719)
Dead link in "Organize Webcompat events" article (https://github.com/webcompat/webcompat.com/issues/3726)
