### PR TITLE
Fixes #3681 - Remove analytics for the form wizard

### DIFF
--- a/webcompat/static/js/lib/issue-wizard-popup.js
+++ b/webcompat/static/js/lib/issue-wizard-popup.js
@@ -4,7 +4,6 @@
 
 import $ from "jquery";
 import Mousetrap from "Mousetrap";
-import { sendAnalyticsEvent } from "./wizard/analytics.js";
 
 class Popup {
   constructor() {
@@ -35,13 +34,6 @@ class Popup {
     const popupTrigger = e.target.dataset.popupTrigger;
     const popupModal = document.querySelector(
       `[data-popup-modal="${popupTrigger}"]`
-    );
-    sendAnalyticsEvent(
-      // transform trigger into camelCase and send as our event
-      popupTrigger.replace(/-([a-z])/g, (match) => {
-        return match[1].toUpperCase();
-      }),
-      "click"
     );
     popupModal.classList.add("is--visible");
     this.overlay.classList.add("is-blacked-out");

--- a/webcompat/static/js/lib/wizard/analytics.js
+++ b/webcompat/static/js/lib/wizard/analytics.js
@@ -10,20 +10,3 @@ export const sendAnalyticsCS = (campaign, source) => {
     });
   }
 };
-
-const sendAnalyticsVpv = (label) => {
-  ga("set", "page", `/vpv-${label}`);
-  ga("send", "pageview");
-};
-
-export const sendAnalyticsEvent = (label, action = "step") => {
-  if (window.ga) {
-    ga("send", "event", {
-      eventCategory: "wizard",
-      eventAction: action,
-      eventLabel: label,
-    });
-
-    sendAnalyticsVpv(label);
-  }
-};

--- a/webcompat/static/js/lib/wizard/stepper.js
+++ b/webcompat/static/js/lib/wizard/stepper.js
@@ -4,7 +4,6 @@
 
 import notify from "./notify.js";
 import { STEPS } from "./steps/index.js";
-import { sendAnalyticsEvent } from "./analytics.js";
 
 const hideStep = (id) => {
   STEPS[id].module.hide();
@@ -14,7 +13,6 @@ const showStep = (message) => {
   const { id, data } = message;
   const step = STEPS[id];
   step.module.show(data);
-  sendAnalyticsEvent(id);
 };
 
 const updateStep = (message) => {

--- a/webcompat/static/js/lib/wizard/steps/submit.js
+++ b/webcompat/static/js/lib/wizard/steps/submit.js
@@ -10,7 +10,6 @@ import $ from "jquery";
 import { showContainer } from "../ui-utils.js";
 import { uploadConsoleLogs } from "./upload-helper/console-logs-upload.js";
 import { uploadImage } from "./upload-helper/image-upload.js";
-import { sendAnalyticsEvent } from "../analytics.js";
 
 const container = $(".step-container.step-submit");
 const form = $("#js-ReportForm form");
@@ -45,7 +44,6 @@ const submitForm = function () {
 
 const onFormSubmit = (event) => {
   event.preventDefault();
-  sendAnalyticsEvent("success", "end");
   disableSubmits();
   showLoadingIndicator();
   uploadConsoleLogs().always(() => uploadImage().then(submitForm));

--- a/webcompat/static/js/lib/wizard/steps/url.js
+++ b/webcompat/static/js/lib/wizard/steps/url.js
@@ -10,7 +10,6 @@ import notify from "../notify.js";
 import { isUrlValid, isEmpty } from "../validation.js";
 import { extractPrettyUrl } from "../utils.js";
 import { showError, showSuccess, hideSuccess } from "../ui-utils.js";
-import { sendAnalyticsEvent } from "../analytics.js";
 
 const urlField = $("#url");
 const nextStepButton = $(".next-url");
@@ -76,7 +75,6 @@ const setInitialInputState = () => {
 initListeners();
 updateDescription(urlField.val());
 setInitialInputState();
-sendAnalyticsEvent("url", "start");
 
 export default {
   //this method is called when url is prefilled via postMessage or GET request


### PR DESCRIPTION
This PR removes detailed analytics from the form wizard that we added to track the success rate of the form.

The standard "pageview" analytics still remain. We don't use the data it collects at the moment, though it could be useful if we need it at some point in the future (to see the spread between android/ desktop reports, for example). With that being said, I'm not opposed to removing it altogether :)