### PR TITLE
Fixes #3748 - Temporary disable outreach comment

### DIFF
--- a/tests/unit/test_webhook_model.py
+++ b/tests/unit/test_webhook_model.py
@@ -199,6 +199,7 @@ def test_prepare_public_comment():
         expected_payload).get('body')
 
 
+@pytest.mark.skip(reason="Outreach comment temporary disabled")
 def test_prepare_outreach_comment():
     """Test we prepare the right comment body."""
     expected_payload = '{"body": "[Generate outreach template](https://webcompat.com/outreach/2598)"}'  # noqa
@@ -209,6 +210,7 @@ def test_prepare_outreach_comment():
         expected_payload).get('body')
 
 
+@pytest.mark.skip(reason="Outreach comment temporary disabled")
 def test_prepare_outreach_comment_for_auth_report():
     """Test we prepare the right comment body."""
     expected_payload = '{"body": "[Generate outreach template](https://webcompat.com/outreach/2598)"}'  # noqa
@@ -332,7 +334,7 @@ def test_process_issue_action_scenarios(mock_mr, mock_classification):
         ('private_milestone_accepted_incomplete.json', incomplete),
         ('private_milestone_accepted_invalid.json', invalid),
         ('private_issue_opened.json', comment_added),
-        ('public_milestone_needscontact.json', outreach_comment_added),
+        # ('public_milestone_needscontact.json', outreach_comment_added),
         ('private_milestone_ml_autoclosed.json', autoclosed),
     ]
     mock_classification.return_value = (

--- a/webcompat/webhooks/model.py
+++ b/webcompat/webhooks/model.py
@@ -338,17 +338,6 @@ class WebHookIssue:
             else:
                 return make_response('gracias, amigo.', 200)
         elif (self.action == 'milestoned' and scope == 'public' and
-              self.milestoned_with == 'needscontact'):
-            # add a comment with a link to outreach template generator
-            # when issue is moved to needscontact
-            try:
-                self.comment_outreach_generator_uri()
-            except HTTPError as e:
-                msg_log(f'comment failed ({e})', self.number)
-                return oops()
-            else:
-                return make_response('outreach generator url added', 200)
-        elif (self.action == 'milestoned' and scope == 'public' and
               self.milestoned_with in ('needsdiagnosis', 'moved')):
             try:
                 if 'bugbug-reopened' in self.original_labels:


### PR DESCRIPTION
As there is no more heroku free tier, the outreach generator is no longer working. This is to disable a comment with the link to outreach email until https://github.com/webcompat/webcompat.com/issues/3742 is resolved