### PR TITLE
Fixes #3758 - Fix a problem with issue getting lost when filing an auth report

### DIFF
--- a/webcompat/static/js/lib/wizard/steps/upload-helper/console-logs-upload.js
+++ b/webcompat/static/js/lib/wizard/steps/upload-helper/console-logs-upload.js
@@ -35,6 +35,9 @@ export const uploadConsoleLogs = () => {
   const formdata = new FormData();
   formdata.append("console_logs", JSON.stringify(details.consoleLog));
 
+  delete details.consoleLog;
+  detailsInput.val(JSON.stringify(details));
+
   return $.ajax({
     contentType: false,
     processData: false,


### PR DESCRIPTION
There is a bit of investigation in https://github.com/webcompat/webcompat.com/issues/3758#issue-1666894730, but in short, stripping the form of console logs after they're saved in a separate file helps reduce the amount of serialized data stored in the session cookie.