### PR TITLE
 Issue #3773 - Fix an issue with auth report not being saved to BQ

### DIFF
--- a/tests/functional/reporting-issue-wizard-non-auth.js
+++ b/tests/functional/reporting-issue-wizard-non-auth.js
@@ -408,7 +408,7 @@ registerSuite("Reporting with wizard", {
           // Click on "Continue without"
           .click()
           .end()
-          .sleep(500)
+          .sleep(1000)
           .findByCssSelector(".step.active .description")
           .getVisibleText()
           .then(function (text) {

--- a/webcompat/views.py
+++ b/webcompat/views.py
@@ -153,6 +153,7 @@ def file_issue():
     if session and (form_data is None):
         abort(403)
     json_response = report_issue(session['form'])
+    send_bq_report(session['form'], json_response.get('html_url'))
     # Get rid of stashed form data
     session.pop('form', None)
     session['show_thanks'] = True


### PR DESCRIPTION
I was testing the dual reporter on staging and realized I missed a case when a report is filed through GitHub, but user is not logged on webcompat.com yet. When doing the auth on GitHub and after redirect back to the app the report wasn't recorded to BQ, so this PR fixes it :)
