### PR TITLE
BigQuery-related changes

### DIFF
--- a/config/environment.py
+++ b/config/environment.py
@@ -70,7 +70,7 @@ if STAGING:
     ES_API_KEY_ID = os.environ.get('ES_API_KEY_ID')
     ES_API_KEY = os.environ.get('ES_API_KEY')
     BQ_PROJECT = 'moz-fx-dev-dschubert-wckb'
-    BQ_TABLE = 'webcompat_user_reports.user_reports_test'
+    BQ_TABLE = 'webcompat_user_reports.user_reports_staging'
 
 if LOCALHOST:
     # for now we are using .env only on localhost
@@ -99,7 +99,7 @@ if LOCALHOST:
     ES_API_KEY_ID = os.environ.get('ES_API_KEY_ID')
     ES_API_KEY = os.environ.get('ES_API_KEY')
     BQ_PROJECT = 'moz-fx-dev-dschubert-wckb'
-    BQ_TABLE = 'webcompat_user_reports.user_reports_test'
+    BQ_TABLE = 'webcompat_user_reports.user_reports_staging'
 
 # BUG STATUS
 # The id will be initialized when the app is started.

--- a/tests/unit/test_form.py
+++ b/tests/unit/test_form.py
@@ -389,7 +389,7 @@ class TestForm(unittest.TestCase):
             expected = {
                 'url': 'https://example.com/',
                 'comments': 'site is broken',
-                'reported_at': [testdt.isoformat()],
+                'reported_at': testdt.isoformat(),
                 'details': json.dumps({
                     'applicationName': 'Firefox',
                     'userAgent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/117.0',       # noqa
@@ -406,7 +406,7 @@ class TestForm(unittest.TestCase):
             expected = {
                 'url': None,
                 'comments': '',
-                'reported_at': [testdt.isoformat()],
+                'reported_at': testdt.isoformat(),
             }
             self.assertIs(type(actual), dict)
             self.assertEqual(actual, expected)

--- a/webcompat/form.py
+++ b/webcompat/form.py
@@ -577,7 +577,7 @@ def build_formdata_bq(form_object, github_issue_url=None):
     form_data = {
         'url': normalize_url(form_object.get('url')),
         'comments': clean_comment(form_object.get('steps_reproduce', '')),
-        'reported_at': [datetime.datetime.utcnow().isoformat()]
+        'reported_at': datetime.datetime.utcnow().isoformat()
     }
 
     details = build_bq_details(


### PR DESCRIPTION
Two things,

- Since I've had to recreate tables anyway, I renamed `user_reports_test` to `user_reports_staging` so that it is very clear what that table is, and that it's used on staging (as opposed to "this is a temporary table used for some testing")
- `reported_at` was not meant to be `REPEATABLE`. Whoops.

r? @ksy36 